### PR TITLE
Feat: 약속된 틈 날짜 리스트 반환 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -46,4 +46,15 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("endTime") LocalDateTime endTime
     );
 
+    @Query("SELECT DISTINCT s.date FROM Schedule s " +
+            "WHERE s.user.id = :userId " +
+            "AND s.type = 'TEUM' " +
+            "AND s.status IN (:statuses) " +
+            "AND FUNCTION('DATE_FORMAT', s.date, '%Y-%m') = :yearMonth " +
+            "AND s.isDeleted = false")
+    List<LocalDate> findScheduledTeumsByMonth(
+            @Param("userId") Long userId,
+            @Param("statuses") List<ScheduleStatus> statuses,
+            @Param("yearMonth") String yearMonth);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -46,15 +46,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("endTime") LocalDateTime endTime
     );
 
-    @Query("SELECT DISTINCT s.date FROM Schedule s " +
-            "WHERE s.user.id = :userId " +
-            "AND s.type = 'TEUM' " +
-            "AND s.status IN (:statuses) " +
-            "AND FUNCTION('DATE_FORMAT', s.date, '%Y-%m') = :yearMonth " +
-            "AND s.isDeleted = false")
+    @Query("""
+    SELECT DISTINCT s.date FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.type = 'TEUM'
+      AND s.status IN (:statuses)
+      AND FUNCTION('DATE_FORMAT', s.date, '%Y-%m') = :yearMonth
+      AND s.isDeleted = false
+""")
     List<LocalDate> findScheduledTeumsByMonth(
             @Param("userId") Long userId,
             @Param("statuses") List<ScheduleStatus> statuses,
-            @Param("yearMonth") String yearMonth);
+            @Param("yearMonth") String yearMonth
+    );
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -21,6 +21,7 @@ import umc.teumteum.server.domain.teum.dto.shared.SharedTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.teum.exception.status.TeumSuccessStatus;
 import umc.teumteum.server.domain.teum.service.TeumService;
+import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
@@ -143,9 +144,9 @@ public class TeumController {
     public ApiResponse<List<String>> getTeumDatesOfMonth(
             @Parameter(description = "조회할 연월 (YYYY-MM)", example = "2025-05")
             @RequestParam("month") String month,
-            @CurrentUser @Parameter(hidden = true) Long userId
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        List<String> dates = teumService.getScheduledTeumsOfMonth(userId, month);
+        List<String> dates = teumService.getScheduledTeumsOfMonth(user.getId(), month);
         return ApiResponse.of(TeumSuccessStatus._SCHEDULED_CALENDAR_LOADED, dates);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -21,6 +21,7 @@ import umc.teumteum.server.domain.teum.dto.shared.SharedTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.teum.exception.status.TeumSuccessStatus;
 import umc.teumteum.server.domain.teum.service.TeumService;
+import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 import java.util.List;
@@ -135,16 +136,18 @@ public class TeumController {
 
     @Operation(
             summary = "약속된 틈 날짜 리스트 조회",
-            description = "사용자가 참여 중인 틈 중, 지정한 월에 약속된 틈이 있는 날짜만 리스트로 반환합니다."
+            description = "사용자가 참여 중인 틈 중, 지정한 월에 약속된 틈이 있는 날짜만 리스트로 반환합니다.",
+            security = @SecurityRequirement(name = "JWT")
     )
     @GetMapping(value = "/scheduled/calendar", produces = "application/json")
     public ApiResponse<List<String>> getTeumDatesOfMonth(
             @Parameter(description = "조회할 연월 (YYYY-MM)", example = "2025-05")
-            @RequestParam("month") String month
+            @RequestParam("month") String month,
+            @CurrentUser @Parameter(hidden = true) Long userId
     ) {
-        return ApiResponse.onSuccess(null);
+        List<String> dates = teumService.getScheduledTeumsOfMonth(userId, month);
+        return ApiResponse.of(TeumSuccessStatus._SCHEDULED_CALENDAR_LOADED, dates);
     }
-
 
     @Operation(
             summary = "특정 날짜의 약속된 틈 조회",

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -205,5 +205,11 @@ public class TeumConverter {
         return available;
     }
 
+    public static List<String> toDateStringList(List<LocalDate> dates) {
+        return dates.stream()
+                .map(LocalDate::toString)
+                .toList();
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -159,8 +159,9 @@ public class TeumServiceImpl implements TeumService {
 
     @Override
     public List<String> getScheduledTeumsOfMonth(Long userId, String month) {
-        // TODO: 약속된 틈의 날짜 리스트 조회 로직 추후 구현
-        return List.of();
+        List<ScheduleStatus> validStatuses = List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
+        List<LocalDate> dates = scheduleRepository.findScheduledTeumsByMonth(userId, validStatuses, month);
+        return TeumConverter.toDateStringList(dates);
     }
 
     @Override


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#60 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 로그인한 사용자의 약속된 틈(TEUM) 스케줄 중 `ACTIVE` 또는 `COMPLETED` 상태의 날짜 리스트 조회 API 구현
- `/api/teums/scheduled/calendar?month=YYYY-MM` 엔드포인트 추가
- `ScheduleRepository`에 `findScheduledTeumsByMonth` JPQL 쿼리 추가
- `Service`에서 날짜 필터 후 문자열 리스트로 변환
- `TeumConverter.toDateStringList()`로 분리 (다른 날짜 리스트 반환 API에서 반복 사용)
- 컨트롤러에서 `@CurrentUser`를 통해 사용자 ID 주입받도록 구현

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 테스트 결과

#### 5월 일정 (CANCELLED와 틈이 아닌 경우 무시)
```json
{
  "isSuccess": true,
  "code": "TEUM2007",
  "message": "약속된 틈 달력 정보가 조회되었습니다.",
  "result": [
    "2025-05-02",
    "2025-05-12"
  ]
}
```
#### 6월 일정 (월 필터 테스트용)
```json
{
  "isSuccess": true,
  "code": "TEUM2007",
  "message": "약속된 틈 달력 정보가 조회되었습니다.",
  "result": [
    "2025-06-03"
  ]
}
```
#### 7월 일정 (약속된 틈 없음)
```
json
{
  "isSuccess": true,
  "code": "TEUM2007",
  "message": "약속된 틈 달력 정보가 조회되었습니다.",
  "result": []
}
```