### PR TITLE
Feat: 친구의 빈틈 시간 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -113,5 +113,16 @@ public class FriendController {
         return ApiResponse.of(FriendSuccessStatus._GET_FRIENDS_SUCCESS, response);
     }
 
+    @Operation(
+            summary = "친구의 빈틈 시간 조회",
+            description = "isIncludeTeumTime == true 인 일정들의 시간을 합산하여 반환합니다."
+    )
+    @GetMapping(value = "/{userId}/teum-time", produces = "application/json")
+    public ApiResponse<Long> getFriendTeumTime(
+            @Parameter(name = "userId", description = "조회할 친구 ID") @PathVariable("userId") Long userId
+    ) {
+        Long result = friendService.getFriendTeumTime(userId);
+        return ApiResponse.of(FriendSuccessStatus._GET_FRIENDS_SUCCESS, result);
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -122,7 +122,7 @@ public class FriendController {
             @Parameter(name = "userId", description = "조회할 친구 ID") @PathVariable("userId") Long userId
     ) {
         Long result = friendService.getFriendTeumTime(userId);
-        return ApiResponse.of(FriendSuccessStatus._GET_FRIENDS_SUCCESS, result);
+        return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_TEUM_TIME_SUCCESS, result);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -7,6 +7,7 @@ import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
 import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
 import umc.teumteum.server.domain.friend.dto.FriendProfileResponseDto;
 import umc.teumteum.server.domain.friend.entity.Friend;
+import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
 
@@ -65,6 +66,12 @@ public class FriendConverter {
                 .isFollowing(followRelation != null)
                 .isFavorite(followRelation != null && followRelation.getIsFavorite())
                 .build();
+    }
+
+    public Long calculateTeumTime(List<Schedule> schedules) {
+        return schedules.stream()
+                .mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes())
+                .sum();
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
@@ -12,7 +12,8 @@ public enum FriendSuccessStatus implements BaseCode {
     _FOLLOW_SUCCESS(HttpStatus.OK, "FRIEND2000", "팔로우가 성공적으로 완료되었습니다."),
     _UNFOLLOW_SUCCESS(HttpStatus.OK, "FRIEND2001", "언팔로우가 성공적으로 완료되었습니다."),
     _GET_FRIENDS_SUCCESS(HttpStatus.OK, "FRIEND2002", "친구 목록 조회에 성공하였습니다."),
-    _FAVORITE_UPDATE_SUCCESS(HttpStatus.OK, "FRIEND2003", "즐겨찾기 설정이 완료되었습니다.");
+    _FAVORITE_UPDATE_SUCCESS(HttpStatus.OK, "FRIEND2003", "즐겨찾기 설정이 완료되었습니다."),
+    GET_FRIEND_TEUM_TIME_SUCCESS(HttpStatus.OK, "FRIEND2004", "친구 빈틈 시간 조회에 성공하였습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -19,4 +19,6 @@ public interface FriendService {
 
     FriendProfileResponseDto getFriendProfile(Long loginUserId, Long targetUserId);
 
+    Long getFriendTeumTime(Long userId);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -10,10 +10,13 @@ import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.friend.exception.status.FriendErrorStatus;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +28,7 @@ public class FriendServiceImpl implements FriendService {
 
     private final UserRepository userRepository;
     private final FriendRepository friendRepository;
+    private final ScheduleRepository scheduleRepository;
     private final FriendConverter friendConverter;
 
     @Override
@@ -101,6 +105,13 @@ public class FriendServiceImpl implements FriendService {
                 .findByFollowerIdAndFollowingId(loginUser.getId(), targetUser.getId());
 
         return friendConverter.toFriendProfileResponse(targetUser, followRelationOpt.orElse(null));
+    }
+
+    @Override
+    public Long getFriendTeumTime(Long userId) {
+        User user = getUserOrThrow(userId);
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndIncludeTeumIsTrue(userId);
+        return friendConverter.calculateTeumTime(schedules);
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -1,4 +1,10 @@
 package umc.teumteum.server.domain.home.repository;
 
-public interface ScheduleRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.home.entity.Schedule;
+
+import java.util.List;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#47 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- GET /api/friends/{userId}/teum-time API 구현
- `includeTeum`이 `true`인 일정들의 총 시간을 계산하여 반환 (단위: 분)
- `ScheduleRepository`에 사용자 일정 조회 메서드 추가
- 시간 계산 로직을 `FriendConverter`로 분리
- 응답은 단일 `Long` 값으로 반환 (`ApiResponse<Long>`)

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- `ScheduleRepository` 쿼리 메서드 네이밍이 너무 길진 않은지...
- `Duration.between(...).toMinutes()` 방식의 시간 계산이 적절한지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 친구의 빈틈 시간 조회 API | <img width="1437" height="1037" alt="image" src="https://github.com/user-attachments/assets/e0b568e7-6f2d-4294-af54-4f6bba8620d9" /> |