### PR TITLE
Feat: 시간표(공통 가능 시간대) 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -9,6 +9,7 @@ import umc.teumteum.server.domain.home.dto.TodoRequestDTO;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.common.BaseEntity;
 
@@ -65,9 +66,17 @@ public class Schedule extends BaseEntity {
     @Column(name = "status", nullable = false)
     private ScheduleStatus status = ScheduleStatus.ACTIVE;
 
+    @Builder.Default
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teum_request_id")
     private TeumRequest teumRequest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "routine_id")
+    private Routine routine;
 
     /*
         양방향 연관관계

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,6 +13,8 @@ import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
+
+    List<Schedule> findByUserIdAndDateAndStatus(Long userId, LocalDate date, ScheduleStatus status);
 
     @Query("""
         SELECT COUNT(s) > 0 FROM Schedule s

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,8 +20,26 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
           AND s.startTime < :endTime
           AND s.endTime > :startTime
     """)
-    boolean existsConflictSchedule(@Param("userId") Long userId,
-                                   @Param("date") java.time.LocalDate date,
-                                   @Param("startTime") LocalDateTime startTime,
-                                   @Param("endTime") LocalDateTime endTime);
+    boolean existsConflictSchedule(
+            @Param("userId") Long userId,
+            @Param("date") java.time.LocalDate date,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime
+    );
+
+    @Query("""
+    SELECT COUNT(s) > 0 FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.date = :date
+      AND s.startTime = :startTime
+      AND s.endTime = :endTime
+      AND s.isDeleted = true
+""")
+    boolean existsDeletedRoutineInstance(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime
+    );
+
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -184,13 +184,14 @@ public class TeumController {
 
     @Operation(
             summary = "공통 가능한 시간대 조회",
-            description = "지정된 사용자들(memberIds)의 특정 날짜에 대해 공통으로 가능한 시간대를 반환합니다."
+            description = "지정된 사용자들(userIds)의 특정 날짜에 대해 공통으로 가능한 시간대를 반환합니다."
     )
     @PostMapping(value = "/availability", consumes = "application/json", produces = "application/json")
     public ApiResponse<AvailableTimeResponseDto> getAvailableTime(
             @RequestBody AvailableTimeRequestDto requestDto
     ) {
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.of(TeumSuccessStatus._AVAILABLE_TIME_LOADED,
+                teumService.getAvailableTime(requestDto));
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -186,7 +186,7 @@ public class TeumController {
             summary = "공통 가능한 시간대 조회",
             description = "지정된 사용자들(userIds)의 특정 날짜에 대해 공통으로 가능한 시간대를 반환합니다."
     )
-    @PostMapping(value = "/availability", consumes = "application/json", produces = "application/json")
+    @PostMapping(value = "/available-time", consumes = "application/json", produces = "application/json")
     public ApiResponse<AvailableTimeResponseDto> getAvailableTime(
             @RequestBody AvailableTimeRequestDto requestDto
     ) {

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -22,6 +22,9 @@ import umc.teumteum.server.global.util.S3Util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 
@@ -142,6 +145,64 @@ public class TeumConverter {
                 .teumCreated(isAccepted)
                 .teumId(teumId)
                 .build();
+    }
+
+    public static TimeSlot fromSchedule(Schedule schedule) {
+        return new TimeSlot(
+                schedule.getStartTime().toLocalTime().toString(),
+                schedule.getEndTime().toLocalTime().toString()
+        );
+    }
+
+    public static List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> scheduledSlots) {
+        if (scheduledSlots.isEmpty()) return Collections.emptyList();
+
+        List<TimeSlot> sorted = new ArrayList<>(scheduledSlots);
+        sorted.sort(Comparator.comparing(slot -> LocalTime.parse(slot.getStart())));
+
+        List<TimeSlot> merged = new ArrayList<>();
+        TimeSlot current = sorted.get(0);
+
+        for (int i = 1; i < sorted.size(); i++) {
+            TimeSlot next = sorted.get(i);
+            LocalTime currEnd = LocalTime.parse(current.getEnd());
+            LocalTime nextStart = LocalTime.parse(next.getStart());
+
+            if (!currEnd.isBefore(nextStart)) {
+                current = new TimeSlot(
+                        current.getStart(),
+                        LocalTime.parse(current.getEnd()).isAfter(LocalTime.parse(next.getEnd()))
+                                ? current.getEnd() : next.getEnd()
+                );
+            } else {
+                merged.add(current);
+                current = next;
+            }
+        }
+        merged.add(current);
+        return merged;
+    }
+
+    public static List<TimeSlot> invertScheduledToAvailable(List<TimeSlot> scheduledSlots) {
+        List<TimeSlot> available = new ArrayList<>();
+        LocalTime startOfDay = LocalTime.of(0, 0);
+        LocalTime endOfDay = LocalTime.of(23, 59);
+
+        for (TimeSlot scheduled : scheduledSlots) {
+            LocalTime scheduledStart = LocalTime.parse(scheduled.getStart());
+            LocalTime scheduledEnd = LocalTime.parse(scheduled.getEnd());
+
+            if (startOfDay.isBefore(scheduledStart)) {
+                available.add(new TimeSlot(startOfDay.toString(), scheduledStart.toString()));
+            }
+            startOfDay = scheduledEnd;
+        }
+
+        if (startOfDay.isBefore(endOfDay)) {
+            available.add(new TimeSlot(startOfDay.toString(), endOfDay.toString()));
+        }
+
+        return available;
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -9,6 +9,7 @@ import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumResendRequestDto;
+import umc.teumteum.server.domain.teum.dto.teum.TeumStatusUpdateResponseDto;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
@@ -134,5 +135,14 @@ public class TeumConverter {
                 .status(ScheduleStatus.ACTIVE)
                 .build();
     }
+
+    public static TeumStatusUpdateResponseDto toStatusUpdateResponseDto(ResponseStatus status, boolean isAccepted, Long teumId) {
+        return TeumStatusUpdateResponseDto.builder()
+                .status(status)
+                .teumCreated(isAccepted)
+                .teumId(teumId)
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/availability/AvailableTimeRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/availability/AvailableTimeRequestDto.java
@@ -11,8 +11,11 @@ import java.util.List;
 @Schema(title = "AvailableTimeRequestDto : 공통 가능 시간 요청 DTO")
 public class AvailableTimeRequestDto {
 
+    @Schema(description = "요청자 ID", example = "5")
+    private Long requesterId;
+
     @Schema(description = "참여자 ID 목록", example = "[1, 2, 3]")
-    private List<Long> memberIds;
+    private List<Long> userIds;
 
     @Schema(description = "날짜 (YYYY-MM-DD)", example = "YYYY-MM-DD")
     private String date;

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -192,12 +192,12 @@ public class TeumServiceImpl implements TeumService {
         List<TimeSlot> scheduledSlots = new ArrayList<>();
         DayOfWeek targetDay = date.getDayOfWeek();
 
-        for (Long memberId : requestDto.getUserIds()) {
-            User member = getUserOrThrow(memberId);
+        for (Long userId : requestDto.getUserIds()) {
+            User user = getUserOrThrow(userId);
 
             // 일반 일정
             List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatus(
-                    memberId, date, ScheduleStatus.ACTIVE
+                    userId, date, ScheduleStatus.ACTIVE
             );
             schedules.stream()
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
@@ -205,8 +205,8 @@ public class TeumServiceImpl implements TeumService {
                     .forEach(scheduledSlots::add);
 
             // 수면 시간
-            LocalTime sleep = member.getSleepTime();
-            LocalTime wake = member.getWakeTime();
+            LocalTime sleep = user.getSleepTime();
+            LocalTime wake = user.getWakeTime();
             if (sleep != null && wake != null) {
                 if (sleep.isBefore(wake)) {
                     scheduledSlots.add(new TimeSlot(sleep.toString(), wake.toString()));
@@ -217,13 +217,13 @@ public class TeumServiceImpl implements TeumService {
             }
 
             // 반복 일정
-            for (Routine routine : member.getRoutines()) {
+            for (Routine routine : user.getRoutines()) {
                 if (routine.getWeekday().matches(targetDay)) {
                     LocalDateTime routineStart = LocalDateTime.of(date, routine.getStartTime());
                     LocalDateTime routineEnd = LocalDateTime.of(date, routine.getEndTime());
 
                     boolean isRoutineDeleted = scheduleRepository.existsDeletedRoutineInstance(
-                            memberId, date, routineStart, routineEnd);
+                            userId, date, routineStart, routineEnd);
 
                     if (!isRoutineDeleted) {
                         scheduledSlots.add(new TimeSlot(

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -157,11 +157,8 @@ public class TeumServiceImpl implements TeumService {
             teumId = schedule.getId();
         }
 
-        return TeumStatusUpdateResponseDto.builder()
-                .status(newStatus)
-                .teumCreated(isAccepted)
-                .teumId(teumId)
-                .build();
+        return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
+
     }
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -12,6 +12,7 @@ import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.teum.converter.TeumConverter;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeResponseDto;
+import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumExitResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
@@ -24,14 +25,17 @@ import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
 import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
@@ -66,12 +70,6 @@ public class TeumServiceImpl implements TeumService {
         return request.getId();
     }
 
-
-    private User getUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
-    }
-
     @Override
     @Transactional
     public Long createResendRequest(Long parentRequestId, TeumResendRequestDto dto) {
@@ -83,16 +81,13 @@ public class TeumServiceImpl implements TeumService {
 
         User resender = getUserOrThrow(dto.getSenderUserId());
 
-        // 새로운 요청/응답 생성
         TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, resender);
         TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, parent.getUser());
         newRequest.getTeumResponses().add(newResponse);
 
-        // 원래 요청의 응답 상태를 RESEND로 변경
         TeumResponse originalResponse = parent.getTeumResponses().getFirst();
-        originalResponse.changeStatus(ResponseStatus.RESEND); // enum도 RESEND로 이름 바꿔주세요
+        originalResponse.changeStatus(ResponseStatus.RESEND);
 
-        // 저장
         teumRequestRepository.save(newRequest);
 
         return newRequest.getId();
@@ -187,14 +182,71 @@ public class TeumServiceImpl implements TeumService {
 
     @Override
     public AvailableTimeResponseDto getAvailableTime(AvailableTimeRequestDto requestDto) {
-        // TODO: 시간표 계산 로직 추후 구현
-        return null;
+        Long requesterId = requestDto.getRequesterId();
+        if (!requestDto.getUserIds().contains(requesterId)) {
+            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
+
+        LocalDate date = LocalDate.parse(requestDto.getDate());
+        List<TimeSlot> scheduledSlots = new ArrayList<>();
+        DayOfWeek targetDay = date.getDayOfWeek();
+
+        for (Long memberId : requestDto.getUserIds()) {
+            User member = getUserOrThrow(memberId);
+
+            // 일반 일정
+            List<Schedule> schedules = scheduleRepository.findByUserIdAndIncludeTeumIsTrue(memberId);
+            schedules.stream()
+                    .filter(schedule -> schedule.getDate().isEqual(date) && !Boolean.TRUE.equals(schedule.getIsDeleted()))
+                    .map(TeumConverter::fromSchedule)
+                    .forEach(scheduledSlots::add);
+
+            // 수면 시간
+            LocalTime sleep = member.getSleepTime();
+            LocalTime wake = member.getWakeTime();
+            if (sleep != null && wake != null) {
+                if (sleep.isBefore(wake)) {
+                    scheduledSlots.add(new TimeSlot(sleep.toString(), wake.toString()));
+                } else {
+                    scheduledSlots.add(new TimeSlot(sleep.toString(), "23:59"));
+                    scheduledSlots.add(new TimeSlot("00:00", wake.toString()));
+                }
+            }
+
+            // 반복 일정
+            for (Routine routine : member.getRoutines()) {
+                if (routine.getWeekday().matches(targetDay)) {
+                    LocalDateTime routineStart = LocalDateTime.of(date, routine.getStartTime());
+                    LocalDateTime routineEnd = LocalDateTime.of(date, routine.getEndTime());
+
+                    boolean isRoutineDeleted = scheduleRepository.existsDeletedRoutineInstance(
+                            memberId, date, routineStart, routineEnd);
+
+                    if (!isRoutineDeleted) {
+                        scheduledSlots.add(new TimeSlot(
+                                routine.getStartTime().toString(),
+                                routine.getEndTime().toString()
+                        ));
+                    }
+                }
+            }
+        }
+
+        List<TimeSlot> merged = TeumConverter.mergeScheduledTimeSlots(scheduledSlots);
+        List<TimeSlot> available = TeumConverter.invertScheduledToAvailable(merged);
+
+        return new AvailableTimeResponseDto(date.toString(), available);
     }
 
     @Override
     public SharedTeumResponseDto getSharedTeumStats(Long userId, Long friendId) {
         // TODO : 함께한 틈 시간 조회 로직 추후 구현
         return null;
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
     }
 
     private TeumResponse getResponseOrThrow(Long responseId) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.teum.converter.TeumConverter;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
@@ -195,9 +196,11 @@ public class TeumServiceImpl implements TeumService {
             User member = getUserOrThrow(memberId);
 
             // 일반 일정
-            List<Schedule> schedules = scheduleRepository.findByUserIdAndIncludeTeumIsTrue(memberId);
+            List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatus(
+                    memberId, date, ScheduleStatus.ACTIVE
+            );
             schedules.stream()
-                    .filter(schedule -> schedule.getDate().isEqual(date) && !Boolean.TRUE.equals(schedule.getIsDeleted()))
+                    .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
                     .map(TeumConverter::fromSchedule)
                     .forEach(scheduledSlots::add);
 

--- a/src/main/java/umc/teumteum/server/domain/user/entity/enums/Weekday.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/enums/Weekday.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.domain.user.entity.enums;
 
+import java.time.DayOfWeek;
+
 public enum Weekday {
     MONDAY,    // 월요일
     TUESDAY,   // 화요일
@@ -9,4 +11,8 @@ public enum Weekday {
     SATURDAY,  // 토요일
     SUNDAY     // 일요일
     ;
+
+    public boolean matches(DayOfWeek dayOfWeek) {
+        return this.name().equalsIgnoreCase(dayOfWeek.name());
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#54 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `Schedule` 엔티티에 `isDeleted`, `routine` 연관관계 필드 추가
- `TeumServiceImpl`에 수면 시간, 루틴, 삭제된 루틴까지 고려한 공통 시간 계산 로직 구현
- `ScheduleRepository`에 삭제된 루틴 인스턴스 조회 쿼리 추가
- TimeSlot 변환 및 병합, 반전 로직를 `Converter`로 분리

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 공통된 시간 계산 로직이 올바른지
- 루틴 삭제 예외 처리 방식이 `Schedule`을 기준으로 잘 작동하는지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 특정 날짜의 반복 일정을 삭제하는 경우에는 스케줄 테이블에 넣고 `is_deleted`를 `true`로 설정해두기로 했기 때문에 `Schedule` 엔티티에 `isDeleted`, `routine` 필드를 추가하였습니다

- 테스트용 DDL은 API 명세서 내에 함께 정리해두었습니다 (https://excessive-pedestrian-954.notion.site/22566802aaae8045a56ecb2b8ca6bc8e)

### 📷 테스트 결과

#### 1, 2, 3 공통 시간대
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-07-23",
    "availableTime": [
      {
        "start": "09:00",
        "end": "09:30"
      },
      {
        "start": "12:00",
        "end": "13:00"
      },
      {
        "start": "17:00",
        "end": "23:00"
      }
    ]
  }
}
```

#### 1, 2 공통 시간대
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-07-23",
    "availableTime": [
      {
        "start": "08:00",
        "end": "09:30"
      },
      {
        "start": "11:00",
        "end": "13:00"
      },
      {
        "start": "15:00",
        "end": "23:00"
      }
    ]
  }
}
```

#### 2, 3 공통 시간대
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-07-23",
    "availableTime": [
      {
        "start": "09:00",
        "end": "09:30"
      },
      {
        "start": "10:30",
        "end": "11:00"
      },
      {
        "start": "12:00",
        "end": "13:00"
      },
      {
        "start": "14:00",
        "end": "15:00"
      },
      {
        "start": "17:00",
        "end": "23:59"
      }
    ]
  }
}
```

#### 반복 일정 삭제 (2번 유저, 7월 23일)
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-07-23",
    "availableTime": [
      {
        "start": "08:00",
        "end": "09:30"
      },
      {
        "start": "10:30",
        "end": "13:00"
      },
      {
        "start": "14:00",
        "end": "23:59"
      }
    ]
  }
}
```
#### 반복 일정 유지 (2번 유저, 7월 30일)
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-07-30",
    "availableTime": [
      {
        "start": "08:00",
        "end": "08:30"
      },
      {
        "start": "09:30",
        "end": "23:59"
      }
    ]
  }
}
```