### PR TITLE
Feat: Swagger CORS 개선, Redis 인텍스 분리, S3 연동 설정 및 테스트 API 추가

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -74,6 +74,10 @@ jobs:
               -e DB_URL=${{ secrets.DB_URL }} \
               -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
+              -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
+              -e S3_BUCKET=${{ secrets.S3_BUCKET }} \
+              -e S3_PREFIX=${{ secrets.S3_PREFIX }} \
               ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
 
             EOF

--- a/build.gradle
+++ b/build.gradle
@@ -24,23 +24,34 @@ repositories {
 }
 
 dependencies {
+	// Spring Basic
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// Database
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'com.h2database:h2'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// Swagger
+	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.1'
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// S3
+	implementation platform('software.amazon.awssdk:bom:2.25.10')
+	implementation 'software.amazon.awssdk:auth'
+	implementation 'software.amazon.awssdk:s3'
 
 }
 

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -1,10 +1,8 @@
 package umc.teumteum.server.global.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -23,41 +21,41 @@ public class RedisConfig {
   @Value("${spring.data.redis.port}")
   private int port;
 
-  private LettuceConnectionFactory createConnectionFactory(int dbIndex){
-    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
-    configuration.setDatabase(dbIndex);
+  private LettuceConnectionFactory createConnectionFactory(int dbIndex) {
+    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+    config.setDatabase(dbIndex);
     if (!password.isEmpty()) {
-      configuration.setPassword(RedisPassword.of(password));
+      config.setPassword(RedisPassword.of(password));
     }
-    return new LettuceConnectionFactory(configuration);
-  }
-
-
-  @Bean
-  public RedisTemplate<String,String> createRedisTemplate(LettuceConnectionFactory factory) {
+    LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
     factory.afterPropertiesSet();
-    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(factory);
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(new StringRedisSerializer());
-    return redisTemplate;
+    return factory;
   }
 
-  // RT용 Redis(index0)
+  private RedisTemplate<String, String> createRedisTemplate(LettuceConnectionFactory factory) {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(factory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.afterPropertiesSet();
+    return template;
+  }
+
+  // RT용 Redis(index 0)
   @Bean
-  public RedisTemplate<String,String> rtRedisTemplate() {
+  public RedisTemplate<String, String> rtRedisTemplate() {
     return createRedisTemplate(createConnectionFactory(0));
   }
 
-  // 알림용 Redis(index1)
+  // 알림용 Redis(index 1)
   @Bean
-  public RedisTemplate<String,String> notificationRedisTemplate() {
+  public RedisTemplate<String, String> notificationRedisTemplate() {
     return createRedisTemplate(createConnectionFactory(1));
   }
 
-  // 채움활동 AI 컨텐츠용 Redis(index2)
+  // AI 컨텐츠용 Redis(index 2)
   @Bean
-  public RedisTemplate<String,String> aiContentsRedisTemplate() {
+  public RedisTemplate<String, String> aiContentsRedisTemplate() {
     return createRedisTemplate(createConnectionFactory(2));
   }
 

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -1,21 +1,64 @@
 package umc.teumteum.server.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@RequiredArgsConstructor
 public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.password}")
+  private String password;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  private LettuceConnectionFactory createConnectionFactory(int dbIndex){
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+    configuration.setDatabase(dbIndex);
+    if (!password.isEmpty()) {
+      configuration.setPassword(RedisPassword.of(password));
+    }
+    return new LettuceConnectionFactory(configuration);
+  }
+
+
   @Bean
-  public RedisTemplate<?,?> redisTemplate(RedisConnectionFactory factory) {
+  public RedisTemplate<String,String> createRedisTemplate(LettuceConnectionFactory factory) {
+    factory.afterPropertiesSet();
     RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(factory);
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     return redisTemplate;
   }
+
+  // RT용 Redis(index0)
+  @Bean
+  public RedisTemplate<String,String> rtRedisTemplate() {
+    return createRedisTemplate(createConnectionFactory(0));
+  }
+
+  // 알림용 Redis(index1)
+  @Bean
+  public RedisTemplate<String,String> notificationRedisTemplate() {
+    return createRedisTemplate(createConnectionFactory(1));
+  }
+
+  // 채움활동 AI 컨텐츠용 Redis(index2)
+  @Bean
+  public RedisTemplate<String,String> aiContentsRedisTemplate() {
+    return createRedisTemplate(createConnectionFactory(2));
+  }
+
 }

--- a/src/main/java/umc/teumteum/server/global/config/S3Config.java
+++ b/src/main/java/umc/teumteum/server/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package umc.teumteum.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Bean
+  public S3Client s3Client() {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .build();
+
+  }
+
+
+}

--- a/src/main/java/umc/teumteum/server/global/config/SwaggerConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/SwaggerConfig.java
@@ -2,21 +2,30 @@ package umc.teumteum.server.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+  @Value("${swagger.server-url}")
+  private String serverUrl;
+
   @Bean
   public OpenAPI openAPI() {
     return new OpenAPI()
-        .info(apiInfo());
+        .info(apiInfo())
+        .servers(List.of(new Server().url(serverUrl)));
   }
+
   private Info apiInfo() {
     return new Info()
         .title("TeumTeum API 명세서")
-        .description("TeumTeum 프로젝트 API 명세 초기 구성")
+        .description("TeumTeum 프로젝트 API 명세 구성")
         .version("1.0.0");
   }
+
 }

--- a/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.global.monitoring.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,8 +12,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import software.amazon.awssdk.services.s3.S3Client;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 import umc.teumteum.server.global.monitoring.service.InfraRedisService;
+import umc.teumteum.server.global.monitoring.service.InfraS3Service;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ import umc.teumteum.server.global.monitoring.service.InfraRedisService;
 @Tag(name = "Test", description = "Redis 등 인프라 점검을 위한 테스트 API 입니다.")
 public class InfraTestController {
   private final InfraRedisService infraRedisServiceImpl;
+  private final InfraS3Service infraS3ServiceImpl;
 
   @GetMapping("/redis/check")
   @Operation(summary = "Redis DB 분리 확인", description = "RT, 알림, AI 콘텐츠용 RedisTemplate 각각에 test_key를 저장/조회/삭제하여 DB 분리 여부를 확인합니다.")
@@ -57,6 +61,17 @@ public class InfraTestController {
   public ResponseEntity<ApiResponse> getPingRtRedisTemplate() {
     String pong = infraRedisServiceImpl.pingRtRedisTemplate();
     return ResponseEntity.ok(ApiResponse.onSuccess("Redis PING with rtTemplate : " + pong));
+  }
+
+
+  @GetMapping("/s3/list")
+  @Operation(
+      summary = "S3 연결 테스트",
+      description = "버킷에 정상적으로 접근되는지 확인하고, 지정한 prefix의 객체 리스트를 조회합니다."
+  )
+  public ResponseEntity<ApiResponse> listS3Objects() {
+    List<String> objects = infraS3ServiceImpl.listObjects();
+    return ResponseEntity.ok(ApiResponse.onSuccess(objects));
   }
 
 

--- a/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/controller/InfraTestController.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.global.monitoring.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,45 +19,45 @@ import umc.teumteum.server.global.monitoring.service.InfraRedisService;
 @RequestMapping("/api/test")
 @Tag(name = "Test", description = "Redis 등 인프라 점검을 위한 테스트 API 입니다.")
 public class InfraTestController {
-  private final InfraRedisService infraRedisService;
+  private final InfraRedisService infraRedisServiceImpl;
 
-  @GetMapping("/redis/set")
-  @Operation(summary = "Redis에 Key-Value 저장", description = "Redis에 입력한 Key와 Value를 저장합니다.")
-  public ResponseEntity<ApiResponse> setKeyValue(
-      @Parameter(description = "저장할 Key", example = "testKey")
-      @RequestParam String key,
-      @Parameter(description = "저장할 Value", example = "testValue")
-      @RequestParam String value) {
-    infraRedisService.setKeyValue(key, value);
-    return ResponseEntity.ok(ApiResponse.onSuccess("Set = " + key + " = " + value));
+  @GetMapping("/redis/check")
+  @Operation(summary = "Redis DB 분리 확인", description = "RT, 알림, AI 콘텐츠용 RedisTemplate 각각에 test_key를 저장/조회/삭제하여 DB 분리 여부를 확인합니다.")
+  public ResponseEntity<ApiResponse> checkRedisIsolation(){
+    Map<String, String> result = infraRedisServiceImpl.checkRedisIsolation();
+    return ResponseEntity.ok(ApiResponse.onSuccess(result));
   }
 
-  @GetMapping("/redis/get")
-  @Operation(summary = "Redis에서 Value 조회")
-  public ResponseEntity<ApiResponse> getValue(
-      @Parameter(description = "조회할 key", example = "testKey")
-      @RequestParam String key
-  ){
-    String value = infraRedisService.getValue(key);
-    return ResponseEntity.ok(ApiResponse.onSuccess("Value = " + value));
+  @GetMapping("/redis/ping/notification")
+  @Operation(
+      summary = "Notification Redis 연결 확인",
+      description = "알림용 RedisTemplate(notificationRedisTemplate)이 정상적으로 Redis(index=1)에 연결되어 있는지 확인합니다."
+  )
+  public ResponseEntity<ApiResponse> getPingNoticitationRedisTemplate() {
+    String pong = infraRedisServiceImpl.pingNotifiactionRedisTemplate();
+    return ResponseEntity.ok(ApiResponse.onSuccess("Redis PING :with noticationTemplate " + pong));
+  }
+
+  @GetMapping("/redis/ping/ai")
+  @Operation(
+      summary = "AI 콘텐츠 Redis 연결 확인",
+      description = "채움활동의 AI 콘텐츠용 RedisTemplate(aiContentsRedisTemplate)이 Redis(index=2)에 정상적으로 연결되어 있는지 확인합니다."
+  )
+  public ResponseEntity<ApiResponse> getPingAiRedisTemplate() {
+    String pong = infraRedisServiceImpl.pingAiContentsRedisTemplate();
+    return ResponseEntity.ok(ApiResponse.onSuccess("Redis PING with aiTemplate: " + pong));
   }
 
 
-  @DeleteMapping("/redis/delete")
-  @Operation(summary = "Redis에서 Key 삭제", description = "지정한 Key를 Redis에서 삭제합니다.")
-  public ResponseEntity<ApiResponse> deleteKey(
-      @Parameter(description = "삭제할 key", example = "testKey")
-      @RequestParam String key
-  ) {
-    infraRedisService.deleteKey(key);
-    return ResponseEntity.ok(ApiResponse.onSuccess("Successfully Deleted key: " + key));
+  @GetMapping("/redis/ping/rt")
+  @Operation(
+      summary = "RT용 Redis 연결 확인",
+      description = "실시간 처리용 RedisTemplate(rtRedisTemplate)이 Redis(index=0)에 정상적으로 연결되어 있는지 확인합니다."
+  )
+  public ResponseEntity<ApiResponse> getPingRtRedisTemplate() {
+    String pong = infraRedisServiceImpl.pingRtRedisTemplate();
+    return ResponseEntity.ok(ApiResponse.onSuccess("Redis PING with rtTemplate : " + pong));
   }
 
-  @GetMapping("/redis/ping")
-  @Operation(summary = "Redis Ping 테스트", description = "Redis 가 정상적으로 연결되어 있는지 확인합니다.")
-  public ResponseEntity<ApiResponse> getPing() {
-    String pong = infraRedisService.ping();
-    return ResponseEntity.ok(ApiResponse.onSuccess("Redis PING : " + pong));
-  }
 
 }

--- a/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisService.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisService.java
@@ -1,8 +1,10 @@
 package umc.teumteum.server.global.monitoring.service;
 
+import java.util.Map;
+
 public interface InfraRedisService {
-  void setKeyValue(String key, String value);
-  String getValue(String key);
-  void deleteKey(String key);
-  String ping();
+  Map<String, String> checkRedisIsolation();
+  String pingNotifiactionRedisTemplate();
+  String pingRtRedisTemplate();
+  String pingAiContentsRedisTemplate();
 }

--- a/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisServiceImpl.java
@@ -1,6 +1,8 @@
 package umc.teumteum.server.global.monitoring.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
@@ -8,45 +10,65 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
 
 @Service
-@RequiredArgsConstructor
 public class InfraRedisServiceImpl implements InfraRedisService {
-  private final RedisTemplate<String, String> redisTemplate;
+
+  private final RedisTemplate<String, String> notifiactionRedisTemplate;
+  private final RedisTemplate<String, String> aiContentsRedisTemplate;
+  private final RedisTemplate<String, String> rtRedisTemplate;
+
+  public InfraRedisServiceImpl(
+      @Qualifier("notificationRedisTemplate") RedisTemplate<String, String> notifiactionRedisTemplate,
+      @Qualifier("aiContentsRedisTemplate") RedisTemplate<String, String> aiContentsRedisTemplate,
+      @Qualifier("rtRedisTemplate") RedisTemplate<String, String> rtRedisTemplate) {
+    this.notifiactionRedisTemplate = notifiactionRedisTemplate;
+    this.aiContentsRedisTemplate = aiContentsRedisTemplate;
+    this.rtRedisTemplate = rtRedisTemplate;
+  }
 
 
   @Override
-  public void setKeyValue(String key, String value) {
+  public Map<String, String> checkRedisIsolation() {
+    Map<String, String> result = new LinkedHashMap<>();
+
+    rtRedisTemplate.opsForValue().set("test_key", "RT_DATA");
+    aiContentsRedisTemplate.opsForValue().set("test_key", "AI_DATA");
+    notifiactionRedisTemplate.opsForValue().set("test_key", "NOTI_DATA");
+
+    String rtValue = rtRedisTemplate.opsForValue().get("test_key");
+    String aiValue = aiContentsRedisTemplate.opsForValue().get("test_key");
+    String notiValue = notifiactionRedisTemplate.opsForValue().get("test_key");
+
+    result.put("RT_DB (index 0)", rtValue);
+    result.put("NOTIFICATION_DB (index 1)", notiValue);
+    result.put("AI_CONTENTS_DB (index 2)", aiValue);
+
+    rtRedisTemplate.delete("test_key");
+    notifiactionRedisTemplate.delete("test_key");
+    aiContentsRedisTemplate.delete("test_key");
+
+    return result;
+  }
+
+  @Override
+  public String pingNotifiactionRedisTemplate() {
     try {
-      redisTemplate.opsForValue().set(key, value);
+      return notifiactionRedisTemplate.getConnectionFactory().getConnection().ping();
     } catch (Exception e) {
       throw new GlobalHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
     }
   }
-
   @Override
-  public String getValue(String key) {
+  public String pingRtRedisTemplate() {
     try {
-      return redisTemplate.opsForValue().get(key);
+      return rtRedisTemplate.getConnectionFactory().getConnection().ping();
     } catch (Exception e) {
       throw new GlobalHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
     }
   }
-
   @Override
-  public void deleteKey(String key) {
+  public String pingAiContentsRedisTemplate() {
     try {
-      Boolean result = redisTemplate.delete(key);
-      if (!Boolean.TRUE.equals(result)) {
-        throw new GlobalHandler(ErrorStatus._BAD_REQUEST); // 커스텀 상태코드가 더 좋을 수도 있음
-      }
-    } catch (Exception e) {
-      throw new GlobalHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  @Override
-  public String ping() {
-    try {
-      return redisTemplate.getConnectionFactory().getConnection().ping();
+      return aiContentsRedisTemplate.getConnectionFactory().getConnection().ping();
     } catch (Exception e) {
       throw new GlobalHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/umc/teumteum/server/global/monitoring/service/InfraS3Service.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/service/InfraS3Service.java
@@ -1,0 +1,8 @@
+package umc.teumteum.server.global.monitoring.service;
+
+import java.util.List;
+
+public interface InfraS3Service {
+  public List<String> listObjects();
+
+}

--- a/src/main/java/umc/teumteum/server/global/monitoring/service/InfraS3ServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/service/InfraS3ServiceImpl.java
@@ -1,0 +1,39 @@
+package umc.teumteum.server.global.monitoring.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@Service
+@RequiredArgsConstructor
+public class InfraS3ServiceImpl implements InfraS3Service{
+
+  private final S3Client s3Client;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Value("${cloud.aws.s3.bucket-path}")
+  private String prefix;
+
+  @Override
+  public List<String> listObjects() {
+    ListObjectsV2Request request = ListObjectsV2Request.builder()
+        .bucket(bucket)
+        .prefix(prefix)
+        .maxKeys(10)
+        .build();
+
+    ListObjectsV2Response response = s3Client.listObjectsV2(request);
+
+    return response.contents().stream()
+        .map(S3Object::key)
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#20 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

 **Swagger 서버 주소 주입 방식 개선**
- SwaggerConfig에서 @Value를 통해 서버 주소를 설정 파일로부터 주입받도록 수정하였습니다.

**Redis index를 분리 및 테스트 API 추가**
- 각 index에 맞는 RedisTemplate Bean 정의(0:RT, 1:Noti, 2:AI)하였습니다.
- @qualifier 기반으로 RedisTemplate 주입 방식을 적용하였습니다.
- 각 Redis 인덱스에 접근하는 테스트(ping, 키 분리 확인) API를 추가하였습니다.

**S3 연동 설정**
- S3 관련 키 값들을 각 환경에 맞게 추가하였습니다.
- S3 키값이 올바르게 주입되었는지, IAM 권한 설정이 올바르게 되었는지 확인하기 위한 간단한 테스트 API를 추가하였습니다.

  

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

- Redis 관련
Redis 관련해서는 노션 "참고"에 작성해 두었습니다!
Redis를 사용해야 한다면 노션 확인 부탁드리겠습니다.

- S3 관련
버킷의 CORS 정책과 IAM 정책 등.. 관련 설정은 마찬가지로 노션 "참고"에 작성해 두었습니다.
/api/test/s3/list API를 통해 prefix 기준으로 S3 접근이 가능한지 테스트 할 수 있습니다.
S3Client 는 S3Config에 Bean으로 등록되어 있기 때문에 주입 받아 바로 사용하시면 됩니다..!


### 📷 스크린샷 또는 GIF

각 테스트 API가 로컬 환경에서 정상적으로 동작함을 확인하였습니다.

| 기능 | 스크린샷 |
| :--: | :------: |
|   테스트 API   | <img width="1174" height="344" alt="스크린샷 2025-07-16 오후 4 54 07" src="https://github.com/user-attachments/assets/3719c106-b0b6-4643-bfb2-af3fc971b4f5" /> |
