### PR TITLE
Feat: 위시 관련 기능 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
@@ -49,8 +49,10 @@ public class WishController {
     @PatchMapping(value = "/{wishId}", consumes = "application/json", produces = "application/json")
     @Operation(summary = "특정 위시 정보 수정 API",description = "특정위시의 상세정보를 수정하는 API입니다.")
     public ApiResponse<String> updateWish(
-            @Parameter(name= "wishId", description = "수정할 위시 ID", example = "123") @PathVariable("wishId") Long wishId){
-        return ApiResponse.onSuccess(null);
+            @Parameter(name= "wishId", description = "수정할 위시 ID", example = "123") @PathVariable("wishId") Long wishId,
+            @RequestBody @Valid WishRequestDTO request){
+        homeService.updateWishInfo(request, wishId);
+        return ApiResponse.of(HomeSuccessStatus._WISH_UPDATED, null);
     }
 
     @GetMapping(value = "/categories", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.home.dto.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.WishInfoResponseDTO;
 import umc.teumteum.server.domain.home.dto.WishRequestDTO;
 import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
@@ -60,8 +61,11 @@ public class WishController {
 
     @DeleteMapping(value = "", consumes = "application/json")
     @Operation(summary = "위시 삭제 API",description = "위시를 삭제하는 API입니다.")
-    public ApiResponse<String> deleteWish(){
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<String> deleteWish(
+            @RequestBody @Valid WishDeleteRequestDTO request
+    ){
+        homeService.deleteWishByIds(request);
+        return ApiResponse.of(HomeSuccessStatus._WISH_DELETED, null);
     }
 
     @GetMapping(value = "/teum", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.home.dto.WishInfoResponseDTO;
 import umc.teumteum.server.domain.home.dto.WishRequestDTO;
 import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
 import umc.teumteum.server.domain.home.service.HomeService;
@@ -38,9 +39,10 @@ public class WishController {
 
     @GetMapping(value = "/{wishId}", produces = "application/json")
     @Operation(summary = "특정 위시 정보 조회 API",description = "특정위시의 상세정보를 조회하는 API입니다.")
-    public ApiResponse<String> getWish(
+    public ApiResponse<WishInfoResponseDTO> getWish(
             @Parameter(name= "wishId", description = "조회할 위시 ID", example = "123") @PathVariable("wishId") Long wishId){
-        return ApiResponse.onSuccess(null);
+        WishInfoResponseDTO response = homeService.getWishInfo(wishId);
+        return ApiResponse.of(HomeSuccessStatus._WISH_LOADED,response);
     }
 
     @PatchMapping(value = "/{wishId}", consumes = "application/json", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
@@ -3,8 +3,12 @@ package umc.teumteum.server.domain.home.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.home.dto.WishRequestDTO;
+import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
+import umc.teumteum.server.domain.home.service.HomeService;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 @RestController
@@ -12,6 +16,8 @@ import umc.teumteum.server.global.apiPayload.ApiResponse;
 @RequestMapping("/api/wishes")
 @Tag(name = "wish", description = "위시 관련 API")
 public class WishController {
+
+    private final HomeService homeService;
 
     @GetMapping(value = "/wishlist", produces = "application/json")
     @Operation(summary = "위시리스트 정보 조회 API",description = "위시 목록을 조회하는 API입니다. query string으로 조회 기간과 page 번호를 입력주세요.")
@@ -23,8 +29,11 @@ public class WishController {
 
     @PostMapping(value = "", consumes = "application/json", produces = "application/json")
     @Operation(summary = "위시 등록 API",description = "새로운 위시를 생성하는 API입니다.")
-    public ApiResponse<String> createWish(){
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<String> createWish(
+            @RequestBody @Valid WishRequestDTO request
+            ){
+        homeService.createWish(request);
+        return ApiResponse.of(HomeSuccessStatus._WISH_CREATED, null);
     }
 
     @GetMapping(value = "/{wishId}", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.converter;
 
 import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.dto.WishInfoResponseDTO;
 import umc.teumteum.server.domain.home.dto.WishRequestDTO;
 import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Wish;
@@ -30,5 +31,23 @@ public class WishConverter {
                         .category(category)
                         .build())
                 .toList();
+    }
+
+    // Wish -> WishInfoResponseDTO
+    public WishInfoResponseDTO toWishInfoDTO(Wish wish) {
+        // WishCategory에서 Category 정보를 추출
+        List<WishInfoResponseDTO.CategoryDTO> categoryDTOS = wish.getWishCategories().stream()
+                .map(wc -> WishInfoResponseDTO.CategoryDTO.builder()
+                        .id(wc.getCategory().getId())
+                        .name(wc.getCategory().getName())
+                        .build())
+                .toList();
+
+        return WishInfoResponseDTO.builder()
+                .title(wish.getTitle())
+                .content(wish.getContent())
+                .estimatedDuration(wish.getEstimatedDuration())
+                .categories(categoryDTOS)
+                .build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
@@ -1,4 +1,34 @@
 package umc.teumteum.server.domain.home.converter;
 
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.dto.WishRequestDTO;
+import umc.teumteum.server.domain.home.entity.Category;
+import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
+import umc.teumteum.server.domain.user.entity.User;
+
+import java.util.List;
+
+@Component
 public class WishConverter {
+
+    // WishRequestDTO -> Wish
+    public Wish toWish(WishRequestDTO dto, User user) {
+        return Wish.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .estimatedDuration(dto.getEstimatedDuration())
+                .user(user)
+                .build();
+    }
+
+    // List<WishCategory> -> WishCategory
+    public List<WishCategory> toWishCategories(Wish wish, List<Category> categories) {
+        return categories.stream()
+                .map(category -> WishCategory.builder()
+                        .wish(wish)
+                        .category(category)
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/WishDeleteRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/WishDeleteRequestDTO.java
@@ -1,0 +1,20 @@
+package umc.teumteum.server.domain.home.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "WishDeleteRequestDTO : 위시 삭제 요청 DTO")
+public class WishDeleteRequestDTO {
+
+    @NotEmpty
+    @NotNull
+    @Schema(description = "위시 ID 리스트", example = "[1,2,3]")
+    private List<Long> wishIds;
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/WishInfoResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/WishInfoResponseDTO.java
@@ -1,0 +1,35 @@
+package umc.teumteum.server.domain.home.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(title = "WishInfoResponseDTO : 위시 정보 조회 응답 DTO")
+public class WishInfoResponseDTO {
+    @Schema(description = "위시 제목", example = "string")
+    private String title;
+
+    @Schema(description = "상세 설명", example = "string")
+    private String content;
+
+    @Schema(description = "예상 소요 시간", example = "10m")
+    private EstimatedDuration estimatedDuration;
+
+    @Schema(description = "위시 카테고리", example = "[{ id: 1, name: '자기계발' }]")
+    private List<CategoryDTO> categories;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CategoryDTO {
+        private Long id;
+        private String name;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
@@ -23,7 +23,7 @@ public class WishRequestDTO {
     private String content;
 
     @NotNull
-    @Schema(description = "예상 소요 시간", example = "MINUTES_10")
+    @Schema(description = "예상 소요 시간", example = "10m")
     private EstimatedDuration estimatedDuration;
 
     @NotEmpty

--- a/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
@@ -1,0 +1,36 @@
+package umc.teumteum.server.domain.home.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "WishRequestDTO : 위시 등록 DTO")
+public class WishRequestDTO {
+
+    @NotBlank
+    @Schema(description = "위시 제목", example = "string")
+    private String title;
+
+    @Schema(description = "상세 설명", example = "string")
+    private String content;
+
+    @NotNull
+    @Schema(description = "예상 소요 시간", example = "MINUTES_10")
+    private EstimatedDuration estimatedDuration;
+
+    @NotEmpty
+    @NotNull
+    @Schema(description = "위시 카테고리", example = "[1]")
+    private List<Long> categories;
+
+    @Schema(description = "회원 ID", example = "1")
+    private Long userId;
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/WishRequestDTO.java
@@ -27,10 +27,10 @@ public class WishRequestDTO {
     private EstimatedDuration estimatedDuration;
 
     @NotEmpty
-    @NotNull
     @Schema(description = "위시 카테고리", example = "[1]")
     private List<Long> categories;
 
+    @NotNull
     @Schema(description = "회원 ID", example = "1")
     private Long userId;
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
@@ -42,7 +42,7 @@ public class Wish extends BaseEntity {
     /*
         양방향 연관관계
     */
-    @OneToMany(mappedBy = "wish", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "wish", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WishCategory> wishCategories;
 
     public void setWishCategories(List<WishCategory> wishCategories) {

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
@@ -51,4 +51,10 @@ public class Wish extends BaseEntity {
             wishCategory.setWish(this);
         }
     }
+
+    public void update(String title, String content, EstimatedDuration duration) {
+        this.title = title;
+        this.content = content;
+        this.estimatedDuration = duration;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Wish.java
@@ -44,4 +44,11 @@ public class Wish extends BaseEntity {
     */
     @OneToMany(mappedBy = "wish", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<WishCategory> wishCategories;
+
+    public void setWishCategories(List<WishCategory> wishCategories) {
+        this.wishCategories = wishCategories;
+        for (WishCategory wishCategory : wishCategories) {
+            wishCategory.setWish(this);
+        }
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/enums/EstimatedDuration.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/enums/EstimatedDuration.java
@@ -1,5 +1,8 @@
 package umc.teumteum.server.domain.home.entity.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum EstimatedDuration {
     MINUTES_10("10m"),    // 10분
     MINUTES_20("20m"),    // 20분
@@ -12,7 +15,19 @@ public enum EstimatedDuration {
         this.displayName = displayName;
     }
 
+    @JsonValue
     public String getDisplayName() {
         return displayName;
     }
+
+    @JsonCreator
+    public static EstimatedDuration from(String value) {
+        for (EstimatedDuration estimatedDuration : values()) {
+            if (estimatedDuration.displayName.equals(value)) {
+                return estimatedDuration;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/mapping/WishCategory.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/mapping/WishCategory.java
@@ -28,4 +28,8 @@ public class WishCategory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public void setWish(Wish wish) {
+        this.wish = wish;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -12,6 +12,7 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "HOME4001", "endTime은 startTime을 앞설 수 없습니다."),
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
+    _WISH_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4043","해당 위시 정보를 찾을 수 없습니다."),
     _WISH_CONFLICT(HttpStatus.CONFLICT, "HOME4091","이미 동일한 위시가 존재합니다.")
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -10,7 +10,10 @@ import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
 @AllArgsConstructor
 public enum HomeErrorStatus implements BaseErrorCode {
     _INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "HOME4001", "endTime은 startTime을 앞설 수 없습니다."),
-    _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다.");
+    _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
+    _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
+    _WISH_CONFLICT(HttpStatus.CONFLICT, "HOME4091","이미 동일한 위시가 존재합니다.")
+    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -14,7 +14,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODO_UPDATED(HttpStatus.OK, "HOME2002", "투두 정보가 성공적으로 수정되었습니다."),
     _TODO_LOADED(HttpStatus.OK, "HOME2003", "투두 정보가 성공적으로 조회되었습니다."),
     _TODO_DELETED(HttpStatus.OK, "HOME2004", "투두가 성공적으로 삭제되었습니다."),
-    _WISH_CREATED(HttpStatus.OK, "HOME2005","위시가 성공적으로 생성되었습니다.");
+    _WISH_CREATED(HttpStatus.OK, "HOME2005","위시가 성공적으로 생성되었습니다."),
+    _WISH_LOADED(HttpStatus.OK, "HOME2006","위시 정보가 성공적으로 조회되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -16,7 +16,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODO_DELETED(HttpStatus.OK, "HOME2004", "투두가 성공적으로 삭제되었습니다."),
     _WISH_CREATED(HttpStatus.OK, "HOME2005","위시가 성공적으로 생성되었습니다."),
     _WISH_LOADED(HttpStatus.OK, "HOME2006","위시 정보가 성공적으로 조회되었습니다."),
-    _WISH_DELETED(HttpStatus.OK, "HOME2007","위시가 성공적으로 삭제되었습니다.");
+    _WISH_DELETED(HttpStatus.OK, "HOME2007","위시가 성공적으로 삭제되었습니다."),
+    _WISH_UPDATED(HttpStatus.OK, "HOME2008", "위시 정보가 성공적으로 수정되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -13,7 +13,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODO_CREATED(HttpStatus.OK, "HOME2001", "투두가 성공적으로 생성되었습니다."),
     _TODO_UPDATED(HttpStatus.OK, "HOME2002", "투두 정보가 성공적으로 수정되었습니다."),
     _TODO_LOADED(HttpStatus.OK, "HOME2003", "투두 정보가 성공적으로 조회되었습니다."),
-    _TODO_DELETED(HttpStatus.OK, "HOME2004", "투두가 성공적으로 삭제되었습니다.");
+    _TODO_DELETED(HttpStatus.OK, "HOME2004", "투두가 성공적으로 삭제되었습니다."),
+    _WISH_CREATED(HttpStatus.OK, "HOME2005","위시가 성공적으로 생성되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -15,7 +15,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODO_LOADED(HttpStatus.OK, "HOME2003", "투두 정보가 성공적으로 조회되었습니다."),
     _TODO_DELETED(HttpStatus.OK, "HOME2004", "투두가 성공적으로 삭제되었습니다."),
     _WISH_CREATED(HttpStatus.OK, "HOME2005","위시가 성공적으로 생성되었습니다."),
-    _WISH_LOADED(HttpStatus.OK, "HOME2006","위시 정보가 성공적으로 조회되었습니다.");
+    _WISH_LOADED(HttpStatus.OK, "HOME2006","위시 정보가 성공적으로 조회되었습니다."),
+    _WISH_DELETED(HttpStatus.OK, "HOME2007","위시가 성공적으로 삭제되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/repository/CategoryRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/CategoryRepository.java
@@ -1,4 +1,7 @@
 package umc.teumteum.server.domain.home.repository;
 
-public interface CategoryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.home.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -5,6 +5,14 @@ import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.user.entity.User;
 
+import java.util.List;
+
 public interface WishRepository extends JpaRepository<Wish, Long> {
     boolean existsByUserAndTitleAndContentAndEstimatedDuration(User user, String title, String content, EstimatedDuration estimatedDuration);
+    List<Wish> findByUserAndTitleAndContentAndEstimatedDuration(
+            User user,
+            String title,
+            String content,
+            EstimatedDuration estimatedDuration
+    );
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -1,4 +1,10 @@
 package umc.teumteum.server.domain.home.repository;
 
-public interface WishRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+import umc.teumteum.server.domain.user.entity.User;
+
+public interface WishRepository extends JpaRepository<Wish, Long> {
+    boolean existsByUserAndTitleAndEstimatedDuration(User user, String title, EstimatedDuration estimatedDuration);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -6,5 +6,5 @@ import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
-    boolean existsByUserAndTitleAndEstimatedDuration(User user, String title, EstimatedDuration estimatedDuration);
+    boolean existsByUserAndTitleAndContentAndEstimatedDuration(User user, String title, String content, EstimatedDuration estimatedDuration);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -1,9 +1,6 @@
 package umc.teumteum.server.domain.home.service;
 
-import umc.teumteum.server.domain.home.dto.TodoRequestDTO;
-import umc.teumteum.server.domain.home.dto.TodoIdResponseDTO;
-import umc.teumteum.server.domain.home.dto.TodoInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.WishRequestDTO;
+import umc.teumteum.server.domain.home.dto.*;
 
 public interface HomeService {
     // Todo 등록
@@ -20,4 +17,7 @@ public interface HomeService {
 
     // Wish 등록
     void createWish(WishRequestDTO dto);
+
+    // Wish 조회
+    WishInfoResponseDTO getWishInfo(Long wishId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -23,4 +23,7 @@ public interface HomeService {
 
     // Wish 삭제
     void deleteWishByIds(WishDeleteRequestDTO dto);
+
+    // Wish 수정
+    void updateWishInfo(WishRequestDTO dto, Long wishId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.home.service;
 import umc.teumteum.server.domain.home.dto.TodoRequestDTO;
 import umc.teumteum.server.domain.home.dto.TodoIdResponseDTO;
 import umc.teumteum.server.domain.home.dto.TodoInfoResponseDTO;
+import umc.teumteum.server.domain.home.dto.WishRequestDTO;
 
 public interface HomeService {
     // Todo 등록
@@ -16,4 +17,7 @@ public interface HomeService {
 
     // Todo(Schedule) 삭제
     void deleteTodo(Long scheduleId);
+
+    // Wish 등록
+    void createWish(WishRequestDTO dto);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -20,4 +20,7 @@ public interface HomeService {
 
     // Wish 조회
     WishInfoResponseDTO getWishInfo(Long wishId);
+
+    // Wish 삭제
+    void deleteWishByIds(WishDeleteRequestDTO dto);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -14,10 +14,7 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.exception.HomeException;
-import umc.teumteum.server.domain.home.repository.CategoryRepository;
-import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
-import umc.teumteum.server.domain.home.repository.ScheduleRepository;
-import umc.teumteum.server.domain.home.repository.WishRepository;
+import umc.teumteum.server.domain.home.repository.*;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
@@ -28,9 +25,8 @@ import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -154,10 +150,10 @@ public class HomeServiceImpl implements HomeService {
     @Override
     public void createWish(WishRequestDTO dto) {
         // Wish 등록
-        User user = userRepository.getReferenceById(dto.getUserId());
+        User user = userRepository.getReferenceById(dto.getUserId()); // 시큐리티 적용후 변경 예정
 
         // 동일한 wish가 이미 존재하는지 확인
-        boolean isDuplicate = wishRepository.existsByUserAndTitleAndEstimatedDuration(user, dto.getTitle(), dto.getEstimatedDuration());
+        boolean isDuplicate = wishRepository.existsByUserAndTitleAndContentAndEstimatedDuration(user, dto.getTitle(),dto.getContent(), dto.getEstimatedDuration());
         if (isDuplicate) {
             throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
         }
@@ -197,6 +193,62 @@ public class HomeServiceImpl implements HomeService {
 
         // 삭제
         wishRepository.deleteAll(wishes);
+    }
 
+    @Transactional
+    @Override
+    public void updateWishInfo(WishRequestDTO dto, Long wishId) {
+        // Wish 수정
+        User user = userRepository.getReferenceById(dto.getUserId()); // 시큐리티 적용후 변경 예정
+
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new HomeException(HomeErrorStatus._WISH_NOT_FOUND));
+
+        // 카테고리 ID 유효성 검사
+        List<Category> categories = categoryRepository.findAllById(dto.getCategories());
+        if(categories.size () != dto.getCategories().size()){
+            throw new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND);
+        }
+
+        // 동일한 wish가 이미 존재하는지 확인
+        if (isDuplicateWish(user, dto, wishId)) {
+            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
+        }
+
+        wish.getWishCategories().clear(); // 기존 wish category 정보 제거
+        // 새로운 WishCategory 저장 & Wish 필드 업데이트
+        List<WishCategory> wishCategories = wishConverter.toWishCategories(wish, categories);
+        wish.getWishCategories().addAll(wishCategories);
+        wish.update(
+                dto.getTitle(),
+                dto.getContent(),
+                dto.getEstimatedDuration()
+        );
+
+    }
+
+    private boolean isDuplicateWish(User user, WishRequestDTO dto, Long currentWishId) {
+        // 위시 수정 - 중복 검사
+        // user, title, content, duration이 같은 wish
+        List<Wish> candidates = wishRepository.findByUserAndTitleAndContentAndEstimatedDuration(
+                user, dto.getTitle(), dto.getContent(), dto.getEstimatedDuration()
+        );
+
+        for (Wish candidate : candidates) {
+            // 현재 wish id(자기자신) 제외
+            if (candidate.getId().equals(currentWishId)) continue;
+
+            // 카테고리 ID 목록 비교
+            Set<Long> dtoCategoryIds = new HashSet<>(dto.getCategories());
+
+            Set<Long> candidateCategoryIds = candidate.getWishCategories().stream()
+                    .map(wc -> wc.getCategory().getId())
+                    .collect(Collectors.toSet());
+
+            if (dtoCategoryIds.equals(candidateCategoryIds)) {
+                return true;
+            } // 카테고리까지 동일하다면 중복
+        }
+        return false;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -182,4 +182,21 @@ public class HomeServiceImpl implements HomeService {
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._WISH_NOT_FOUND));
         return wishConverter.toWishInfoDTO(wish);
     }
+
+    @Transactional
+    @Override
+    public void deleteWishByIds(WishDeleteRequestDTO dto) {
+        // Wish 삭제
+        List<Long> ids = dto.getWishIds();
+        List<Wish> wishes = wishRepository.findAllById(ids);
+
+        // 존재하지 않는 ID가 있는 경우 예외 처리
+        if (wishes.size() != ids.size()) {
+            throw new HomeException(HomeErrorStatus._WISH_NOT_FOUND);
+        }
+
+        // 삭제
+        wishRepository.deleteAll(wishes);
+
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -152,16 +152,15 @@ public class HomeServiceImpl implements HomeService {
         // Wish 등록
         User user = userRepository.getReferenceById(dto.getUserId()); // 시큐리티 적용후 변경 예정
 
-        // 동일한 wish가 이미 존재하는지 확인
-        boolean isDuplicate = wishRepository.existsByUserAndTitleAndContentAndEstimatedDuration(user, dto.getTitle(),dto.getContent(), dto.getEstimatedDuration());
-        if (isDuplicate) {
-            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
-        }
-
         // 카테고리 ID 유효성 검사
         List<Category> categories = categoryRepository.findAllById(dto.getCategories());
         if(categories.size () != dto.getCategories().size()){
             throw new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND);
+        }
+
+        // 동일한 wish가 이미 존재하는지 확인
+        if (isDuplicateWish(user, dto, null)) {
+            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
         }
 
         // Wish & Wish Category 저장
@@ -228,7 +227,7 @@ public class HomeServiceImpl implements HomeService {
     }
 
     private boolean isDuplicateWish(User user, WishRequestDTO dto, Long currentWishId) {
-        // 위시 수정 - 중복 검사
+        // 중복 검사
         // user, title, content, duration이 같은 wish
         List<Wish> candidates = wishRepository.findByUserAndTitleAndContentAndEstimatedDuration(
                 user, dto.getTitle(), dto.getContent(), dto.getEstimatedDuration()
@@ -236,7 +235,7 @@ public class HomeServiceImpl implements HomeService {
 
         for (Wish candidate : candidates) {
             // 현재 wish id(자기자신) 제외
-            if (candidate.getId().equals(currentWishId)) continue;
+            if (currentWishId != null && currentWishId.equals(candidate.getId())) continue;
 
             // 카테고리 ID 목록 비교
             Set<Long> dtoCategoryIds = new HashSet<>(dto.getCategories());

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -4,16 +4,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.converter.ScheduleConverter;
+import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.TodoRequestDTO;
 import umc.teumteum.server.domain.home.dto.TodoIdResponseDTO;
 import umc.teumteum.server.domain.home.dto.TodoInfoResponseDTO;
+import umc.teumteum.server.domain.home.dto.WishRequestDTO;
+import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
+import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.exception.HomeException;
+import umc.teumteum.server.domain.home.repository.CategoryRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
@@ -33,10 +40,13 @@ import java.util.Objects;
 public class HomeServiceImpl implements HomeService {
 
     private final ScheduleConverter scheduleConverter;
+    private final WishConverter wishConverter;
     private final ScheduleRepository scheduleRepository;
     private final ScheduleReminderRepository scheduleReminderRepository;
     private final TeumRequestRepository teumRequestRepository;
     private final UserRepository userRepository;
+    private final WishRepository wishRepository;
+    private final CategoryRepository categoryRepository;
     private final S3Util s3Util;
 
     @Transactional
@@ -141,5 +151,30 @@ public class HomeServiceImpl implements HomeService {
 
         scheduleRepository.deleteById(scheduleId);
         scheduleReminderRepository.deleteByScheduleId(scheduleId);
+    }
+
+    @Transactional
+    @Override
+    public void createWish(WishRequestDTO dto) {
+        // Wish 등록
+        User user = userRepository.getReferenceById(dto.getUserId());
+
+        // 동일한 wish가 이미 존재하는지 확인
+        boolean isDuplicate = wishRepository.existsByUserAndTitleAndEstimatedDuration(user, dto.getTitle(), dto.getEstimatedDuration());
+        if (isDuplicate) {
+            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
+        }
+
+        // 카테고리 ID 유효성 검사
+        List<Category> categories = categoryRepository.findAllById(dto.getCategories());
+        if(categories.size () != dto.getCategories().size()){
+            throw new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND);
+        }
+
+        // Wish & Wish Category 저장
+        Wish wish = wishConverter.toWish(dto,user);
+        List<WishCategory> wishCategories = wishConverter.toWishCategories(wish,categories);
+        wish.setWishCategories(wishCategories);
+        wishRepository.save(wish);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -5,10 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.converter.ScheduleConverter;
 import umc.teumteum.server.domain.home.converter.WishConverter;
-import umc.teumteum.server.domain.home.dto.TodoRequestDTO;
-import umc.teumteum.server.domain.home.dto.TodoIdResponseDTO;
-import umc.teumteum.server.domain.home.dto.TodoInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.WishRequestDTO;
+import umc.teumteum.server.domain.home.dto.*;
 import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
@@ -176,5 +173,13 @@ public class HomeServiceImpl implements HomeService {
         List<WishCategory> wishCategories = wishConverter.toWishCategories(wish,categories);
         wish.setWishCategories(wishCategories);
         wishRepository.save(wish);
+    }
+
+    @Override
+    public WishInfoResponseDTO getWishInfo(Long wishId) {
+        // Wish 조회
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new HomeException(HomeErrorStatus._WISH_NOT_FOUND));
+        return wishConverter.toWishInfoDTO(wish);
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#49 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 위시 생성, 조회, 수정, 삭제 로직 구현했습니다.
- 위시를 등록할 때 제목, 내용, 카테고리, 예상 시간이 모두 동일하다면 이미 존재하는 위시로 판단하고 등록이 안되도록 했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- POST `/api/wishes`
     - https://excessive-pedestrian-954.notion.site/22966802aaae8075b82cc68c526b2361
- GET `/api/wishes/{wishId}`
     - https://excessive-pedestrian-954.notion.site/22966802aaae80d79e9dffce78b22747
- PATCH `/api/wishes/{wishId}`
     - https://excessive-pedestrian-954.notion.site/22966802aaae8087954ac64060ed38f0?pvs=74
- DELETE `/api/wishes`
     - https://excessive-pedestrian-954.notion.site/22966802aaae8033bee0d6c7677cd4a9?pvs=74


### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 위시의 카테고리 정보가 없어서 DDL로 입력해주셔야합니다.
```sql
INSERT INTO category (created_at, updated_at, name)
VALUES (now(), now(),'자기계발'),
       (now(), now(),'운동'),
       (now(), now(),'취미'),
       (now(), now(),'문화생활'),
       (now(), now(),'일상'),
       (now(), now(),'휴식');
```
- 노션에 Error Status 첨부해뒀습니다. 

### 📷 스크린샷 또는 GIF
X