### PR TITLE
Feat: 틈 요청 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/ServerApplication.java
+++ b/src/main/java/umc/teumteum/server/ServerApplication.java
@@ -3,9 +3,11 @@ package umc.teumteum.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
@@ -14,6 +15,7 @@ import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumListResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
+import umc.teumteum.server.domain.teum.exception.status.TeumSuccessStatus;
 import umc.teumteum.server.domain.teum.service.TeumService;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
@@ -32,9 +34,10 @@ public class TeumController {
             description = "틈 요청을 전송합니다."
     )
     @PostMapping(value = "/request", consumes = "application/json", produces = "application/json")
-    public ApiResponse<TeumResponseDto> createTeumRequest(@RequestBody TeumRequestDto requestDto) {
+    public ApiResponse<Long> createTeumRequest(@RequestBody @Valid TeumRequestDto requestDto) {
         Long id = teumService.createRequest(requestDto);
-        return ApiResponse.of(null, new TeumResponseDto(id));
+        return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CREATED, id);
+
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumRequestDto.java
@@ -1,6 +1,10 @@
 package umc.teumteum.server.domain.teum.dto.teum;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.List;
@@ -10,27 +14,40 @@ import java.util.List;
 @Schema(title = "TeumRequestDto : 틈 요청 생성 DTO")
 public class TeumRequestDto {
 
+    @NotBlank
     @Schema(description = "제목", example = "string")
     private String title;
 
     @Schema(description = "상세 내용", example = "string")
     private String description;
 
+    @NotBlank
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 YYYY-MM-DD이어야 합니다.")
     @Schema(description = "날짜 (YYYY-MM-DD)", example = "YYYY-MM-DD")
     private String date;
 
+    @NotBlank
+    @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
     @Schema(description = "시작 시간 (HH:MM)", example = "00:00")
     private String startTime;
 
+    @NotBlank
+    @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
     @Schema(description = "종료 시간 (HH:MM)", example = "00:00")
     private String endTime;
 
+    @NotNull
     @Schema(description = "그래픽 ID", example = "1")
     private Long graphicId;
 
+    @NotEmpty
     @Schema(description = "수신자 ID 배열", example = "[0, 1]")
     private List<Long> receiverUserIds;
 
     @Schema(description = "재요청 시 기존 요청 ID (없으면 null)", example = "null")
     private Long parentRequestId;
+
+    @NotNull
+    @Schema(description = "(임시) 요청자 ID", example = "1")
+    private Long senderUserId;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumRequestDto.java
@@ -44,9 +44,6 @@ public class TeumRequestDto {
     @Schema(description = "수신자 ID 배열", example = "[0, 1]")
     private List<Long> receiverUserIds;
 
-    @Schema(description = "재요청 시 기존 요청 ID (없으면 null)", example = "null")
-    private Long parentRequestId;
-
     @NotNull
     @Schema(description = "(임시) 요청자 ID", example = "1")
     private Long senderUserId;

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
@@ -67,4 +67,8 @@ public class TeumRequest extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "teumRequest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TeumResponse> teumResponses = new ArrayList<>();
+
+    public void markAsClosed() {
+        this.status = RequestStatus.CLOSED;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.teum.entity.enums.RequestStatus;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.common.BaseEntity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -50,6 +52,11 @@ public class TeumRequest extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private RequestStatus status = RequestStatus.ACTIVE;
+
 
     /*
         양방향 연관관계
@@ -57,6 +64,7 @@ public class TeumRequest extends BaseEntity {
     @OneToMany(mappedBy = "parentRequest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TeumRequest> childRequests;
 
+    @Builder.Default
     @OneToMany(mappedBy = "teumRequest", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<TeumResponse> teumResponses;
+    private List<TeumResponse> teumResponses = new ArrayList<>();
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
@@ -39,6 +39,6 @@ public class TeumResponse extends BaseEntity {
     @Column(name = "status", nullable = false)
     private ResponseStatus status = ResponseStatus.PENDING;
 
-    @Column(name = "react_at", nullable = false)
-    private LocalDateTime reactAt;
+    @Column(name = "read_at", nullable = true)
+    private LocalDateTime readAt;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/RequestStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/RequestStatus.java
@@ -1,0 +1,6 @@
+package umc.teumteum.server.domain.teum.entity.enums;
+
+public enum RequestStatus {
+    ACTIVE,    // 진행 중
+    CLOSED,    // 자동 마감 (시간 지남)
+}

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
@@ -1,0 +1,44 @@
+package umc.teumteum.server.domain.teum.exception.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc.teumteum.server.global.apiPayload.code.BaseErrorCode;
+import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
+
+@Getter
+@AllArgsConstructor
+public enum TeumErrorStatus implements BaseErrorCode {
+
+    TEUM_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "TEUM4040", "존재하지 않는 틈 요청입니다."),
+    TEUM_RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEUM4041", "존재하지 않는 틈 응답입니다."),
+    USER_NOT_ELIGIBLE(HttpStatus.FORBIDDEN, "TEUM4030", "요청 또는 응답에 대한 권한이 없습니다."),
+    INVALID_TEUM_TIME(HttpStatus.BAD_REQUEST, "TEUM4001", "시작 시간과 종료 시간이 유효하지 않습니다."),
+    DUPLICATE_RECEIVER(HttpStatus.CONFLICT, "TEUM4090", "수신자 목록에 중복된 사용자가 포함되어 있습니다."),
+    CANNOT_REQUEST_SELF(HttpStatus.CONFLICT, "TEUM4091", "자기 자신에게 틈 요청을 보낼 수 없습니다."),
+    REQUEST_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "TEUM4002", "이미 마감된 요청입니다."),
+    INVALID_PARENT_REQUEST(HttpStatus.BAD_REQUEST, "TEUM4003", "재요청의 기준이 되는 요청이 올바르지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
@@ -1,0 +1,50 @@
+package umc.teumteum.server.domain.teum.exception.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc.teumteum.server.global.apiPayload.code.BaseCode;
+import umc.teumteum.server.global.apiPayload.code.ReasonDto;
+
+@Getter
+@AllArgsConstructor
+public enum TeumSuccessStatus implements BaseCode {
+
+    _TEUM_REQUEST_CREATED(HttpStatus.OK, "TEUM2000", "틈 요청이 성공적으로 생성되었습니다."),
+    _TEUM_RESEND_CREATED(HttpStatus.OK, "TEUM2001", "재요청이 성공적으로 생성되었습니다."),
+    _TEUM_RECEIVED_LIST_LOADED(HttpStatus.OK, "TEUM2002", "받은 틈 요청 목록이 조회되었습니다."),
+    _TEUM_DETAIL_LOADED(HttpStatus.OK, "TEUM2003", "틈 요청 상세 정보가 조회되었습니다."),
+    _TEUM_STATUS_UPDATED(HttpStatus.OK, "TEUM2004", "틈 응답 상태가 성공적으로 변경되었습니다."),
+    _TEUM_CALENDAR_LOADED(HttpStatus.OK, "TEUM2005", "요청 달력 정보가 조회되었습니다."),
+    _TEUM_LIST_BY_DATE_LOADED(HttpStatus.OK, "TEUM2006", "지정한 날짜의 틈 요청 목록이 조회되었습니다."),
+    _SCHEDULED_CALENDAR_LOADED(HttpStatus.OK, "TEUM2007", "약속된 틈 달력 정보가 조회되었습니다."),
+    _SCHEDULED_LIST_LOADED(HttpStatus.OK, "TEUM2008", "지정한 날짜의 약속된 틈 목록이 조회되었습니다."),
+    _SCHEDULED_DETAIL_LOADED(HttpStatus.OK, "TEUM2009", "약속된 틈 상세 정보가 조회되었습니다."),
+    _SCHEDULED_EXITED(HttpStatus.OK, "TEUM2010", "약속된 틈에서 성공적으로 나갔습니다."),
+    _AVAILABLE_TIME_LOADED(HttpStatus.OK, "TEUM2011", "공통 가능한 시간대가 조회되었습니다."),
+    _SHARED_TIME_LOADED(HttpStatus.OK, "TEUM2012", "함께한 틈 시간 정보가 조회되었습니다."),
+    _SHARED_LIST_LOADED(HttpStatus.OK, "TEUM2013", "함께한 틈 목록이 조회되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRepository.java
@@ -1,5 +1,0 @@
-package umc.teumteum.server.domain.teum.repository;
-
-public class TeumRepository {
-    // TODO : 추후 리포지토리 구현 예정
-}

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -1,8 +1,17 @@
 package umc.teumteum.server.domain.teum.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 
+import java.util.List;
+
 public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> {
-    // 필요 시 커스텀 메서드 추가
+    @Query("SELECT t FROM TeumRequest t " +
+            "WHERE t.status = 'ACTIVE' AND " +
+            "(t.date < :today OR (t.date = :today AND t.startTime < :nowTime))")
+    List<TeumRequest> findAllClosed(@Param("today") java.time.LocalDate today,
+                                     @Param("nowTime") java.time.LocalTime nowTime);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -1,0 +1,8 @@
+package umc.teumteum.server.domain.teum.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
+
+public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> {
+    // 필요 시 커스텀 메서드 추가
+}

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -1,0 +1,8 @@
+package umc.teumteum.server.domain.teum.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.teum.entity.TeumResponse;
+
+public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
+    // 필요 시 커스텀 메서드 추가
+}

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -39,12 +39,6 @@ public class TeumServiceImpl implements TeumService {
         User sender = userRepository.findById(dto.getSenderUserId())
                 .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
 
-        TeumRequest parent = null;
-        if (dto.getParentRequestId() != null) {
-            parent = teumRequestRepository.findById(dto.getParentRequestId())
-                    .orElseThrow(() -> new GeneralException(TeumErrorStatus.INVALID_PARENT_REQUEST));
-        }
-
         TeumRequest request = TeumRequest.builder()
                 .title(dto.getTitle())
                 .description(dto.getDescription())
@@ -53,7 +47,6 @@ public class TeumServiceImpl implements TeumService {
                 .endTime(LocalTime.parse(dto.getEndTime()))
                 .graphicId(dto.getGraphicId())
                 .user(sender)
-                .parentRequest(parent)
                 .build();
 
         List<TeumResponse> responses = dto.getReceiverUserIds().stream()

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -10,18 +10,73 @@ import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumExitResponseDto
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.entity.TeumResponse;
+import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
+import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
+import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.exception.GeneralException;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TeumServiceImpl implements TeumService {
 
+    private final UserRepository userRepository;
+    private final TeumRequestRepository teumRequestRepository;
+    private final TeumResponseRepository teumResponseRepository;
+
     @Override
     @Transactional
-    public Long createRequest(TeumRequestDto requestDto) {
-        // TODO : 틈 요청 로직 추후 구현
-        return 1L;
+    public Long createRequest(TeumRequestDto dto) {
+        // senderUserId로 요청자 조회 (임시방안)
+        User sender = userRepository.findById(dto.getSenderUserId())
+                .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
+
+        TeumRequest parent = null;
+        if (dto.getParentRequestId() != null) {
+            parent = teumRequestRepository.findById(dto.getParentRequestId())
+                    .orElseThrow(() -> new GeneralException(TeumErrorStatus.INVALID_PARENT_REQUEST));
+        }
+
+        TeumRequest request = TeumRequest.builder()
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .date(LocalDate.parse(dto.getDate()))
+                .startTime(LocalTime.parse(dto.getStartTime()))
+                .endTime(LocalTime.parse(dto.getEndTime()))
+                .graphicId(dto.getGraphicId())
+                .user(sender)
+                .parentRequest(parent)
+                .build();
+
+        List<TeumResponse> responses = dto.getReceiverUserIds().stream()
+                .distinct()
+                .map(receiverId -> {
+                    if (receiverId.equals(sender.getId())) {
+                        throw new GeneralException(TeumErrorStatus.CANNOT_REQUEST_SELF);
+                    }
+                    User receiver = userRepository.findById(receiverId)
+                            .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
+                    return TeumResponse.builder()
+                            .teumRequest(request)
+                            .receiverUser(receiver)
+                            .status(ResponseStatus.PENDING)
+                            .readAt(null)
+                            .message("")
+                            .build();
+                }).toList();
+
+        request.getTeumResponses().addAll(responses);
+        teumRequestRepository.save(request);
+
+        return request.getId();
     }
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -1,4 +1,8 @@
 package umc.teumteum.server.domain.user.repository;
 
-public interface UserRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 필요시 커스텀 메서드 추가
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/TeumRequestStatusScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/TeumRequestStatusScheduler.java
@@ -1,0 +1,40 @@
+package umc.teumteum.server.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeumRequestStatusScheduler {
+
+    private final TeumRequestRepository teumRequestRepository;
+
+    @Transactional
+    @Scheduled(fixedRate = 300000) // 5분마다 실행
+    public void updateClosedTeums() {
+        LocalDate today = LocalDate.now();
+        LocalTime nowTime = LocalTime.now();
+
+        List<TeumRequest> closed = teumRequestRepository.findAllClosed(today, nowTime);
+
+        if (closed.isEmpty()) return;
+
+        closed.forEach(request -> {
+            request.markAsClosed();
+            log.info("TeumRequest {} marked as closed", request.getId());
+        });
+
+        teumRequestRepository.saveAll(closed);
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#26 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 틈 요청 API 구현
  - `TeumRequest`, `TeumResponse` 기반 요청 생성 로직 구성
  - Controller, DTO, Service 전반 작성
  - 요청자가 지정한 `receiverUserIds` 기준으로 TeumResponse 목록 자동 생성
  - 요청자는 단일, 수신자는 복수 가능
  - 성공/에러 상태 코드를 `TeumSuccessStatus`, `TeumErrorStatus` Enum으로 관리

- 상태 변경 스케줄러 추가
  - 매 5분마다 실행되는 스케줄러를 통해, `TeumRequest` 중 시작 시간이 지난 요청의 상태를 `CLOSED`로 자동 변경
  - 관련 메서드: `TeumRequestRepository#findAllClosed()`, `TeumRequestStatusScheduler`
  - 스케줄러 활성화를 위해 `@EnableScheduling` 어노테이션을 `ServerApplication`에 추가

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 요청 생성 흐름에 대한 구조적 피드백
- 스케줄러 주기, 성능, 쿼리 최적화 등 고려할 점

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- `graphicId`는 별도의 이미지 업로드 없이 프론트가 관리하는 리소스를 선택하는 방식
  → 추후 필요 시 `Graphic` 테이블 도입 고려
- `readAt`은 nullable → 읽지 않은 상태 표현
- 로그인 미구현 상태라 `senderUserId`를 DTO에 포함하여 임시로 처리

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :----: | :------: |
| 요청 성공 | <img width="1172" height="481" alt="image" src="https://github.com/user-attachments/assets/b8431531-004e-42d3-b71f-3aadfadc7f55" /> |
| 요청 생성 확인 | <img width="1903" height="204" alt="image" src="https://github.com/user-attachments/assets/0e82ae6e-eff2-4800-8bdc-44835190079d" /> |
| 요청 생성 확인 | <img width="1902" height="185" alt="image" src="https://github.com/user-attachments/assets/3dd27283-b965-4392-b238-5bd7525d226e" /> |
| 스케줄러 | <img width="1415" height="206" alt="image" src="https://github.com/user-attachments/assets/760dd06e-1cfc-4f91-98b6-3c974764110a" /> |
| 없는 유저한테 보냈을 때 | <img width="1174" height="501" alt="image" src="https://github.com/user-attachments/assets/c2007208-68db-4766-94c8-4459473c9bdd" /> |
| 본인한테 요청했을 때 | <img width="1178" height="430" alt="image" src="https://github.com/user-attachments/assets/430b2956-dc0a-4dbd-bc32-510617263450" /> |
| 날짜 형식이 잘못되었을 때 (시간 포맷 오류도 이와 유사) | <img width="1173" height="532" alt="image" src="https://github.com/user-attachments/assets/a770a92b-4b41-4b8c-a75e-14b941d08122" /> |