### PR TITLE
Feat: 틈 응답 상태 변경 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -1,10 +1,26 @@
 package umc.teumteum.server.domain.home.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
+
+    @Query("""
+        SELECT COUNT(s) > 0 FROM Schedule s
+        WHERE s.user.id = :userId
+          AND s.status = umc.teumteum.server.domain.home.entity.enums.ScheduleStatus.ACTIVE
+          AND s.date = :date
+          AND s.startTime < :endTime
+          AND s.endTime > :startTime
+    """)
+    boolean existsConflictSchedule(@Param("userId") Long userId,
+                                   @Param("date") java.time.LocalDate date,
+                                   @Param("startTime") LocalDateTime startTime,
+                                   @Param("endTime") LocalDateTime endTime);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -97,13 +97,16 @@ public class TeumController {
             summary = "틈 응답 상태 변경",
             description = "응답 ID(responseId)에 해당하는 응답의 상태를 변경합니다. 상태가 'accepted'인 경우 틈 생성 여부를 판단하여 반환합니다."
     )
-    @PatchMapping(value = "/response/{responseId}/status", consumes = "application/json", produces = "application/json")
+    @PatchMapping("/response/{responseId}/status")
     public ApiResponse<TeumStatusUpdateResponseDto> updateResponseStatus(
-            @Parameter(name = "responseId", description = "상태를 변경할 응답 ID", example = "1")
+            @Parameter(name = "responseId", description = "응답 ID", example = "1")
             @PathVariable("responseId") Long responseId,
+            @Parameter(name = "userId", description = "현재 사용자 ID", example = "2")
+            @RequestParam("userId") Long userId,
             @RequestBody TeumStatusUpdateRequestDto requestDto
     ) {
-        return ApiResponse.onSuccess(null);
+        TeumStatusUpdateResponseDto result = teumService.updateResponseStatus(responseId, userId, requestDto);
+        return ApiResponse.of(TeumSuccessStatus._TEUM_STATUS_UPDATED, result);
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -1,6 +1,10 @@
 package umc.teumteum.server.domain.teum.converter;
 
 import java.time.Duration;
+
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
@@ -15,6 +19,7 @@ import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.function.Function;
@@ -108,6 +113,25 @@ public class TeumConverter {
                 .status(ResponseStatus.PENDING)
                 .message("")
                 .readAt(null)
+                .build();
+    }
+
+    public static Schedule toScheduleFromTeumRequest(TeumRequest request, User receiver) {
+        LocalDateTime start = LocalDateTime.of(request.getDate(), request.getStartTime());
+        LocalDateTime end = LocalDateTime.of(request.getDate(), request.getEndTime());
+
+        return Schedule.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .type(ScheduleType.TEUM)
+                .date(request.getDate())
+                .startTime(start)
+                .endTime(end)
+                .user(receiver)
+                .isPublic(false)
+                .includeTeum(false)
+                .teumRequest(request)
+                .status(ScheduleStatus.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumResponseStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumResponseStatus.java
@@ -1,8 +1,0 @@
-package umc.teumteum.server.domain.teum.dto.teum;
-
-public enum TeumResponseStatus {
-    ACCEPTED,
-    DECLINED,
-    SUGGESTED;
-}
-

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumStatusUpdateRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumStatusUpdateRequestDto.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 public class TeumStatusUpdateRequestDto {
 
     @Schema(description = "응답 상태", example = "ACCEPTED", allowableValues = {"ACCEPTED", "DECLINED", "SUGGESTED"})
-    private TeumResponseStatus status;
+    private String status;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumStatusUpdateResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/teum/TeumStatusUpdateResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 
 @Getter
 @Builder
@@ -14,11 +15,11 @@ import lombok.NoArgsConstructor;
 public class TeumStatusUpdateResponseDto {
 
     @Schema(description = "응답 상태", example = "ACCEPTED")
-    private TeumResponseStatus status;
+    private ResponseStatus status;
 
     @Schema(description = "새로운 틈이 생성되었는지 여부 (accepted일 때만 반환)", example = "true")
     private Boolean teumCreated;
 
-    @Schema(description = "생성된 틈 ID (accepted이고 새로 생성된 경우만)", example = "1")
+    @Schema(description = "생성된 틈 ID (accepted일 때만 반환)", example = "1")
     private Long teumId;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
@@ -16,10 +16,12 @@ public enum TeumErrorStatus implements BaseErrorCode {
     INVALID_TEUM_TIME(HttpStatus.BAD_REQUEST, "TEUM4001", "시작 시간과 종료 시간이 유효하지 않습니다."),
     DUPLICATE_RECEIVER(HttpStatus.CONFLICT, "TEUM4090", "수신자 목록에 중복된 사용자가 포함되어 있습니다."),
     CANNOT_REQUEST_SELF(HttpStatus.CONFLICT, "TEUM4091", "자기 자신에게 틈 요청을 보낼 수 없습니다."),
+    SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "TEUM4092", "이미 해당 시간에 다른 스케줄이 존재합니다."),
     REQUEST_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "TEUM4002", "이미 마감된 요청입니다."),
     INVALID_PARENT_REQUEST(HttpStatus.BAD_REQUEST, "TEUM4003", "재요청의 기준이 되는 요청이 올바르지 않습니다."),
     REQUEST_NOT_ONE_TO_ONE(HttpStatus.BAD_REQUEST, "TEUM4004", "재요청은 수신자가 1명인 요청에 대해서만 가능합니다."),
-    REQUEST_ALREADY_RESENT(HttpStatus.BAD_REQUEST, "TEUM4005", "재요청을 기반으로 다시 재요청할 수 없습니다.");
+    REQUEST_ALREADY_RESENT(HttpStatus.BAD_REQUEST, "TEUM4005", "재요청을 기반으로 다시 재요청할 수 없습니다."),
+    INVALID_RESPONSE_STATUS(HttpStatus.BAD_REQUEST, "TEUM4006", "응답 status 값은 accepted 또는 rejected 이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -119,10 +119,7 @@ public class TeumServiceImpl implements TeumService {
     @Transactional
     public Long updateReadStatus(Long responseId, Long userId) {
         TeumResponse response = getResponseOrThrow(responseId);
-
-        if (!response.getReceiverUser().getId().equals(userId)) {
-            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
-        }
+        validateReceiver(response, userId);
 
         response.markAsRead();
         return responseId;
@@ -132,10 +129,7 @@ public class TeumServiceImpl implements TeumService {
     @Transactional
     public TeumStatusUpdateResponseDto updateResponseStatus(Long responseId, Long userId, TeumStatusUpdateRequestDto requestDto) {
         TeumResponse response = getResponseOrThrow(responseId);
-
-        if (!response.getReceiverUser().getId().equals(userId)) {
-            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
-        }
+        validateReceiver(response, userId);
 
         if (response.getStatus() != ResponseStatus.PENDING) {
             throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
@@ -218,6 +212,12 @@ public class TeumServiceImpl implements TeumService {
             throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
         }
         return request;
+    }
+
+    private void validateReceiver(TeumResponse response, Long userId) {
+        if (!response.getReceiverUser().getId().equals(userId)) {
+            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
     }
 
     private void validateResendableRequest(TeumRequest request) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.teum.converter.TeumConverter;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeResponseDto;
@@ -28,6 +30,7 @@ import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -41,6 +44,7 @@ public class TeumServiceImpl implements TeumService {
     private final UserRepository userRepository;
     private final TeumRequestRepository teumRequestRepository;
     private final TeumResponseRepository teumResponseRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Override
     @Transactional
@@ -125,9 +129,45 @@ public class TeumServiceImpl implements TeumService {
     }
 
     @Override
+    @Transactional
     public TeumStatusUpdateResponseDto updateResponseStatus(Long responseId, Long userId, TeumStatusUpdateRequestDto requestDto) {
-        // TODO: 틈 응답 상태 변경 로직 추후 구현
-        return null;
+        TeumResponse response = getResponseOrThrow(responseId);
+
+        if (!response.getReceiverUser().getId().equals(userId)) {
+            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
+
+        if (response.getStatus() != ResponseStatus.PENDING) {
+            throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
+        }
+
+        ResponseStatus newStatus;
+        try {
+            newStatus = ResponseStatus.valueOf(requestDto.getStatus().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(TeumErrorStatus.INVALID_RESPONSE_STATUS);
+        }
+
+        response.changeStatus(newStatus);
+
+        boolean isAccepted = newStatus == ResponseStatus.ACCEPTED;
+        Long teumId = null;
+
+        if (isAccepted) {
+            TeumRequest request = response.getTeumRequest();
+            User receiver = response.getReceiverUser();
+
+            Schedule schedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
+            scheduleRepository.save(schedule);
+
+            teumId = schedule.getId();
+        }
+
+        return TeumStatusUpdateResponseDto.builder()
+                .status(newStatus)
+                .teumCreated(isAccepted)
+                .teumId(teumId)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#52 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 수신자가 PENDING 상태의 요청에 대해 ACCEPTED 또는 REJECTED로 응답할 수 있는 API 구현
- ACCEPTED 응답 시 해당 요청 정보를 기반으로 Schedule 엔티티 생성 및 저장
- REJECTED 응답 시 상태만 변경
- 응답에 따라 TeumStatusUpdateResponseDto 반환 (teumCreated, teumId, status 포함)

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 요청 생성 | <img width="1697" height="204" alt="image" src="https://github.com/user-attachments/assets/b0617f29-c48b-4b5f-a51c-fd2f276d700d" /> |
| 응답 상태 변경 | <img width="1697" height="149" alt="image" src="https://github.com/user-attachments/assets/d9ccef16-d89c-4334-8cdd-fcf6e576d90e" /> |
| 스케줄 생성 | <img width="2048" height="218" alt="image" src="https://github.com/user-attachments/assets/5bb3b2ea-e0e8-4b63-a886-44c29679731a" /> |


#### 수락
```json
{
  "isSuccess": true,
  "code": "TEUM2004",
  "message": "틈 응답 상태가 성공적으로 변경되었습니다.",
  "result": {
    "status": "ACCEPTED",
    "teumCreated": true,
    "teumId": 1
  }
}
```
#### 거절
``` json
{
  "isSuccess": true,
  "code": "TEUM2004",
  "message": "틈 응답 상태가 성공적으로 변경되었습니다.",
  "result": {
    "status": "REJECTED",
    "teumCreated": false,
    "teumId": null
  }
}
```
#### PENDING 상태가 아닌 경우
``` json
{
  "isSuccess": false,
  "code": "TEUM4002",
  "message": "이미 마감된 요청입니다."
}
```
#### 응답이 없는 경우
``` json
{
  "isSuccess": false,
  "code": "TEUM4041",
  "message": "존재하지 않는 틈 응답입니다."
}
```
#### 수신자가 아닌 경우
``` json
{
  "isSuccess": false,
  "code": "TEUM4030",
  "message": "요청 또는 응답에 대한 권한이 없습니다."
}
```
#### 다른 응답을 한 경우
``` json
{
  "isSuccess": false,
  "code": "TEUM4006",
  "message": "응답 status 값은 accepted 또는 rejected 이어야 합니다."
}
```