### PR TITLE
Feat: 약관 동의 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
@@ -10,7 +10,7 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 @AllArgsConstructor
 public enum AuthSuccessStatus implements BaseCode {
 
-    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 성공적으로 완료되었습니다."),
+    SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 완료되었습니다."),
     DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다.")
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -56,7 +56,7 @@ public class AuthServiceImpl implements AuthService {
         rtRedisTemplate.opsForValue().set(key, refreshToken, refreshDuration);
 
         // 5. 다음 단계 결정
-        String nextStep = userService.determineUserNextStep(user);
+        String nextStep = String.valueOf(user.getStep());
 
         // 6. converter 작업
         return AuthConverter.toLoginResponse(accessToken, refreshToken, nextStep);

--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -1,0 +1,100 @@
+package umc.teumteum.server.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.teumteum.server.domain.user.dto.UserRequestDTO;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.exception.status.UserSuccessStatus;
+import umc.teumteum.server.domain.user.service.UserService;
+import umc.teumteum.server.global.annotation.CurrentUser;
+import umc.teumteum.server.global.apiPayload.ApiResponse;
+
+
+@Tag(name = "User", description = "사용자 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class OnboardingController {
+
+    private final UserService userService;
+
+    @Operation(
+            summary = "온보딩 약관 동의",
+            description = "온보딩 과정에서 약관 동의 정보를 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/agreement", produces = "application/json")
+    public ApiResponse<Object> saveTerms(
+            @RequestBody @Valid UserRequestDTO.AgreeRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
+            ) {
+        userService.saveAgreement(request, user);
+        return ApiResponse.of(UserSuccessStatus.AGREEMENT_SAVED, null);
+    }
+
+
+    @Operation(
+            summary = "온보딩 닉네임과 분야/직종 저장",
+            description = "온보딩 과정에서 닉네임과 분야/직종 정보를 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/nickname-job", produces = "application/json")
+    public ApiResponse<Object> saveNicknameAndJob(
+    ) {
+        // TODO: 온보딩 닉네임과 분야/직종 저장 로직 구현
+        return null;
+    }
+
+
+    @Operation(
+            summary = "온보딩 프로필 이미지 저장",
+            description = "온보딩 과정에서 S3에 업로드되고 난 뒤의 프로필 이미지 키를 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/profile-image", produces = "application/json")
+    public ApiResponse<Object> saveProfileImageKey(
+    ) {
+        // TODO: 온보딩 프로필 이미지 키 저장 로직 구현
+        return null;
+    }
+
+
+    @Operation(
+            summary = "온보딩 요일별 반복 일정 저장",
+            description = "온보딩 과정에서 요일별 반복 일정을 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/routine", produces = "application/json")
+    public ApiResponse<Object> saveRoutine(
+    ) {
+        // TODO: 온보딩 루틴 저장 로직 구현
+        return null;
+    }
+
+
+    @Operation(
+            summary = "온보딩 수면 패턴 저장",
+            description = "온보딩 과정에서 수면 패턴(취침시간/기상시간)을 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/sleep-pattern", produces = "application/json")
+    public ApiResponse<Object> saveSleepPattern(
+    ) {
+        // TODO: 온보딩 수면 패턴 저장 로직 구현
+        return null;
+    }
+
+
+    @Operation(
+            summary = "온보딩 리마인드 알림 설정 저장",
+            description = "온보딩 과정에서 리마인드 알림 시간 설정(1분 전/3분 전/5분 전/10분 전/30분 전)을 저장합니다."
+    )
+    @PostMapping(value = "/onboarding/reminder", produces = "application/json")
+    public ApiResponse<Object> saveReminder(
+    ) {
+        // TODO: 온보딩 리마인드 알림 설정 저장 로직 구현
+        return null;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -4,13 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.exception.status.UserSuccessStatus;
 import umc.teumteum.server.domain.user.service.UserService;
@@ -26,77 +21,6 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
-
-    @Operation(
-            summary = "온보딩 약관 동의",
-            description = "온보딩 과정에서 약관 동의 정보를 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/agreement", produces = "application/json")
-    public ApiResponse<Object> saveTerms(
-    ) {
-        // TODO: 온보딩 약관 동의 저장 로직 구현
-        return null;
-    }
-
-
-    @Operation(
-            summary = "온보딩 닉네임과 분야/직종 저장",
-            description = "온보딩 과정에서 닉네임과 분야/직종 정보를 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/nickname-job", produces = "application/json")
-    public ApiResponse<Object> saveNicknameAndJob(
-    ) {
-        // TODO: 온보딩 닉네임과 분야/직종 저장 로직 구현
-        return null;
-    }
-
-
-    @Operation(
-            summary = "온보딩 프로필 이미지 저장",
-            description = "온보딩 과정에서 S3에 업로드되고 난 뒤의 프로필 이미지 키를 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/profile-image", produces = "application/json")
-    public ApiResponse<Object> saveProfileImageKey(
-    ) {
-        // TODO: 온보딩 프로필 이미지 키 저장 로직 구현
-        return null;
-    }
-
-
-    @Operation(
-            summary = "온보딩 요일별 반복 일정 저장",
-            description = "온보딩 과정에서 요일별 반복 일정을 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/routine", produces = "application/json")
-    public ApiResponse<Object> saveRoutine(
-    ) {
-        // TODO: 온보딩 루틴 저장 로직 구현
-        return null;
-    }
-
-
-    @Operation(
-            summary = "온보딩 수면 패턴 저장",
-            description = "온보딩 과정에서 수면 패턴(취침시간/기상시간)을 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/sleep-pattern", produces = "application/json")
-    public ApiResponse<Object> saveSleepPattern(
-    ) {
-        // TODO: 온보딩 수면 패턴 저장 로직 구현
-        return null;
-    }
-
-
-    @Operation(
-            summary = "온보딩 리마인드 알림 설정 저장",
-            description = "온보딩 과정에서 리마인드 알림 시간 설정(1분 전/3분 전/5분 전/10분 전/30분 전)을 저장합니다."
-    )
-    @PostMapping(value = "/onboarding/reminder", produces = "application/json")
-    public ApiResponse<Object> saveReminder(
-    ) {
-        // TODO: 온보딩 리마인드 알림 설정 저장 로직 구현
-        return null;
-    }
 
     @Operation(
             summary = "닉네임 사용자 검색",

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
             summary = "온보딩 약관 동의",
             description = "온보딩 과정에서 약관 동의 정보를 저장합니다."
     )
-    @PostMapping(value = "/onboarding/terms", produces = "application/json")
+    @PostMapping(value = "/onboarding/agreement", produces = "application/json")
     public ApiResponse<Object> saveTerms(
     ) {
         // TODO: 온보딩 약관 동의 저장 로직 구현

--- a/src/main/java/umc/teumteum/server/domain/user/converter/AgreementConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/AgreementConverter.java
@@ -1,0 +1,17 @@
+package umc.teumteum.server.domain.user.converter;
+
+import umc.teumteum.server.domain.user.dto.UserRequestDTO;
+import umc.teumteum.server.domain.user.entity.Agreement;
+import umc.teumteum.server.domain.user.entity.User;
+
+public class AgreementConverter {
+
+    public static Agreement toAgreement(UserRequestDTO.AgreeRequest request, User user) {
+        return Agreement.builder()
+                .user(user)
+                .thirdPartyConsent(request.getThirdPartyConsent())
+                .marketingConsent(request.getMarketingConsent())
+                .build()
+                ;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
@@ -1,4 +1,34 @@
 package umc.teumteum.server.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class UserRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AgreeRequest {
+
+        @NotNull
+        @Schema(description = "서비스 이용약관 동의 여부 (필수)", example = "true")
+        private Boolean tosConsent;
+
+        @NotNull
+        @Schema(description = "개인정보 수집 및 이용 동의 여부 (필수)", example = "true")
+        private Boolean privacyConsent;
+
+        @NotNull
+        @Schema(description = "개인정보 제3자 제공 동의 여부 (선택)", example = "false")
+        private Boolean thirdPartyConsent;
+
+        @NotNull
+        @Schema(description = "마케팅 정보 수신 동의 여부 (선택)", example = "false")
+        private Boolean marketingConsent;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/Agreement.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/Agreement.java
@@ -27,6 +27,7 @@ public class Agreement extends BaseEntity {
     @Column(name = "tos_consent", nullable = false)
     private Boolean tosConsent = true;
 
+    @Builder.Default
     @Column(name = "privacy_consent", nullable = false)
     private Boolean privacyConsent = true;
 

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -15,6 +15,7 @@ import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserRole;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
 import umc.teumteum.server.global.common.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -62,6 +63,11 @@ public class User extends BaseEntity {
 
     @Column(name = "profile_image_key")
     private String profileImageKey;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "step", nullable = false)
+    private UserStep step = UserStep.AGREEMENT;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -117,4 +117,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Wish> wishes;
 
+
+    public void updateStep(UserStep step) {
+        this.step = step;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/enums/UserStep.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/enums/UserStep.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.user.entity.enums;
+
+public enum UserStep {
+    AGREEMENT,      // 약관 동의
+    ONBOARDING,     // 온보딩
+    MAIN,           // 메인
+}

--- a/src/main/java/umc/teumteum/server/domain/user/exception/UserHandler.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/UserHandler.java
@@ -1,0 +1,11 @@
+package umc.teumteum.server.domain.user.exception;
+
+import umc.teumteum.server.global.apiPayload.code.BaseErrorCode;
+import umc.teumteum.server.global.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+
+  public UserHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -10,7 +10,13 @@ import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
 @AllArgsConstructor
 public enum UserErrorStatus implements BaseErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다."),
+
+
+    // 사용자 온보딩
+    TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "USER4001", "서비스 이용약관은 필수 동의 항목입니다."),
+    PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "USER4002", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -14,8 +14,9 @@ public enum UserErrorStatus implements BaseErrorCode {
 
 
     // 사용자 온보딩
-    TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "USER4001", "서비스 이용약관은 필수 동의 항목입니다."),
-    PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "USER4002", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
+    TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "서비스 이용약관은 필수 동의 항목입니다."),
+    PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
+    AGREEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 약관에 동의한 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -10,7 +10,12 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 @AllArgsConstructor
 public enum UserSuccessStatus implements BaseCode {
 
-    _USER_FOUND(HttpStatus.OK, "USER2000", "사용자 조회 성공");
+    _USER_FOUND(HttpStatus.OK, "USER2001", "사용자 조회 성공"),
+
+
+    // 사용자 온보딩
+    AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 성공적으로 완료되었습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -14,7 +14,7 @@ public enum UserSuccessStatus implements BaseCode {
 
 
     // 사용자 온보딩
-    AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 성공적으로 완료되었습니다."),
+    AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 완료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface AgreementRepository extends JpaRepository<Agreement, Long> {
     Optional<Agreement> findByUser(User user);
+
+    boolean existsByUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -21,8 +21,6 @@ public interface UserService {
 
     User findOrCreateUser(OAuthUserInfo userInfo);
 
-    String determineUserNextStep(User user);
-
     User createDevUser();
 
     Optional<User> findUser(Long userId);

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package umc.teumteum.server.domain.user.service;
 
+import jakarta.validation.Valid;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import umc.teumteum.server.domain.user.dto.UserRequestDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -24,4 +26,6 @@ public interface UserService {
     User createDevUser();
 
     Optional<User> findUser(Long userId);
+
+    void saveAgreement(UserRequestDTO.AgreeRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -120,7 +120,12 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void saveAgreement(UserRequestDTO.AgreeRequest request, User user) {
-        // 1. 필수 항목 동의 여부 확인
+        // 1. 기존 동의 이력이 있는지 확인
+        if (agreementRepository.existsByUser(user)) {
+            throw new UserHandler(UserErrorStatus.AGREEMENT_ALREADY_EXISTS);
+        }
+
+        // 2. 필수 항목 동의 여부 확인
         if (!request.getTosConsent()) {
             throw new UserHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
         }
@@ -128,13 +133,13 @@ public class UserServiceImpl implements UserService {
             throw new UserHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
         }
 
-        // 2. Entity 변환
+        // 3. Entity 변환
         Agreement agreement = AgreementConverter.toAgreement(request, user);
 
-        // 3. 저장
+        // 4. 저장
         agreementRepository.save(agreement);
 
-        // 4. 사용자 step 변경
+        // 5. 사용자 step 변경
         user.updateStep(UserStep.ONBOARDING);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -91,28 +91,6 @@ public class UserServiceImpl implements UserService {
                 });
     }
 
-    // 소셜 로그인 시, 사용자 다음 화면 결정
-    @Override
-    @Transactional(readOnly = true)
-    public String determineUserNextStep(User user) {
-        // 1. 약관 동의 체크 -> 없으면 약관 동의 화면
-        Agreement agreement = agreementRepository.findByUser(user)
-                .orElse(null);
-        if (agreement == null) {
-            return "AGREEMENT";
-        }
-
-        // 2. 리마인드 알림 체크 -> 없으면 온보딩 화면
-        RemindAlarm remindAlarm = remindAlarmRepository.findByUser(user)
-                .orElse(null);
-        if (remindAlarm == null) {
-            return "ONBOARDING";
-        }
-
-        // 3. 메인 화면
-        return "MAIN";
-    }
-
 
     // 개발용 액세스 토큰 사용자 생성
     @Override

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -2,22 +2,25 @@ package umc.teumteum.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.converter.AgreementConverter;
 import umc.teumteum.server.domain.user.converter.UserConverter;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import umc.teumteum.server.domain.user.dto.UserRequestDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
 import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
+import umc.teumteum.server.domain.user.exception.UserHandler;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.AgreementRepository;
 import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -110,6 +113,8 @@ public class UserServiceImpl implements UserService {
         return "MAIN";
     }
 
+
+    // 개발용 액세스 토큰 사용자 생성
     @Override
     @Transactional
     public User createDevUser() {
@@ -125,9 +130,33 @@ public class UserServiceImpl implements UserService {
     }
 
 
+    // Resolver 사용자 조회
     @Override
     @Transactional(readOnly = true)
     public Optional<User> findUser(Long userId) {
         return userRepository.findById(userId);
+    }
+
+
+    // 온보딩 - 약관 동의
+    @Override
+    @Transactional
+    public void saveAgreement(UserRequestDTO.AgreeRequest request, User user) {
+        // 1. 필수 항목 동의 여부 확인
+        if (!request.getTosConsent()) {
+            throw new UserHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
+        }
+        if (!request.getPrivacyConsent()) {
+            throw new UserHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
+        }
+
+        // 2. Entity 변환
+        Agreement agreement = AgreementConverter.toAgreement(request, user);
+
+        // 3. 저장
+        agreementRepository.save(agreement);
+
+        // 4. 사용자 step 변경
+        user.updateStep(UserStep.ONBOARDING);
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#67 

### ✨ 작업한 내용
- **약관 동의 API 구현**
엔드포인트 간단하게 변경하였는데 노션 API 명세서에 반영하였습니다.

- **User 테이블 step 필드 추가**
이슈에서도 언급하였지만, 온보딩 리마인드 알림이 `선택 입력`이라는 사실을 알게 되어 기존 로직으로는 온보딩 완료 판단이 어려워졌습니다.
따라서, 별도의 필드를 두어 회원가입 / 약관 동의 / 온보딩 완료 시마다 step을 `AGREEMENT` / `ONBOARDING` / `MAIN`으로 변경하여 로그인 시 전환해야 되는 화면을 알려주도록 하였습니다.


### 🌀 PR Point
X

### 🍰 참고사항
User Controller의 내용이 너무 길어서 온보딩 관련 Controller 파일 따로 분리하였습니다!
그런데 이러다보니 Service, ErrorStatus 등에서도 user와 onboarding을 분리해야 할지 애매하네요...
개발 진행하며, 마찬가지로 너무 길면 고민해보겠습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   약관 동의 API   |  <img width="480" height="855" alt="스크린샷 2025-07-22 오전 10 55 31" src="https://github.com/user-attachments/assets/73e8bc3d-df94-413e-9583-a08a1c6e55e0" />  |
