### PR TITLE
Feat: 마이페이지, 알림, 채움활동 API Controller 작성

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/fcm/controller/FcmController.java
+++ b/src/main/java/umc/teumteum/server/domain/fcm/controller/FcmController.java
@@ -1,0 +1,36 @@
+package umc.teumteum.server.domain.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.teumteum.server.domain.fcm.dto.FcmTokenRequestDto;
+
+@Tag(name="FCM", description = "FCM 클라이언트 토큰 관련 API")
+@RestController
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+  @Operation(summary = "클라이언트 토큰 등록", description = "로그인한 사용자의 FCM 토큰을 서버에 등록합니다.")
+  @PostMapping("/token")
+  public ResponseEntity<Object> registerFcmToken(@RequestBody FcmTokenRequestDto request){
+    // TODO : FCM 토큰 등록 로직 구현
+    return null;
+  }
+
+
+  @Operation(summary = "로그아웃 시 토큰 삭제", description = "로그아웃하는 사용자의 FCM 토큰을 삭제합니다.")
+  @DeleteMapping("/token")
+  public ResponseEntity<Object> deleteFcmToken(){
+    // TODO : FCM 토큰 삭제 로직 구현
+    return null;
+
+  }
+
+
+}

--- a/src/main/java/umc/teumteum/server/domain/fcm/controller/FcmController.java
+++ b/src/main/java/umc/teumteum/server/domain/fcm/controller/FcmController.java
@@ -5,27 +5,35 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import umc.teumteum.server.domain.fcm.dto.FcmTokenRequestDto;
+import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 @Tag(name="FCM", description = "FCM 클라이언트 토큰 관련 API")
 @RestController
 @RequestMapping("/api/fcm")
 public class FcmController {
 
-  @Operation(summary = "클라이언트 토큰 등록", description = "로그인한 사용자의 FCM 토큰을 서버에 등록합니다.")
-  @PostMapping("/token")
+  @Operation(
+      summary = "클라이언트 토큰 등록",
+      description = "로그인한 사용자의 FCM 토큰을 서버에 등록합니다."
+  )
+  @PostMapping(value = "/token", produces = "application/json")
   public ResponseEntity<Object> registerFcmToken(@RequestBody FcmTokenRequestDto request){
     // TODO : FCM 토큰 등록 로직 구현
     return null;
   }
 
 
-  @Operation(summary = "로그아웃 시 토큰 삭제", description = "로그아웃하는 사용자의 FCM 토큰을 삭제합니다.")
-  @DeleteMapping("/token")
+  @Operation(
+      summary = "로그아웃 시 토큰 삭제",
+      description = "로그아웃하는 사용자의 FCM 토큰을 삭제합니다."
+  )
+  @DeleteMapping(value = "/token", produces = "application/json")
   public ResponseEntity<Object> deleteFcmToken(){
     // TODO : FCM 토큰 삭제 로직 구현
     return null;

--- a/src/main/java/umc/teumteum/server/domain/fcm/dto/FcmTokenRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/fcm/dto/FcmTokenRequestDto.java
@@ -1,0 +1,20 @@
+package umc.teumteum.server.domain.fcm.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "FcmTokenRequestDto : FCM 토큰 등록 요청 DTO", description = "알림 기능을 이용하기 위해 FCM 클라이언트 토큰을 등록 요청하는 Dto 입니다. ")
+public class FcmTokenRequestDto {
+
+  @Schema(description = "디바이스에서 발급받은 FCM 토큰", example = "c7DJdddsaaaasssdvvv")
+  private String token;
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
@@ -1,4 +1,58 @@
 package umc.teumteum.server.domain.home.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.teumteum.server.global.apiPayload.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/activities")
+@Tag(name="Activity", description = "채움 활동 관련 API")
 public class ActivityController {
+
+  @Operation(
+      summary = "채움활동 위시리스트 조회",
+      description = "채움활동에서 사용자가 입력한 조건들을 만족하는 '내가 등록한 위시'들을 조회합니다."
+  )
+  @PostMapping(value = "/user-wishes", produces = "application/json")
+  public ApiResponse<Object> getMyWish(
+  ) {
+    // TODO: 채움활동에서 사용자의 조건을 만족하는 "내가 등록한 위시" 조회 로직 구현
+    return null;
+
+  }
+
+
+  @Operation(
+      summary = "채움활동 AI 추천 컨텐츠 조회(자동 새로고침 포함)",
+      description = "채움활동에서 AI가 추천한 콘텐츠 목록들을 조회합니다. 새로고침 시에도 해당 api를 사용해 주세요."
+  )
+  @PostMapping(value = "/ai", produces = "application/json")
+  public ApiResponse<Object> getAiWish(
+  ) {
+    // TODO: Redis에서 기존 컨텐츠 확인 후, 채움활동 "AI 추천 컨텐츠" 생성 및 Redis 저장 후 반환 로직 구현
+    // 1. Redis 캐시 삭제 (기존 추천 초기화)
+    // 2. AI 추천 로직 실행 -> 콘텐츠 목록 생성
+    // 3. 콘텐츠 목록을 응답으로 반환
+    return null;
+
+  }
+
+
+  @Operation(
+      summary = "AI 컨텐츠 빈틈 채우기(AI 컨텐츠 투두 등록)",
+      description = "사용자가 선택한 AI 추천 컨텐츠를 투두에 등록합니다."
+  )
+  @PostMapping(value = "/ai/assign", produces = "application/json")
+  public ApiResponse<Object> assignAiContent(
+  ) {
+    // TODO: 넘겨준 AI 추천 컨텐츠를 투두에 등록하는 로직 필요
+    return null;
+
+  }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/controller/NotificationController.java
@@ -12,8 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/notifications")
 public class NotificationController {
 
-  @GetMapping
-  @Operation(summary = "알림 목록 조회", description = "로그인한 사용자의 알림 목록을 조회합니다.")
+  @GetMapping(produces = "application/json")
+  @Operation(
+      summary = "알림 목록 조회",
+      description = "로그인한 사용자의 알림 목록을 조회합니다."
+  )
   public ResponseEntity<Object> getNotifications(){
     // TODO : 알림 목록 조회 로직 구현
     return null;

--- a/src/main/java/umc/teumteum/server/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/controller/NotificationController.java
@@ -1,0 +1,24 @@
+package umc.teumteum.server.domain.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="Notifications", description = "사용자 알림 관련 API")
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+  @GetMapping
+  @Operation(summary = "알림 목록 조회", description = "로그인한 사용자의 알림 목록을 조회합니다.")
+  public ResponseEntity<Object> getNotifications(){
+    // TODO : 알림 목록 조회 로직 구현
+    return null;
+  }
+
+
+
+}

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -4,8 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 import java.util.List;
@@ -88,6 +93,7 @@ public class UserController {
         return null;
     }
 
+
     @Operation(
             summary = "닉네임 사용자 검색",
             description = "닉네임으로 사용자를 검색하여 유저 번호를 반환합니다."
@@ -140,6 +146,31 @@ public class UserController {
             @RequestParam("month") String month
     ) {
         return ApiResponse.onSuccess(null);
+    }
+
+
+    @Operation(
+        summary = "마이페이지 정보 조회",
+        description = "사용자의 프로필, 이름, 직업 분야, 아이디 등 마이페이지에 필요한 정보를 조회합니다."
+    )
+    @GetMapping(value = "/mypage", produces = "application/json")
+    public ApiResponse<Object> getMypageInfo(
+    ) {
+        // TODO: 마이페이지 화면(프로필,이름,직업분야, 내 아이디) 조회 로직 구현
+        return null;
+    }
+
+
+    @Operation(
+        summary = "마이페이지 정보 (지금까지 채운 빈틈) 조회",
+        description = "사용자가 지금까지 채운 빈틈 시간 정보를 조회합니다."
+    )
+    @GetMapping(value = "/mypage/teum", produces = "application/json")
+    public ApiResponse<Object> getMypageTeum(
+    ) {
+        // TODO: 마이페이지 "지금까지 채운 빈틈" 조회 로직 구현
+        return null;
+
     }
 
 }

--- a/src/main/java/umc/teumteum/server/global/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/ApiResponse.java
@@ -3,7 +3,7 @@ package umc.teumteum.server.global.apiPayload;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.Locale;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import umc.teumteum.server.global.apiPayload.code.BaseCode;
@@ -15,7 +15,6 @@ import umc.teumteum.server.global.apiPayload.code.status.SuccessStatus;
 public class ApiResponse<T> {
   @JsonProperty("isSuccess")
   private final  Boolean isSuccess;
-
   private final String code;
   private final String message;
 

--- a/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
@@ -16,7 +16,7 @@ import umc.teumteum.server.global.monitoring.service.InfraRedisService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/test")
-@Tag(name = "test", description = "Redis 등 인프라 점검을 위한 테스트 API 입니다.")
+@Tag(name = "Test", description = "Redis 등 인프라 점검을 위한 테스트 API 입니다.")
 public class InfraTestController {
   private final InfraRedisService infraRedisService;
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#7 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
알림, 마이페이지, FCM 토큰, 채움활동 Controller 추가 및 Schema 작성 작업을 진행하였습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
**API 명세서에서 변경된 부분**
<img width="734" height="102" alt="스크린샷 2025-07-14 오전 2 12 29" src="https://github.com/user-attachments/assets/d08870bf-9967-40cb-92db-2a509c1b77fe" />

위에 보이는 AI 추천 컨텐츠 불러오기와 새로고침 API를 하나로 통합했습니다.
사용자가 다른 화면에 있다가 AI 컨텐츠 화면에 다시 진입하는 경우, 
기존 Redis에 추천 데이터가 남아 있더라도 콘텐츠를 생성해서 보여주는 흐름이 더 자연스럽다고 생각합니다.. 
결과적으로, 불러오기와 새로고침 모두 동일한 동작 ( = Redis 초기화 후 추천 생성)을 하게 되어 합치는게 나을 것 같다고 생각했습니다.
해당 변경 사항은 노션 명세서에도 반영해 두었습니다.

<img width="646" height="47" alt="스크린샷 2025-07-14 오전 3 48 27" src="https://github.com/user-attachments/assets/766e56ae-2d8f-4adb-a90a-6eb1156e709a" />

그리고 AI 콘텐츠 등록 가능 시간 조회 API랑 위시 등록 가능 시간 조회 API도 비슷한 내용인거 같은데 하나로 합치는게 좋을것 같다는 생각이 들었습니다. 이 부분에 대해선 회의때 얘기해보면 좋을 것 같습니다!



### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
| 알림 목록 조회 API | <img src="https://github.com/user-attachments/assets/aed5f50c-021e-45c2-b7b9-aa829753c67f" width="500" /> |
| 마이페이지 관련 API | <img src="https://github.com/user-attachments/assets/105b667d-30bd-45a5-96e9-a14d15a66187" width="600" /> |
| FCM 토큰 관련 API   | <img src="https://github.com/user-attachments/assets/52f9a787-1e30-47eb-bd73-7877e7da72ba" width="400" /> |
| 채움활동 관련 API   | <img src="https://github.com/user-attachments/assets/ac70709e-f5bf-4e2e-b121-031e58433d33" width="600" /> |
