### PR TITLE
Feat: 틈 재요청 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -55,7 +55,7 @@ public class TeumController {
             @RequestBody TeumResendRequestDto resendRequestDto
     ) {
         Long id = teumService.createResendRequest(parentRequestId, resendRequestDto);
-        return ApiResponse.of(null, new TeumResendResponseDto(id));
+        return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CREATED, new TeumResendResponseDto(id));
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.teum.converter;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
+import umc.teumteum.server.domain.teum.dto.teum.TeumResendRequestDto;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
@@ -83,6 +84,29 @@ public class TeumConverter {
         return responses.stream()
                 .map(response -> toReceivedResponseDto(response, s3Util))
                 .toList();
+    }
+
+    public static TeumRequest toResendTeumRequest(TeumRequest parent, TeumResendRequestDto dto, User resender) {
+        return TeumRequest.builder()
+                .title(parent.getTitle())
+                .description(parent.getDescription())
+                .date(parent.getDate())
+                .startTime(LocalTime.parse(dto.getStartTime()))
+                .endTime(LocalTime.parse(dto.getEndTime()))
+                .graphicId(parent.getGraphicId())
+                .user(resender)
+                .parentRequest(parent)
+                .build();
+    }
+
+    public static TeumResponse toResendTeumResponse(TeumRequest request, User newReceiver) {
+        return TeumResponse.builder()
+                .teumRequest(request)
+                .receiverUser(newReceiver)
+                .status(ResponseStatus.PENDING)
+                .message("")
+                .readAt(null)
+                .build();
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumResendRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumResendRequestDto.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.teum.dto.teum;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,4 +15,8 @@ public class TeumResendRequestDto {
 
     @Schema(description = "종료 시간", example = "00:00")
     private String endTime;
+
+    @NotNull
+    @Schema(description = "재요청을 보내는 유저 (원래 요청의 수신자)", example = "1")
+    private Long senderUserId;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
@@ -39,6 +39,20 @@ public class TeumResponse extends BaseEntity {
     @Column(name = "status", nullable = false)
     private ResponseStatus status = ResponseStatus.PENDING;
 
-    @Column(name = "read_at", nullable = true)
+    @Column(name = "read_at")
     private LocalDateTime readAt;
+
+    /**
+     * 응답 상태 변경
+     */
+    public void changeStatus(ResponseStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    /**
+     * 응답 읽음 처리
+     */
+    public void markAsRead() {
+        this.readAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
@@ -4,5 +4,5 @@ public enum ResponseStatus {
     PENDING,    // 수신자가 응답을 하지 않음
     ACCEPTED,   // 수신자가 요청을 수락
     REJECTED,   // 수신자가 요청을 거절
-    SUGGESTED   // 수신자가 시간대 바꿔 재요청
+    RESEND   // 수신자가 시간대 바꿔 재요청
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
@@ -17,7 +17,9 @@ public enum TeumErrorStatus implements BaseErrorCode {
     DUPLICATE_RECEIVER(HttpStatus.CONFLICT, "TEUM4090", "수신자 목록에 중복된 사용자가 포함되어 있습니다."),
     CANNOT_REQUEST_SELF(HttpStatus.CONFLICT, "TEUM4091", "자기 자신에게 틈 요청을 보낼 수 없습니다."),
     REQUEST_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "TEUM4002", "이미 마감된 요청입니다."),
-    INVALID_PARENT_REQUEST(HttpStatus.BAD_REQUEST, "TEUM4003", "재요청의 기준이 되는 요청이 올바르지 않습니다.");
+    INVALID_PARENT_REQUEST(HttpStatus.BAD_REQUEST, "TEUM4003", "재요청의 기준이 되는 요청이 올바르지 않습니다."),
+    REQUEST_NOT_ONE_TO_ONE(HttpStatus.BAD_REQUEST, "TEUM4004", "재요청은 수신자가 1명인 요청에 대해서만 가능합니다."),
+    REQUEST_ALREADY_RESENT(HttpStatus.BAD_REQUEST, "TEUM4005", "재요청을 기반으로 다시 재요청할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -79,15 +79,20 @@ public class TeumServiceImpl implements TeumService {
 
         User resender = getUserOrThrow(dto.getSenderUserId());
 
+        // 새로운 요청/응답 생성
         TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, resender);
         TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, parent.getUser());
-
         newRequest.getTeumResponses().add(newResponse);
+
+        // 원래 요청의 응답 상태를 RESEND로 변경
+        TeumResponse originalResponse = parent.getTeumResponses().getFirst();
+        originalResponse.changeStatus(ResponseStatus.RESEND); // enum도 RESEND로 이름 바꿔주세요
+
+        // 저장
         teumRequestRepository.save(newRequest);
 
         return newRequest.getId();
     }
-
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -31,6 +31,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
+
 @Service
 @RequiredArgsConstructor
 public class TeumServiceImpl implements TeumService {
@@ -68,10 +70,24 @@ public class TeumServiceImpl implements TeumService {
 
     @Override
     @Transactional
-    public Long createResendRequest(Long parentRequestId, TeumResendRequestDto resendRequestDto) {
-        // TODO: 틈 요청 로직 추후 구현
-        return 1L;
+    public Long createResendRequest(Long parentRequestId, TeumResendRequestDto dto) {
+        TeumRequest parent = findActiveRequestOrThrow(parentRequestId);
+
+        validateResendableRequest(parent);
+        validateResender(parent, dto.getSenderUserId());
+        validateTimeOrder(dto.getStartTime(), dto.getEndTime());
+
+        User resender = getUserOrThrow(dto.getSenderUserId());
+
+        TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, resender);
+        TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, parent.getUser());
+
+        newRequest.getTeumResponses().add(newResponse);
+        teumRequestRepository.save(newRequest);
+
+        return newRequest.getId();
     }
+
 
     @Override
     @Transactional(readOnly = true)
@@ -137,5 +153,40 @@ public class TeumServiceImpl implements TeumService {
         // TODO : 함께한 틈 시간 조회 로직 추후 구현
         return null;
     }
+
+    private TeumRequest findActiveRequestOrThrow(Long requestId) {
+        TeumRequest request = teumRequestRepository.findById(requestId)
+                .orElseThrow(() -> new GeneralException(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND));
+        if (request.getStatus() != RequestStatus.ACTIVE) {
+            throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
+        }
+        return request;
+    }
+
+    private void validateResendableRequest(TeumRequest request) {
+        if (request.getParentRequest() != null) {
+            throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_RESENT);
+        }
+        if (request.getTeumResponses().size() != 1) {
+            throw new GeneralException(TeumErrorStatus.REQUEST_NOT_ONE_TO_ONE);
+        }
+    }
+
+    private void validateResender(TeumRequest request, Long senderUserId) {
+        User resender = getUserOrThrow(senderUserId);
+        User actualReceiver = request.getTeumResponses().getFirst().getReceiverUser();
+        if (!resender.getId().equals(actualReceiver.getId())) {
+            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
+    }
+
+    private void validateTimeOrder(String startTime, String endTime) {
+        LocalTime start = LocalTime.parse(startTime);
+        LocalTime end = LocalTime.parse(endTime);
+        if (!start.isBefore(end)) {
+            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        }
+    }
+
 
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#36 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 틈 재요청 API (POST /api/teums/request/{parentRequestId}/resend) 구현
- 기존 요청의 수신자가, 요청자에게 시간대를 제안하여 재요청 생성
- 재요청은 일대일 요청에 대해서만 가능
- 재요청이 생성되면
   - 새로운 `TeumRequest`, `TeumResponse` 생성
   - 원래 요청의 `TeumResponse.status`를 `RESEND`로 변경
- 응답 상태가 RESEND이면 /request/received 목록에서 제외됨

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 재요청이 적절하게 제한되고 있는지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 빠른 시일 내에 기존에 개발한 API들과 함께 Auth 기반으로 리팩토링할 예정입니다.
- API 명세서에 아래의 내용에 대한 결과를 작성해 두었습니다.
  - 존재하지 않는 틈에 대한 재요청
  - 이미 마감된 틈에 대한 재요청
  - 일대다 요청에 대한 재요청
  - 수신자가 옳지 않은 재요청
  - 시간 설정이 잘못된 재요청
  - 재요청을 기반으로 한 재요청
  > https://excessive-pedestrian-954.notion.site/22666802aaae80b98bc9eaac17261170?pvs=74

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 틈 재요청 API | <img width="1436" height="1201" alt="image" src="https://github.com/user-attachments/assets/77d1bc32-2f00-4382-9af1-f80731ce02fb" /> |