### PR TITLE
Feat: 개발용 액세스 토큰 발급 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
@@ -52,6 +53,19 @@ public class AuthController {
     ) {
         // TODO: 토큰 재발급 로직 구현
         return null;
+    }
+
+
+    @Profile("dev")
+    @Operation(
+            summary = "개발용 액세스 토큰 발급",
+            description = "개발 진행 과정에서의 테스트를 위한 액세스 토큰을 발급합니다."
+    )
+    @PostMapping(value = "/dev-token", produces = "application/json")
+    public ApiResponse<AuthResponseDTO.DevTokenResponse> generateDevAccessToken() {
+        AuthResponseDTO.DevTokenResponse response = authService.generateDevAccessToken();
+
+        return ApiResponse.of(AuthSuccessStatus.DEV_TOKEN_ISSUED, response);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -11,6 +11,8 @@ import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 import umc.teumteum.server.domain.auth.exception.status.AuthSuccessStatus;
 import umc.teumteum.server.domain.auth.service.AuthService;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -55,8 +57,8 @@ public class AuthController {
 
 //    @GetMapping(value = "/test/jwt", produces = "application/json")
 //    public ApiResponse<Long> getUser(
-//            @CurrentUser @Parameter(hidden = true) Long userId
+//            @CurrentUser @Parameter(hidden = true) User user
 //    ) {
-//        return ApiResponse.onSuccess(userId);
+//        return ApiResponse.onSuccess(user.getId());
 //    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
@@ -23,4 +23,11 @@ public class AuthConverter {
                 .build()
                 ;
     }
+
+    public static AuthResponseDTO.DevTokenResponse toDevTokenResponse(String accessToken) {
+        return AuthResponseDTO.DevTokenResponse.builder()
+                .accessToken(accessToken)
+                .build()
+                ;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
@@ -16,4 +16,12 @@ public class AuthResponseDTO {
         private String refreshToken;    // 리프레시토큰
         private String nextStep;        // 다음 화면 단계
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DevTokenResponse {
+        private String accessToken;     // 액세스토큰
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
@@ -11,6 +11,7 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 public enum AuthSuccessStatus implements BaseCode {
 
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 성공적으로 완료되었습니다."),
+    DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
@@ -5,4 +5,6 @@ import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 
 public interface AuthService {
     AuthResponseDTO.LoginResponse socialLogin(String socialType, AuthRequestDTO.SocialLoginRequest request);
+
+    AuthResponseDTO.DevTokenResponse generateDevAccessToken();
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -6,15 +6,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.converter.AuthConverter;
 import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.auth.exception.AuthHandler;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.service.UserService;
-import umc.teumteum.server.domain.auth.exception.AuthHandler;
 import umc.teumteum.server.global.jwt.JwtProvider;
 
 import java.time.Duration;
@@ -36,6 +37,7 @@ public class AuthServiceImpl implements AuthService {
     private long refreshExpirationMs;
 
     @Override
+    @Transactional
     public AuthResponseDTO.LoginResponse socialLogin(String socialType, AuthRequestDTO.SocialLoginRequest request) {
         // 1. 소셜 로그인 - 사용자 정보 불러오기
         OAuthUserInfo userInfo = getUserInfo(SocialType.valueOf(socialType.toUpperCase()), request.getAccessToken());
@@ -70,5 +72,19 @@ public class AuthServiceImpl implements AuthService {
             default:
                 throw new AuthHandler(AuthErrorStatus.INVALID_SOCIAL_TYPE);
         }
+    }
+
+
+    @Override
+    @Transactional
+    public AuthResponseDTO.DevTokenResponse generateDevAccessToken() {
+        // 1. 더미 사용자 조회 (없으면 생성)
+        User masterUser = userService.createDevUser();
+
+        // 2. 액세스 토큰 발급
+        String accessToken = jwtProvider.generateAccessToken(masterUser.getId());
+
+        // 3. converter 작업
+        return AuthConverter.toDevTokenResponse(accessToken);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findByNicknameContaining(String keyword);
 
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -19,4 +19,6 @@ public interface UserService {
     User findOrCreateUser(OAuthUserInfo userInfo);
 
     String determineUserNextStep(User user);
+
+    User createDevUser();
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserService {
     List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long requesterId);
@@ -21,4 +22,6 @@ public interface UserService {
     String determineUserNextStep(User user);
 
     User createDevUser();
+
+    Optional<User> findUser(Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.converter.UserConverter;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
@@ -16,10 +17,8 @@ import umc.teumteum.server.domain.user.repository.AgreementRepository;
 import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 
-import java.util.AbstractMap;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -69,6 +68,7 @@ public class UserServiceImpl implements UserService {
 
     // 소셜 로그인 시, 사용자 조회 (없으면 생성)
     @Override
+    @Transactional
     public User findOrCreateUser(OAuthUserInfo userInfo) {
 
         SocialType socialType = userInfo.getSocialType();
@@ -90,6 +90,7 @@ public class UserServiceImpl implements UserService {
 
     // 소셜 로그인 시, 사용자 다음 화면 결정
     @Override
+    @Transactional(readOnly = true)
     public String determineUserNextStep(User user) {
         // 1. 약관 동의 체크 -> 없으면 약관 동의 화면
         Agreement agreement = agreementRepository.findByUser(user)
@@ -107,5 +108,19 @@ public class UserServiceImpl implements UserService {
 
         // 3. 메인 화면
         return "MAIN";
+    }
+
+    @Override
+    @Transactional
+    public User createDevUser() {
+        return userRepository.findByEmail("teumteum@kakao.com")
+                .orElseGet(() -> {
+                    User devUser = User.builder()
+                            .email("teumteum@kakao.com")
+                            .socialId(UUID.randomUUID().toString())
+                            .socialType(SocialType.KAKAO)
+                            .build();
+                    return userRepository.save(devUser);
+                });
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -123,4 +123,11 @@ public class UserServiceImpl implements UserService {
                     return userRepository.save(devUser);
                 });
     }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> findUser(Long userId) {
+        return userRepository.findById(userId);
+    }
 }

--- a/src/main/java/umc/teumteum/server/global/config/WebConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/WebConfig.java
@@ -1,16 +1,22 @@
 package umc.teumteum.server.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.resolver.CurrentUserArgumentResolver;
 
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final UserRepository userRepository;
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new CurrentUserArgumentResolver());
+        resolvers.add(new CurrentUserArgumentResolver(userRepository));
     }
 }

--- a/src/main/java/umc/teumteum/server/global/config/WebConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/WebConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.resolver.CurrentUserArgumentResolver;
 
 import java.util.List;
@@ -13,10 +14,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new CurrentUserArgumentResolver(userRepository));
+        resolvers.add(new CurrentUserArgumentResolver(userService));
     }
 }

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
@@ -44,8 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // 5. Authentication 객체 생성
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails, null, userDetails.getAuthorities());
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
                 // 6. SecurityContext에 인증 정보 설정
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/umc/teumteum/server/global/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/umc/teumteum/server/global/resolver/CurrentUserArgumentResolver.java
@@ -10,6 +10,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
@@ -17,7 +18,7 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 @RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     // @CurrentUser 어노테이션이 붙었는지 + 파라미터 타입이 Long인지 검사
     @Override
@@ -41,7 +42,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         // 3. userId로 DB에서 조회해서 반환
         Long userId = Long.parseLong(user.getUsername());
 
-        return userRepository.findById(userId)
+        return userService.findUser(userId)
                 .orElseThrow(() -> new GlobalHandler(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/teumteum/server/global/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/umc/teumteum/server/global/resolver/CurrentUserArgumentResolver.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.global.resolver;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -7,17 +8,22 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
+@RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
 
     // @CurrentUser 어노테이션이 붙었는지 + 파라미터 타입이 Long인지 검사
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(CurrentUser.class) &&
-                parameter.getParameterType().equals(Long.class);
+                parameter.getParameterType().equals(User.class);
     }
 
     // 인증된 사용자 정보에서 userId를 꺼내 Long 타입으로 반환
@@ -32,6 +38,10 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             throw new GlobalHandler(ErrorStatus._UNAUTHORIZED);
         }
 
-        return Long.parseLong(user.getUsername());
+        // 3. userId로 DB에서 조회해서 반환
+        Long userId = Long.parseLong(user.getUsername());
+
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalHandler(ErrorStatus.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#59

### ✨ 작업한 내용
- **개발용 액세스 토큰 발급 API**
Controller에 `@Profile("dev")`를 붙여서 dev환경에서만 사용 가능하도록 제한
(제대로 설정되었는지 확인이 불가하여,,, Merge 이후에 서버 스웨거에서도 해당 Controller가 표시된다면 바로 수정하겠습니다)

- **CurrentUserArgumentResolver 수정**
기존) UserId를 반환
-> 각 Controller마다 User를 다시 조회하는 경우가 발생할 거 같아서 User 엔티티를 반환하도록 수정하였습니다.


### 🌀 PR Point
X

### 🍰 참고사항
사용자 데이터가 필요한 API에서 아래와 같이 Controller에 작성하시면 됩니다!
```
    @GetMapping(value = "/test/jwt", produces = "application/json")
    public ApiResponse<Long> getUser(
------>     @CurrentUser @Parameter(hidden = true) User user
    ) {
        return ApiResponse.onSuccess(user.getId());
    }
```

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  개발용 액세스 토큰 발급 API  |  <img width="774" height="829" alt="스크린샷 2025-07-21 오후 5 40 15" src="https://github.com/user-attachments/assets/1911d6eb-3195-4a8c-9706-6c972d69f9ad" />. |
|  JWT 테스트 API  |  <img width="645" height="702" alt="스크린샷 2025-07-21 오후 5 40 27" src="https://github.com/user-attachments/assets/5c905769-8ab4-473b-adf9-b6718a9b14c0" />. |

