### PR TITLE
Feat: 친구 프로필 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -100,14 +100,18 @@ public class FriendController {
 
     @Operation(
             summary = "친구 프로필 조회",
-            description = "지정한 친구(userId)의 프로필 정보를 반환합니다."
+            description = "지정한 친구(userId)의 프로필 정보를 반환합니다. 인증 미적용 상태에서는 loginUserId도 파라미터로 전달해야 합니다."
     )
     @GetMapping(value = "/{userId}/profile", produces = "application/json")
     public ApiResponse<FriendProfileResponseDto> getFriendProfile(
-            @Parameter(name = "userId", description = "조회할 친구 ID", example = "1")
-            @PathVariable("userId") Long userId
+            @Parameter(name = "userId", description = "조회할 친구 ID", example = "2")
+            @PathVariable("userId") Long targetUserId,
+            @Parameter(name = "loginUserId", description = "현재 로그인한 유저 ID", example = "1")
+            @RequestParam("loginUserId") Long loginUserId
     ) {
-        return ApiResponse.onSuccess(null);
+        FriendProfileResponseDto response = friendService.getFriendProfile(loginUserId, targetUserId);
+        return ApiResponse.of(FriendSuccessStatus._GET_FRIENDS_SUCCESS, response);
     }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
 import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
+import umc.teumteum.server.domain.friend.dto.FriendProfileResponseDto;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
@@ -51,4 +52,18 @@ public class FriendConverter {
                 .map(this::toFollowerUserResponse)
                 .collect(Collectors.toList());
     }
+
+    public FriendProfileResponseDto toFriendProfileResponse(User targetUser, Friend followRelation) {
+        String imageUrl = s3Util.toUrl(targetUser.getProfileImageKey());
+
+        return FriendProfileResponseDto.builder()
+                .userId(targetUser.getId())
+                .name(targetUser.getNickname())
+                .profileImageUrl(imageUrl)
+                .field(targetUser.getJob()) // 또는 getField() 등
+                .isFollowing(followRelation != null)
+                .isFavorite(followRelation != null && followRelation.getIsFavorite())
+                .build();
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.friend.converter;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
@@ -20,7 +21,7 @@ public class FriendConverter {
 
     public FollowingUserResponseDto toFollowingUserResponse(Friend friend) {
         User following = friend.getFollowing();
-        String imageUrl = s3Util.toUrl(following.getProfileImageKey());
+        String imageUrl = s3Util.toPresignedUrl(following.getProfileImageKey(), Duration.ofMinutes(30));
 
         return new FollowingUserResponseDto(
                 following.getId(),
@@ -38,7 +39,7 @@ public class FriendConverter {
 
     public FollowerUserResponseDto toFollowerUserResponse(Friend friend) {
         User follower = friend.getFollower();
-        String imageUrl = s3Util.toUrl(follower.getProfileImageKey());
+        String imageUrl = s3Util.toPresignedUrl(follower.getProfileImageKey(), Duration.ofMinutes(30));
 
         return new FollowerUserResponseDto(
                 follower.getId(),
@@ -54,7 +55,7 @@ public class FriendConverter {
     }
 
     public FriendProfileResponseDto toFriendProfileResponse(User targetUser, Friend followRelation) {
-        String imageUrl = s3Util.toUrl(targetUser.getProfileImageKey());
+        String imageUrl = s3Util.toPresignedUrl(targetUser.getProfileImageKey(), Duration.ofMinutes(30));
 
         return FriendProfileResponseDto.builder()
                 .userId(targetUser.getId())

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
@@ -12,8 +12,8 @@ public enum FriendErrorStatus implements BaseErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4040", "존재하지 않는 유저입니다."),
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FRIEND4001", "이미 팔로우한 유저입니다."),
-    CANNOT_FOLLOW_SELF(HttpStatus.CONFLICT, "FRIEND4090", "자기 자신은 팔로우할 수 없습니다."),
-    BLOCKED_USER(HttpStatus.FORBIDDEN, "FRIEND4030", "차단된 유저는 팔로우할 수 없습니다.");
+    CANNOT_VIEW_SELF(HttpStatus.BAD_REQUEST, "FRIEND4002", "자기 자신의 프로필은 친구 프로필 API에서 조회할 수 없습니다."),
+    CANNOT_FOLLOW_SELF(HttpStatus.CONFLICT, "FRIEND4090", "자기 자신은 팔로우할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
@@ -4,9 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.friend.entity.Friend;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findByFollowerId(Long followerId);
 
     List<Friend> findByFollowingId(Long id);
+
+    Optional<Friend> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -1,14 +1,12 @@
 package umc.teumteum.server.domain.friend.service;
 
-import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FriendMutualResponseDto;
-import umc.teumteum.server.domain.friend.dto.FavoriteResponseDto;
+import umc.teumteum.server.domain.friend.dto.*;
 
 import java.util.List;
 
 public interface FriendService {
     Long follow(Long userId);
+
     void unfollow(Long userId);
 
     List<FriendMutualResponseDto> getMutualFriends();
@@ -18,5 +16,7 @@ public interface FriendService {
     List<FollowingUserResponseDto> getFollowingsByUser(Long userId, int page, int size);
 
     List<FollowerUserResponseDto> getFollowersByUser(Long userId, int page, int size);
+
+    FriendProfileResponseDto getFriendProfile(Long loginUserId, Long targetUserId);
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -6,10 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import umc.teumteum.server.domain.friend.controller.FriendController;
 import umc.teumteum.server.domain.friend.converter.FriendConverter;
-import umc.teumteum.server.domain.friend.dto.FavoriteResponseDto;
-import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FriendMutualResponseDto;
+import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.friend.exception.status.FriendErrorStatus;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
@@ -19,6 +16,7 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -88,6 +86,21 @@ public class FriendServiceImpl implements FriendService {
         int end = Math.min(start + size, sortedList.size());
 
         return (start >= sortedList.size()) ? List.of() : sortedList.subList(start, end);
+    }
+
+    @Override
+    public FriendProfileResponseDto getFriendProfile(Long loginUserId, Long targetUserId) {
+        if (loginUserId.equals(targetUserId)) {
+            throw new GlobalHandler(FriendErrorStatus.CANNOT_VIEW_SELF);
+        }
+
+        User loginUser = getUserOrThrow(loginUserId);
+        User targetUser = getUserOrThrow(targetUserId);
+
+        Optional<Friend> followRelationOpt = friendRepository
+                .findByFollowerIdAndFollowingId(loginUser.getId(), targetUser.getId());
+
+        return friendConverter.toFriendProfileResponse(targetUser, followRelationOpt.orElse(null));
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.teum.converter;
 
+import java.time.Duration;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
@@ -69,7 +70,8 @@ public class TeumConverter {
                 .senderUser(ParticipantDto.builder()
                         .userId(sender.getId())
                         .nickname(sender.getNickname())
-                        .profileImageUrl(s3Util.toUrl(sender.getProfileImageKey()))
+                        .profileImageUrl(s3Util.toPresignedUrl(sender.getProfileImageKey(),
+                            Duration.ofMinutes(30)))
                         .build())
                 .date(request.getDate().toString())
                 .timeSlot(TimeSlot.builder()

--- a/src/main/java/umc/teumteum/server/global/config/S3Config.java
+++ b/src/main/java/umc/teumteum/server/global/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @RequiredArgsConstructor
@@ -29,6 +30,14 @@ public class S3Config {
         .credentialsProvider(StaticCredentialsProvider.create(credentials))
         .build();
 
+  }
+  @Bean
+  public S3Presigner s3Presigner() {
+    AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .build();
   }
 
 

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 @RequiredArgsConstructor
 public class S3Util {
 
-    @Value("${cloud.aws.s3.bucket.name}")
+    @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
     private final S3Presigner s3Presigner;

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -1,15 +1,32 @@
 package umc.teumteum.server.global.util;
 
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Component
+@RequiredArgsConstructor
 public class S3Util {
 
-    @Value("${cloud.aws.s3.bucket.url:https://mock-bucket.s3.amazonaws.com/}")
-    private String bucketUrl;
+    @Value("${cloud.aws.s3.bucket.name}")
+    private String bucketName;
 
-    public String toUrl(String key) {
-        return bucketUrl.endsWith("/") ? bucketUrl + key : bucketUrl + "/" + key;
+    private final S3Presigner s3Presigner;
+
+    public String toPresignedUrl(String key, Duration duration) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+            .bucket(bucketName)
+            .key(key).build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+            .signatureDuration(duration)
+            .getObjectRequest(getObjectRequest)
+            .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#45 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 친구 프로필 조회 API 구현 (GET /api/friends/{userId}/profile?loginUserId=xx)
- 로그인 유저 기준으로
   - 대상 유저 정보 (닉네임, 직종, 프로필 이미지) 조회
   - 팔로잉 여부, 즐겨찾기 여부 포함
- 없는 사용자거나 자기 자신의 프로필을 조회할 경우 예외 처리 

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 현재 Spring Security 미적용 상태이므로 loginUserId는 쿼리 파라미터로 받음

### 📷 응답 JSON

#### 조회 성공
```JSON
{
  "isSuccess": true,
  "code": "FRIEND2002",
  "message": "친구 목록 조회에 성공하였습니다.",
  "result": {
    "userId": 2,
    "name": "유저2",
    "profileImageUrl": "https://mock-bucket.s3.amazonaws.com/profile2.jpg",
    "field": "프론트엔드 개발자",
    "following": true,
    "favorite": true
  }
}
```
#### 없는 유저 조회
```JSON
{
  "isSuccess": false,
  "code": "FRIEND4040",
  "message": "존재하지 않는 유저입니다."
}
```
#### 본인 조회
```JSON
{
  "isSuccess": false,
  "code": "FRIEND4002",
  "message": "자기 자신의 프로필은 친구 프로필 API에서 조회할 수 없습니다."
}
```