### PR TITLE
Feat: 닉네임 & 분야/직종 등록 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -40,14 +40,16 @@ public class OnboardingController {
 
 
     @Operation(
-            summary = "온보딩 닉네임과 분야/직종 저장",
+            summary = "온보딩 닉네임과 분야/직종 등록",
             description = "온보딩 과정에서 닉네임과 분야/직종 정보를 저장합니다."
     )
     @PostMapping(value = "/onboarding/nickname-job", produces = "application/json")
     public ApiResponse<Object> saveNicknameAndJob(
+            @RequestBody @Valid UserRequestDTO.NicknameJobRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        // TODO: 온보딩 닉네임과 분야/직종 저장 로직 구현
-        return null;
+        userService.saveNicknameAndJob(request, user);
+        return ApiResponse.of(UserSuccessStatus.NICKNAME_JOB_SAVED, null);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -54,8 +54,8 @@ public class OnboardingController {
 
 
     @Operation(
-            summary = "온보딩 프로필 이미지 저장",
-            description = "온보딩 과정에서 S3에 업로드되고 난 뒤의 프로필 이미지 키를 저장합니다."
+            summary = "온보딩 프로필 이미지 등록",
+            description = "온보딩 과정에서 S3에 업로드된 프로필 이미지의 키를 저장합니다."
     )
     @PostMapping(value = "/onboarding/profile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
@@ -66,7 +66,7 @@ public class OnboardingController {
 
 
     @Operation(
-            summary = "온보딩 요일별 반복 일정 저장",
+            summary = "온보딩 요일별 반복 일정 등록",
             description = "온보딩 과정에서 요일별 반복 일정을 저장합니다."
     )
     @PostMapping(value = "/onboarding/routine", produces = "application/json")
@@ -78,7 +78,7 @@ public class OnboardingController {
 
 
     @Operation(
-            summary = "온보딩 수면 패턴 저장",
+            summary = "온보딩 수면 패턴 등록",
             description = "온보딩 과정에서 수면 패턴(취침시간/기상시간)을 저장합니다."
     )
     @PostMapping(value = "/onboarding/sleep-pattern", produces = "application/json")
@@ -90,7 +90,7 @@ public class OnboardingController {
 
 
     @Operation(
-            summary = "온보딩 리마인드 알림 설정 저장",
+            summary = "온보딩 리마인드 알림 설정 등록",
             description = "온보딩 과정에서 리마인드 알림 시간 설정(1분 전/3분 전/5분 전/10분 전/30분 전)을 저장합니다."
     )
     @PostMapping(value = "/onboarding/reminder", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
@@ -1,7 +1,10 @@
 package umc.teumteum.server.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,5 +33,23 @@ public class UserRequestDTO {
         @NotNull
         @Schema(description = "마케팅 정보 수신 동의 여부 (선택)", example = "false")
         private Boolean marketingConsent;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NicknameJobRequest {
+
+        @NotBlank(message = "닉네임은 필수 입력입니다")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다")
+        @Pattern(regexp = "^[a-zA-Z가-힣]*$", message = "닉네임은 영어와 한글만 가능합니다")
+        @Schema(description = "사용자 닉네임 (최대 10자, 영어&한글만, 중복 불가)", example = "틈틈")
+        private String nickname;
+
+        @NotBlank(message = "분야/직종은 필수 입력입니다")
+        @Size(max = 10, message = "분야/직종은 최대 10자까지 가능합니다")
+        @Schema(description = "사용자의 분야/직종 (최대 10자)", example = "개발자")
+        private String jobField;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDTO.java
@@ -18,19 +18,19 @@ public class UserRequestDTO {
     @AllArgsConstructor
     public static class AgreeRequest {
 
-        @NotNull
+        @NotNull(message = "서비스 이용약관 동의 여부를 입력해야 합니다")
         @Schema(description = "서비스 이용약관 동의 여부 (필수)", example = "true")
         private Boolean tosConsent;
 
-        @NotNull
+        @NotNull(message = "개인정보 수집 및 이용 동의 여부를 입력해야 합니다")
         @Schema(description = "개인정보 수집 및 이용 동의 여부 (필수)", example = "true")
         private Boolean privacyConsent;
 
-        @NotNull
+        @NotNull(message = "개인정보 제3자 제공 동의 여부를 입력해야 합니다")
         @Schema(description = "개인정보 제3자 제공 동의 여부 (선택)", example = "false")
         private Boolean thirdPartyConsent;
 
-        @NotNull
+        @NotNull(message = "마케팅 정보 수신 동의 여부를 입력해야 합니다")
         @Schema(description = "마케팅 정보 수신 동의 여부 (선택)", example = "false")
         private Boolean marketingConsent;
     }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -2,6 +2,9 @@ package umc.teumteum.server.domain.user.entity;
 
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -120,5 +123,10 @@ public class User extends BaseEntity {
 
     public void updateStep(UserStep step) {
         this.step = step;
+    }
+
+    public void updateNicknameAndJob(String nickname, String jobField) {
+        this.nickname = nickname;
+        this.job = jobField;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -14,8 +14,9 @@ public enum UserErrorStatus implements BaseErrorCode {
 
 
     // 사용자 온보딩
-    TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "서비스 이용약관은 필수 동의 항목입니다."),
-    PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
+    INVALID_STEP(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "현재 진행할 수 있는 단계가 아닙니다."),
+    TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "서비스 이용약관은 필수 동의 항목입니다."),
+    PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4003", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
     AGREEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 약관에 동의한 사용자입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4092", "이미 사용 중인 닉네임입니다."),
     ;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -17,6 +17,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "서비스 이용약관은 필수 동의 항목입니다."),
     PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
     AGREEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 약관에 동의한 사용자입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4092", "이미 사용 중인 닉네임입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -15,6 +15,8 @@ public enum UserSuccessStatus implements BaseCode {
 
     // 사용자 온보딩
     AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 완료되었습니다."),
+    NICKNAME_JOB_SAVED(HttpStatus.OK, "ONBOARDING2002", "닉네임과 분야/직종 등록이 완료되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -1,5 +1,8 @@
 package umc.teumteum.server.domain.user.repository;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
@@ -13,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findByNicknameContaining(String keyword);
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -26,4 +26,6 @@ public interface UserService {
     Optional<User> findUser(Long userId);
 
     void saveAgreement(UserRequestDTO.AgreeRequest request, User user);
+
+    void saveNicknameAndJob(UserRequestDTO.NicknameJobRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -142,4 +142,27 @@ public class UserServiceImpl implements UserService {
         // 5. 사용자 step 변경
         user.updateStep(UserStep.ONBOARDING);
     }
+
+
+    // 온보딩 - 닉네임 & 분야/직종 등록
+    @Override
+    @Transactional
+    public void saveNicknameAndJob(UserRequestDTO.NicknameJobRequest request, User user) {
+        // 1. 닉네임 중복 여부 확인
+        // 기존 닉네임이 null이면(=처음 닉네임 등록) 단순 중복 체크
+        if (user.getNickname() == null) {
+            if (userRepository.existsByNickname(request.getNickname())) {
+                throw new UserHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
+            }
+        }
+        // 기존 닉네임이 있으면(=온보딩 중단으로 인한 닉네임 재등록) 본인 닉네임 이외와 중복 체크
+        else {
+            if (!request.getNickname().equals(user.getNickname()) && userRepository.existsByNickname(request.getNickname())) {
+                throw new UserHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
+            }
+        }
+
+        // 2. 닉네임과 분야/직종 수정
+        user.updateNicknameAndJob(request.getNickname(), request.getJobField());
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -11,7 +11,6 @@ import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
-import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStep;
@@ -120,12 +119,15 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void saveAgreement(UserRequestDTO.AgreeRequest request, User user) {
-        // 1. 기존 동의 이력이 있는지 확인
+        // 1. 사용자 step 확인
+        validateOnboardingStep(user, UserStep.AGREEMENT);
+
+        // 2. 기존 동의 이력이 있는지 확인
         if (agreementRepository.existsByUser(user)) {
             throw new UserHandler(UserErrorStatus.AGREEMENT_ALREADY_EXISTS);
         }
 
-        // 2. 필수 항목 동의 여부 확인
+        // 3. 필수 항목 동의 여부 확인
         if (!request.getTosConsent()) {
             throw new UserHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
         }
@@ -133,13 +135,13 @@ public class UserServiceImpl implements UserService {
             throw new UserHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
         }
 
-        // 3. Entity 변환
+        // 4. Entity 변환
         Agreement agreement = AgreementConverter.toAgreement(request, user);
 
-        // 4. 저장
+        // 5. 저장
         agreementRepository.save(agreement);
 
-        // 5. 사용자 step 변경
+        // 6. 사용자 step 변경
         user.updateStep(UserStep.ONBOARDING);
     }
 
@@ -148,7 +150,10 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void saveNicknameAndJob(UserRequestDTO.NicknameJobRequest request, User user) {
-        // 1. 닉네임 중복 여부 확인
+        // 1. 사용자 step 확인
+        validateOnboardingStep(user, UserStep.ONBOARDING);
+
+        // 2. 닉네임 중복 여부 확인
         // 기존 닉네임이 null이면(=처음 닉네임 등록) 단순 중복 체크
         if (user.getNickname() == null) {
             if (userRepository.existsByNickname(request.getNickname())) {
@@ -162,7 +167,15 @@ public class UserServiceImpl implements UserService {
             }
         }
 
-        // 2. 닉네임과 분야/직종 수정
+        // 3. 닉네임과 분야/직종 수정
         user.updateNicknameAndJob(request.getNickname(), request.getJobField());
+    }
+
+
+    // 사용자의 step을 확인
+    private void validateOnboardingStep(User user, UserStep expectedStep) {
+        if (user.getStep() == null || !user.getStep().equals(expectedStep)) {
+            throw new UserHandler(UserErrorStatus.INVALID_STEP);
+        }
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#71 

### ✨ 작업한 내용
- **사용자의 현재 step을 확인하는 로직 추가**
약관 동의 API에서는 AGREEMENT인지 / 나머지 온보딩 등록 API에서는 ONBOARDING인지를 확인

- **닉네임 & 분야/직종 등록 API**
각각 제약사항 확인 후, 닉네임은 다른 사용자들의 닉네임과 중복 확인

### 🌀 PR Point
X

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  닉네임 & 분야/직종 등록 API  |  <img width="409" height="702" alt="스크린샷 2025-07-23 오전 2 16 00" src="https://github.com/user-attachments/assets/c543bb58-95d2-4186-860f-3a6c5884cd15" />  |