### PR TITLE
Bug: 개발용 토큰 발급 API Controller 분리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -56,19 +56,6 @@ public class AuthController {
     }
 
 
-    @Profile("dev")
-    @Operation(
-            summary = "개발용 액세스 토큰 발급",
-            description = "개발 진행 과정에서의 테스트를 위한 액세스 토큰을 발급합니다."
-    )
-    @PostMapping(value = "/dev-token", produces = "application/json")
-    public ApiResponse<AuthResponseDTO.DevTokenResponse> generateDevAccessToken() {
-        AuthResponseDTO.DevTokenResponse response = authService.generateDevAccessToken();
-
-        return ApiResponse.of(AuthSuccessStatus.DEV_TOKEN_ISSUED, response);
-    }
-
-
 //    @GetMapping(value = "/test/jwt", produces = "application/json")
 //    public ApiResponse<Long> getUser(
 //            @CurrentUser @Parameter(hidden = true) User user

--- a/src/main/java/umc/teumteum/server/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/DevAuthController.java
@@ -1,0 +1,36 @@
+package umc.teumteum.server.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
+import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
+import umc.teumteum.server.domain.auth.exception.status.AuthSuccessStatus;
+import umc.teumteum.server.domain.auth.service.AuthService;
+import umc.teumteum.server.global.apiPayload.ApiResponse;
+
+@Profile("dev")
+@Tag(name = "Auth", description = "인증 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class DevAuthController {
+
+    private final AuthService authService;
+
+    @Operation(
+            summary = "개발용 액세스 토큰 발급",
+            description = "개발 진행 과정에서의 테스트를 위한 액세스 토큰을 발급합니다."
+    )
+    @PostMapping(value = "/dev-token", produces = "application/json")
+    public ApiResponse<AuthResponseDTO.DevTokenResponse> generateDevAccessToken() {
+        AuthResponseDTO.DevTokenResponse response = authService.generateDevAccessToken();
+
+        return ApiResponse.of(AuthSuccessStatus.DEV_TOKEN_ISSUED, response);
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈
#64 

### ✨ 작업한 내용
`/api/auth/dev-token`을 통해 액세스 토큰을 발급받으면 별도의 로그인 과정없이 서비스를 자유롭게 이용할 수 있기 때문에,
해당 API는 개발 환경에서만 동작하도록 제한하고자 했습니다. 이를 위해 `@Profile("dev")` 어노테이션을 활용하고자 했으나, 해당 어노테이션은 `@Component` 계열의 클래스에 적용되어야 정상적으로 작동한다고 합니다. (현재는 메소드에 작성하여 서버 스웨거에서 노출되는 상태...)

이에 따라 개발용 토큰 발급 API를 별도의 컨트롤러 클래스로 분리한 뒤,
해당 클래스에 `@Profile("dev")`를 적용하여 dev 환경에서만 활성화되도록 수정하였습니다.


### 🌀 PR Point
X

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF
X