### PR TITLE
Feat: 소셜 로그인 API 구현 - 카카오

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	implementation 'software.amazon.awssdk:auth'
 	implementation 'software.amazon.awssdk:s3'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -2,10 +2,15 @@ package umc.teumteum.server.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
+import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
+import umc.teumteum.server.domain.auth.service.AuthService;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -14,15 +19,19 @@ import umc.teumteum.server.global.apiPayload.ApiResponse;
 @RequestMapping("/api/auth")
 public class AuthController {
 
+    private final AuthService authService;
+
     @Operation(
             summary = "소셜 로그인",
             description = "카카오, 네이버에 대한 소셜 플랫폼을 통한 로그인을 처리합니다."
     )
     @PostMapping(value = "/social-login", produces = "application/json")
-    public ApiResponse<Object> socialLogin(
-    ) {
-        // TODO: 소셜 로그인 로직 구현
-        return null;
+    public ApiResponse<AuthResponseDTO.LoginResponse> socialLogin(
+            @Valid @RequestBody AuthRequestDTO.SocialLoginRequest request
+            ) {
+        AuthResponseDTO.LoginResponse response = authService.socialLogin(request);
+
+        return ApiResponse.onSuccess(response);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,26 @@
+package umc.teumteum.server.domain.auth.converter;
+
+import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+
+public class AuthConverter {
+
+    public static OAuthUserInfo toOAuthUserInfoDTO (SocialType socialType, String socialId, String email) {
+        return OAuthUserInfo.builder()
+                .socialType(socialType)
+                .socialId(socialId)
+                .email(email)
+                .build()
+                ;
+    }
+
+    public static AuthResponseDTO.LoginResponse toLoginResponse(String accessToken, String refreshToken, String nextStep) {
+        return AuthResponseDTO.LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .nextStep(nextStep)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDTO.java
@@ -1,4 +1,28 @@
 package umc.teumteum.server.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class AuthRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SocialLoginRequest {
+
+        @NotBlank(message = "소셜 로그인 타입은 필수입니다")
+        @Pattern(regexp = "^(kakao|naver)$", message = "지원하지 않는 소셜 로그인 제공자입니다")
+        @Schema(description = "소셜 로그인 타입", example = "kakao", allowableValues = {"kakao", "naver"})
+        private String socialType;
+
+        @NotBlank(message = "액세스 토큰은 필수입니다")
+        @Schema(description = "소셜 로그인 액세스 토큰")
+        private String accessToken;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
@@ -1,4 +1,19 @@
 package umc.teumteum.server.domain.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class AuthResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginResponse {
+        private String accessToken;     // 액세스토큰
+        private String refreshToken;    // 리프레시토큰
+        private String nextStep;        // 다음 화면 단계
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/OAuthUserInfo.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/OAuthUserInfo.java
@@ -1,0 +1,14 @@
+package umc.teumteum.server.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+
+@Getter
+@Builder
+public class OAuthUserInfo {
+
+    private SocialType socialType;  // 소셜 로그인 타입 (kakao, naver)
+    private String socialId;        // 소셜 로그인 시의 고유 ID
+    private String email;           // 소셜에서의 사용자 이메일
+}

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
@@ -1,4 +1,8 @@
 package umc.teumteum.server.domain.auth.service;
 
+import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
+import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
+
 public interface AuthService {
+    AuthResponseDTO.LoginResponse socialLogin(AuthRequestDTO.SocialLoginRequest request);
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -25,12 +25,12 @@ public class AuthServiceImpl implements AuthService {
         // 1. 소셜 로그인 - 사용자 정보 불러오기
         OAuthUserInfo userInfo = getUserInfo(request.getSocialType(), request.getAccessToken());
 
-        // 2. 사용자 조회 (없으면 회원가입)
+        // 2. 사용자 조회 (없으면 생성)
         User user = userService.findOrCreateUser(userInfo);
 
         // 3. 토큰 생성
-        // 액세스 토큰 생성
-        // 리프레시 토큰 생성
+        String accessToken = jwtUtil.generateAccessToken(user.getId());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId());
 
         // 4. TODO 리프레시 토큰 저장
 
@@ -38,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
         String nextStep = userService.determineUserNextStep(user);
 
         // 6. converter 작업
-        return AuthConverter.toLoginResponse(null, null, nextStep);
+        return AuthConverter.toLoginResponse(accessToken, refreshToken, nextStep);
     }
 
     // SocialType 따라 로그인 분기 처리

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -1,4 +1,58 @@
 package umc.teumteum.server.domain.auth.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.auth.converter.AuthConverter;
+import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
+import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.service.UserService;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.exception.handler.AuthHandler;
+import umc.teumteum.server.global.util.JwtUtil;
+
+@Service
+@RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public AuthResponseDTO.LoginResponse socialLogin(AuthRequestDTO.SocialLoginRequest request) {
+        // 1. 소셜 로그인 - 사용자 정보 불러오기
+        OAuthUserInfo userInfo = getUserInfo(request.getSocialType(), request.getAccessToken());
+
+        // 2. 사용자 조회 (없으면 회원가입)
+        User user = userService.findOrCreateUser(userInfo);
+
+        // 3. 토큰 생성
+        // 액세스 토큰 생성
+        // 리프레시 토큰 생성
+
+        // 4. TODO 리프레시 토큰 저장
+
+        // 5. 다음 단계 결정
+        String nextStep = userService.determineUserNextStep(user);
+
+        // 6. converter 작업
+        return AuthConverter.toLoginResponse(null, null, nextStep);
+    }
+
+    // SocialType 따라 로그인 분기 처리
+    private OAuthUserInfo getUserInfo(String socialType, String accessToken) {
+        switch (socialType.toUpperCase()) {
+            case "KAKAO":
+                return kakaoOAuthService.getUserInfoWithAccessToken(accessToken);
+
+//             TODO 네이버 소셜 로그인 구현
+//            case "naver":
+//                return naverOAuthService.getUserInfoWithAccessToken(accessToken);
+
+            default:
+                throw new AuthHandler(ErrorStatus.INVALID_SOCIAL_TYPE);
+        }
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.auth.service;
+
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+
+public interface KakaoOAuthService {
+    OAuthUserInfo getUserInfoWithAccessToken(String accessToken);
+}

--- a/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
@@ -1,0 +1,52 @@
+package umc.teumteum.server.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import umc.teumteum.server.domain.auth.converter.AuthConverter;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.exception.handler.AuthHandler;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthServiceImpl implements KakaoOAuthService {
+
+    private final RestTemplate restTemplate;
+
+    // 사용자 정보 조회
+    @Override
+    public OAuthUserInfo getUserInfoWithAccessToken(String accessToken) {
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, request, Map.class);
+            Map<String, Object> body = response.getBody();
+
+            if (body == null || !body.containsKey("id")) {
+                throw new AuthHandler(ErrorStatus.KAKAO_USER_INFO_FAILED);
+            }
+
+            String socialId = String.valueOf(body.get("id"));
+            Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+            String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+
+            return AuthConverter.toOAuthUserInfoDTO(SocialType.KAKAO, socialId, email);
+
+        } catch (Exception e) {
+            throw new AuthHandler(ErrorStatus.KAKAO_USER_INFO_FAILED);
+        }
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -38,8 +38,8 @@ public class User extends BaseEntity {
     private String socialId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
-    private SocialType type;
+    @Column(name = "social_type", nullable = false)
+    private SocialType socialType;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
@@ -49,13 +49,13 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true, length = 255)
     private String email;
 
-    @Column(name = "nickname", nullable = false)
+    @Column(name = "nickname")
     private String nickname;
 
-    @Column(name = "sleep_time", nullable = false)
+    @Column(name = "sleep_time")
     private LocalTime sleepTime;
 
-    @Column(name = "wake_time", nullable = false)
+    @Column(name = "wake_time")
     private LocalTime wakeTime;
 
     @Column(name = "job")

--- a/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
@@ -1,0 +1,11 @@
+package umc.teumteum.server.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.user.entity.Agreement;
+import umc.teumteum.server.domain.user.entity.User;
+
+import java.util.Optional;
+
+public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+    Optional<Agreement> findByUser(User user);
+}

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -2,7 +2,10 @@ package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    // 필요시 커스텀 메서드 추가
+    Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package umc.teumteum.server.domain.user.service;
 
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import umc.teumteum.server.domain.user.entity.User;
 
 import java.util.List;
 
@@ -12,4 +14,8 @@ public interface UserService {
     List<PublicTodoResponseDto> getDailyPublicTodos(Long userId, String date);
 
     List<String> getTodoDatesOfMonth(Long userId, String month);
+
+    User findOrCreateUser(OAuthUserInfo userInfo);
+
+    String determineUserNextStep(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -44,7 +44,7 @@ public class UserServiceImpl implements UserService {
     }
 
 
-    // 소셜 로그인 시, 사용자 조회 (없으면 회원가입)
+    // 소셜 로그인 시, 사용자 조회 (없으면 생성)
     @Override
     public User findOrCreateUser(OAuthUserInfo userInfo) {
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -1,10 +1,24 @@
 package umc.teumteum.server.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import umc.teumteum.server.domain.user.entity.Agreement;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.repository.AgreementRepository;
+import umc.teumteum.server.domain.user.repository.UserRepository;
 
 import java.util.List;
 
+@Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final AgreementRepository agreementRepository;
+
     @Override
     public Long searchByNickname(String nickname) {
         // TODO : 닉네임으로 사용자 검색 로직 구현
@@ -27,5 +41,46 @@ public class UserServiceImpl implements UserService {
     public List<String> getTodoDatesOfMonth(Long userId, String month) {
         // TODO : 공개 투두가 있는 날짜 조회 로직 구현
         return List.of();
+    }
+
+
+    // 소셜 로그인 시, 사용자 조회 (없으면 회원가입)
+    @Override
+    public User findOrCreateUser(OAuthUserInfo userInfo) {
+
+        SocialType socialType = userInfo.getSocialType();
+        String socialId = userInfo.getSocialId();
+        String email = userInfo.getEmail();
+
+        return userRepository.findBySocialTypeAndSocialId(socialType, socialId)
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .socialType(socialType)
+                            .socialId(socialId)
+                            .email(email)
+                            .build()
+                            ;
+
+                    return userRepository.save(newUser);
+                });
+    }
+
+    // 소셜 로그인 시, 사용자 다음 화면 결정
+    @Override
+    public String determineUserNextStep(User user) {
+        // 1. 약관 동의 체크 -> 약관 동의 화면
+        Agreement agreement = agreementRepository.findByUser(user)
+                .orElse(null);
+        if (agreement == null) {
+            return "AGREEMENT";
+        }
+
+        // 2. 닉네임 체크 -> 온보딩 화면
+        if (user.getNickname() == null) {
+            return "ONBOARDING";
+        }
+
+        // 3. 메인 화면
+        return "MAIN";
     }
 }

--- a/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
@@ -12,7 +12,15 @@ public enum ErrorStatus implements BaseErrorCode {
   _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
   _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
   _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-  _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+  _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+  // 인증 관련
+  INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "AUTH4001", "지원하지 않는 소셜 로그인 타입입니다."),
+  KAKAO_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "카카오 사용자 정보 조회에 실패했습니다."),
+
+
+  ;
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/umc/teumteum/server/global/config/RestTemplateConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package umc.teumteum.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/exception/handler/AuthHandler.java
+++ b/src/main/java/umc/teumteum/server/global/exception/handler/AuthHandler.java
@@ -1,0 +1,11 @@
+package umc.teumteum.server.global.exception.handler;
+
+import umc.teumteum.server.global.apiPayload.code.BaseErrorCode;
+import umc.teumteum.server.global.exception.GeneralException;
+
+public class AuthHandler extends GeneralException {
+
+  public AuthHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/umc/teumteum/server/global/util/JwtUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/JwtUtil.java
@@ -1,0 +1,56 @@
+package umc.teumteum.server.global.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-expiration-ms}")
+    private long accessExpirationMs;
+
+    @Value("${jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 액세스 토큰 생성
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, accessExpirationMs, "ACCESS");
+    }
+
+    // 리프레시 토큰 생성
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, refreshExpirationMs, "REFRESH");
+    }
+
+    // 토큰 생성 (타입 구분)
+    private String generateToken(Long userId, long expiration, String tokenType) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("type", tokenType)   // ACCESS or REFRESH
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact()
+                ;
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈
#24 

### ✨ 작업한 내용
- **Kakao Developers에서 앱 생성**
- **UserEntity 수정**
소셜 로그인 시, 서비스의 기존 회원이 아니라면 새롭게 User 레코드를 생성합니다.
이후에 온보딩 흐름이 진행되는 것이기 때문에, 현 API 단계에서는 닉네임과 수면 패턴의 경우에는 nullable이 적합하다고 생각하여 수정하였습니다.
-  **카카오를 통한 소셜 로그인 구현**
다음과 같은 흐름으로 진행됩니다.
    1) _프론트에서 안드로이드 SDK를 통해서 카카오 액세스 토큰 발급_
    2) 해당 액세스 토큰을 통해서, 백엔드에서 카카오에 접근하여 사용자 정보(이메일)를 불러옴
    3) 해당 정보를 통해 사용자를 조회하고 없으면 새로 생성
    4) 사용자 기본키 값으로 JWT 생성
    5) 약관 동의 / 온보딩 / 홈화면 등 다음 단계 결정
- 추후, 다른 이슈 통해서 네이버 소셜 로그인 & 리프레시 토큰 저장 / Spring Security 설정 등 추가하도록 하겠습니다.
- API 테스트 방법(카카오 액세스 토큰 발급) 노션에 정리하도록 하겠습니다.

### 🌀 PR Point
X

### 🍰 참고사항
- properties 추가로 인해 서브모듈 업데이트 필요합니다!
- 해당 방식대로는 개발 진행하면서 백엔드 자체적으로 저희 액세스 토큰 발급까지의 과정이 상당히 번거롭습니다...
개발용으로 서비스 액세스 토큰 발급하는 API를 추가할까요??

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   카카오 소셜 로그인 API   | <img width="969" height="857" alt="스크린샷 2025-07-16 오후 6 28 38" src="https://github.com/user-attachments/assets/011c4802-2363-4855-85ec-cd0d841046ca" /> |