### PR TITLE
Fix : 브랜치 생성 직후 CI 실행되지 않도록 조건 추가

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   CI:
     name: Continuous Integration
+    if: github.event_name != 'push' || github.event.created == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION

### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
없음 - 단순 CI 설정 개선 작업입니다.

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- GitHub Actions 워크플로우 조건 개선
- 브랜치 생성 직후의 첫 push에서 CI가 실행되는 문제 방지
- `github.event.created == false` 조건 추가

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
단순 브랜치 생성 후 첫 push 시 CI가 실행되는 문제가 있어 수정하였습니다.
- 조건문 위치 (`jobs.CI.if`)가 적절한지
- 필터 조건이 잘 적용되는지 확인 부탁드립니다

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- develop 브랜치가 protected라서 patch 브랜치에서 PR 생성했습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |