### PR TITLE
Feat: 틈 요청 목록 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -55,12 +55,14 @@ public class TeumController {
     }
 
     @Operation(
-            summary = "내가 받은 틈 요청 조회",
+            summary = "틈 요청 조회",
             description = "현재 로그인 사용자가 응답자로 지정된 틈 요청 중, 아직 응답하지 않았고 요청 시간이 지나지 않은 요청 목록을 조회합니다."
     )
-    @GetMapping(value = "/request/received", produces = "application/json")
-    public ApiResponse<List<TeumReceivedResponseDto>> getReceivedTeumRequests() {
-        return ApiResponse.onSuccess(null);
+    @GetMapping("/request/received")
+    public ApiResponse<List<TeumReceivedResponseDto>> getReceivedTeumRequests(
+            @RequestParam("userId") Long userId
+    ) {
+        return ApiResponse.onSuccess(teumService.getReceivedRequests(userId));
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -6,6 +6,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeResponseDto;
@@ -59,10 +63,19 @@ public class TeumController {
             description = "현재 로그인 사용자가 응답자로 지정된 틈 요청 중, 아직 응답하지 않았고 요청 시간이 지나지 않은 요청 목록을 조회합니다."
     )
     @GetMapping("/request/received")
-    public ApiResponse<List<TeumReceivedResponseDto>> getReceivedTeumRequests(
-            @RequestParam("userId") Long userId
+    public ApiResponse<Page<TeumReceivedResponseDto>> getReceivedTeumRequests(
+            @Parameter(description = "조회할 유저의 ID") @RequestParam(name = "userId") Long userId,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(name = "page", defaultValue = "0") int page,
+            @Parameter(description = "한 페이지에 포함될 항목 수") @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        return ApiResponse.onSuccess(teumService.getReceivedRequests(userId));
+        Sort sort = Sort.by(
+                Sort.Order.asc("readAt"),
+                Sort.Order.desc("createdAt")
+        );
+
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return ApiResponse.onSuccess(teumService.getReceivedRequests(userId, pageable));
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.domain.teum.converter;
 
+import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
+import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
@@ -7,6 +9,8 @@ import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.exception.GeneralException;
+import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
+import umc.teumteum.server.global.util.S3Util;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -46,6 +50,38 @@ public class TeumConverter {
                             .message("")
                             .build();
                 })
+                .toList();
+    }
+
+    public static TeumReceivedResponseDto toReceivedResponseDto(TeumResponse response, S3Util s3Util) {
+        TeumRequest request = response.getTeumRequest();
+        User sender = request.getUser();
+
+        return TeumReceivedResponseDto.builder()
+                .responseId(response.getId())
+                .requestId(request.getId())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .graphicId(request.getGraphicId())
+                .isRead(response.getReadAt() != null)
+                .receiverCount(request.getTeumResponses().size())
+                .senderUser(ParticipantDto.builder()
+                        .userId(sender.getId())
+                        .nickname(sender.getNickname())
+                        .profileImageUrl(s3Util.toUrl(sender.getProfileImageKey()))
+                        .build())
+                .date(request.getDate().toString())
+                .timeSlot(TimeSlot.builder()
+                        .start(request.getStartTime().toString())
+                        .end(request.getEndTime().toString())
+                        .build())
+                .build();
+    }
+
+
+    public static List<TeumReceivedResponseDto> toReceivedResponseDtoList(List<TeumResponse> responses, S3Util s3Util) {
+        return responses.stream()
+                .map(response -> toReceivedResponseDto(response, s3Util))
                 .toList();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/common/ParticipantDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/common/ParticipantDto.java
@@ -2,9 +2,11 @@ package umc.teumteum.server.domain.teum.dto.common;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumReceivedResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumReceivedResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
+import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 
 @Getter
 @Builder
@@ -23,6 +24,12 @@ public class TeumReceivedResponseDto {
     @Schema(description = "제목", example = "string")
     private String title;
 
+    @Schema(description = "내용", example = "string")
+    private String description;
+
+    @Schema(description = "그래픽 ID", example = "1")
+    private Long graphicId;
+
     @Schema(description = "읽음 여부", example = "false")
     private boolean isRead;
 
@@ -31,4 +38,10 @@ public class TeumReceivedResponseDto {
 
     @Schema(description = "수신자 총 인원 수 (본인 포함)", example = "1")
     private int receiverCount;
+
+    @Schema(description = "요청 날짜", example = "2025-07-15")
+    private String date;
+
+    @Schema(description = "요청 시간 구간")
+    private TimeSlot timeSlot;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -1,8 +1,31 @@
 package umc.teumteum.server.domain.teum.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
 public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
-    // 필요 시 커스텀 메서드 추가
+
+    @Query("""
+        SELECT r FROM TeumResponse r
+        JOIN FETCH r.teumRequest tr
+        JOIN FETCH tr.user sender
+        WHERE r.receiverUser.id = :userId
+          AND r.status = umc.teumteum.server.domain.teum.entity.enums.ResponseStatus.PENDING
+          AND tr.status = umc.teumteum.server.domain.teum.entity.enums.RequestStatus.ACTIVE
+          AND (tr.date > :today OR (tr.date = :today AND tr.startTime > :now))
+        ORDER BY 
+          CASE WHEN r.readAt IS NULL THEN 0 ELSE 1 END ASC,
+          r.createdAt DESC
+    """)
+    List<TeumResponse> findValidPendingResponses(
+            @Param("userId") Long userId,
+            @Param("today") LocalDate today,
+            @Param("now") LocalTime now
+    );
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -1,5 +1,8 @@
 package umc.teumteum.server.domain.teum.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,25 +10,22 @@ import umc.teumteum.server.domain.teum.entity.TeumResponse;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 
 public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
 
+    @EntityGraph(attributePaths = {"teumRequest", "teumRequest.user"})
     @Query("""
-        SELECT r FROM TeumResponse r
-        JOIN FETCH r.teumRequest tr
-        JOIN FETCH tr.user sender
-        WHERE r.receiverUser.id = :userId
-          AND r.status = umc.teumteum.server.domain.teum.entity.enums.ResponseStatus.PENDING
-          AND tr.status = umc.teumteum.server.domain.teum.entity.enums.RequestStatus.ACTIVE
-          AND (tr.date > :today OR (tr.date = :today AND tr.startTime > :now))
-        ORDER BY 
-          CASE WHEN r.readAt IS NULL THEN 0 ELSE 1 END ASC,
-          r.createdAt DESC
-    """)
-    List<TeumResponse> findValidPendingResponses(
+    SELECT r FROM TeumResponse r
+    WHERE r.receiverUser.id = :userId
+      AND r.status = umc.teumteum.server.domain.teum.entity.enums.ResponseStatus.PENDING
+      AND r.teumRequest.status = umc.teumteum.server.domain.teum.entity.enums.RequestStatus.ACTIVE
+      AND (r.teumRequest.date > :today OR (r.teumRequest.date = :today AND r.teumRequest.startTime > :now))
+""")
+    Page<TeumResponse> findValidPendingResponses(
             @Param("userId") Long userId,
             @Param("today") LocalDate today,
-            @Param("now") LocalTime now
+            @Param("now") LocalTime now,
+            Pageable pageable
     );
+
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.domain.teum.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
@@ -16,7 +18,7 @@ public interface TeumService {
 
     Long createResendRequest(Long parentRequestId, TeumResendRequestDto resendRequestDto);
 
-    List<TeumReceivedResponseDto> getReceivedRequests(Long userId);
+    Page<TeumReceivedResponseDto> getReceivedRequests(Long userId, Pageable pageable);
 
     TeumRequestDetailResponseDto getRequestDetail(Long responseId, Long userId);
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -1,6 +1,10 @@
 package umc.teumteum.server.domain.teum.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.teum.converter.TeumConverter;
@@ -71,14 +75,19 @@ public class TeumServiceImpl implements TeumService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<TeumReceivedResponseDto> getReceivedRequests(Long userId) {
+    public Page<TeumReceivedResponseDto> getReceivedRequests(Long userId, Pageable pageable) {
         getUserOrThrow(userId);
+
         LocalDate today = LocalDate.now();
         LocalTime now = LocalTime.now();
 
-        List<TeumResponse> responses = teumResponseRepository.findValidPendingResponses(userId, today, now);
+        Page<TeumResponse> page = teumResponseRepository.findValidPendingResponses(userId, today, now, pageable);
 
-        return TeumConverter.toReceivedResponseDtoList(responses, s3Util);
+        List<TeumReceivedResponseDto> dtoList = page.getContent().stream()
+                .map(response -> TeumConverter.toReceivedResponseDto(response, s3Util))
+                .toList();
+
+        return new PageImpl<>(dtoList, pageable, page.getTotalElements());
     }
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -13,6 +13,7 @@ import umc.teumteum.server.domain.teum.dto.shared.SharedTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
+import umc.teumteum.server.domain.teum.entity.enums.RequestStatus;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
@@ -20,6 +21,7 @@ import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
+import umc.teumteum.server.global.util.S3Util;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -29,6 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeumServiceImpl implements TeumService {
 
+    private final S3Util s3Util;
     private final UserRepository userRepository;
     private final TeumRequestRepository teumRequestRepository;
     private final TeumResponseRepository teumResponseRepository;
@@ -67,9 +70,15 @@ public class TeumServiceImpl implements TeumService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<TeumReceivedResponseDto> getReceivedRequests(Long userId) {
-        // TODO: 틈 요청 불러오기 로직 추후 구현
-        return List.of();
+        getUserOrThrow(userId);
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        List<TeumResponse> responses = teumResponseRepository.findValidPendingResponses(userId, today, now);
+
+        return TeumConverter.toReceivedResponseDtoList(responses, s3Util);
     }
 
     @Override


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#30 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 로그인된 사용자가 응답자로 지정된 틈 요청 목록 조회 API 구현 (현재는 임시로 유저아이디를 받고 있음)
- **필터링 조건**:
  - 응답 상태가 `PENDING`인 경우만
  - 요청 상태가 `ACTIVE`인 경우만
  - 현재 시각 기준으로 요청의 시작 시간이 지나지 않은 경우만
- **정렬 조건**:
  - `readAt IS NULL` → 미확인 요청 우선 정렬
  - 이후 `createdAt DESC` → 최신 요청 우선 정렬
- `TeumReceivedResponseDto`에 필요한 뷰페이저용 상세 정보 포함:
  - `title`, `description`, `graphicId`, `date`, `timeSlot` 등
  - `senderUser` 정보는 `ParticipantDto`로 구조화하여 재사용성 강화
- `@EntityGraph` 적용으로 N+1 문제 방지 및 Pageable과 안전하게 병행 사용
- 테스트 데이터 기반으로 총 6개의 요청, 14개의 응답 케이스에서 동작 확인 완료

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 필터링 조건이 정확히 적용되는지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 지난 PR의 피드백에 따라 **Spring Data JPA의 `Pageable + Sort` 조합**을 사용
  - 대량 데이터 처리 시 메모리 이슈 방지
  - DB 차원에서 정렬 및 필터링 처리
  - 팔로잉/팔로워 목록 API의 페이징은 차차 리팩토링 하겠습니다...
- 응답 포맷은 `Page<T>` 구조로 구성됨
  - 클라이언트가 `isLast`, `totalElements`, `page` 등의 정보를 쉽게 활용 가능
  - 필요 시 커스텀 래핑 DTO (`PagedResponse<T>` 등)로 리팩토링

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 틈 요청 조회 API | <img width="1078" height="988" alt="image" src="https://github.com/user-attachments/assets/7af1da82-e5f9-437f-b003-318e324fcfce" /> |

다양하게 테스트를 진행했는데 PR에 모두 작성하긴 어려워 API 명세서에 붙여놨습니다.
> https://excessive-pedestrian-954.notion.site/22566802aaae80228876d8c4cedc6f58