### PR TITLE
Feat: 약속된 틈 상세조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
 
 
 import java.time.LocalDate;
@@ -59,6 +60,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("statuses") List<ScheduleStatus> statuses,
             @Param("yearMonth") String yearMonth
     );
+
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.teumRequest = :teumRequest
+      AND s.status IN :statuses
+      AND s.type = 'TEUM'
+      AND s.isDeleted = false
+""")
+    List<Schedule> findByTeumRequestAndStatusIn(
+            @Param("teumRequest") TeumRequest teumRequest,
+            @Param("statuses") List<ScheduleStatus> statuses
+    );
+
 
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -170,11 +170,14 @@ public class TeumController {
     @GetMapping(value = "/scheduled/{teumId}", produces = "application/json")
     public ApiResponse<ScheduledTeumDetailResponseDto> getTeumDetail(
             @Parameter(name = "teumId", description = "상세 정보를 조회할 틈 ID", example = "1")
-            @PathVariable("teumId") Long teumId
+            @PathVariable("teumId") Long teumId,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.of(
+                TeumSuccessStatus._SCHEDULED_DETAIL_LOADED,
+                teumService.getScheduledTeumDetail(teumId, user.getId())
+        );
     }
-
     @Operation(
             summary = "약속된 틈 나가기",
             description = "현재 로그인한 사용자가 참여 중인 틈(teumId)에서 나갑니다. 마지막 참여자가 나갈 경우 틈은 cancelled 상태로 변경됩니다."

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -165,19 +165,20 @@ public class TeumController {
 
     @Operation(
             summary = "약속된 틈 상세 조회",
-            description = "사용자가 참여 중인 틈(teumId)에 대한 상세 정보를 조회합니다. 과거 여부도 함께 반환됩니다."
+            description = "사용자가 참여 중인 약속된 틈(scheduleId)에 대한 상세 정보를 조회합니다."
     )
-    @GetMapping(value = "/scheduled/{teumId}", produces = "application/json")
-    public ApiResponse<ScheduledTeumDetailResponseDto> getTeumDetail(
-            @Parameter(name = "teumId", description = "상세 정보를 조회할 틈 ID", example = "1")
-            @PathVariable("teumId") Long teumId,
+    @GetMapping(value = "/scheduled/{scheduleId}", produces = "application/json")
+    public ApiResponse<ScheduledTeumDetailResponseDto> getScheduledTeumDetail(
+            @Parameter(name = "scheduleId", description = "사용자 본인의 약속된 틈 일정 ID", example = "300")
+            @PathVariable("scheduleId") Long scheduleId,
             @CurrentUser @Parameter(hidden = true) User user
     ) {
         return ApiResponse.of(
                 TeumSuccessStatus._SCHEDULED_DETAIL_LOADED,
-                teumService.getScheduledTeumDetail(teumId, user.getId())
+                teumService.getScheduledTeumDetail(scheduleId, user.getId())
         );
     }
+
     @Operation(
             summary = "약속된 틈 나가기",
             description = "현재 로그인한 사용자가 참여 중인 틈(teumId)에서 나갑니다. 마지막 참여자가 나갈 경우 틈은 cancelled 상태로 변경됩니다."

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -6,6 +6,7 @@ import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
+import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumResendRequestDto;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class TeumConverter {
 
@@ -211,5 +213,26 @@ public class TeumConverter {
                 .toList();
     }
 
+    public static ScheduledTeumDetailResponseDto toScheduledTeumDetailDto(
+            Schedule baseSchedule,
+            List<Schedule> relatedSchedules,
+            S3Util s3Util
+    ) {
+        return ScheduledTeumDetailResponseDto.builder()
+                .teumId(baseSchedule.getTeumRequest().getId())
+                .title(baseSchedule.getTitle())
+                .date(baseSchedule.getDate().toString())
+                .startTime(baseSchedule.getStartTime().toLocalTime().toString())
+                .endTime(baseSchedule.getEndTime().toLocalTime().toString())
+                .status(baseSchedule.getStatus())
+                .participants(relatedSchedules.stream()
+                        .map(s -> {
+                            var u = s.getUser();
+                            String presignedUrl = s3Util.toPresignedUrl(u.getProfileImageKey(), Duration.ofMinutes(30));
+                            return new ParticipantDto(u.getId(), u.getNickname(), presignedUrl);
+                        })
+                        .collect(Collectors.toList()))
+                .build();
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/schedule/ScheduledTeumDetailResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/schedule/ScheduledTeumDetailResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class ScheduledTeumDetailResponseDto {
     @Schema(description = "종료 시간", example = "00:00")
     private String endTime;
 
+    @Schema(description = "스케줄 상태", example = "ACTIVE")
+    private ScheduleStatus status;
+
     @Schema(description = "참여자 목록")
     private List<ParticipantDto> participants;
-
-    @Schema(description = "이미 지난 틈 여부", example = "false")
-    private boolean isPast;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
@@ -12,7 +12,8 @@ public enum TeumErrorStatus implements BaseErrorCode {
 
     TEUM_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "TEUM4040", "존재하지 않는 틈 요청입니다."),
     TEUM_RESPONSE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEUM4041", "존재하지 않는 틈 응답입니다."),
-    USER_NOT_ELIGIBLE(HttpStatus.FORBIDDEN, "TEUM4030", "요청 또는 응답에 대한 권한이 없습니다."),
+    TEUM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEUM4042", "약속된 틈이 존재하지 않습니다."),
+    USER_NOT_ELIGIBLE(HttpStatus.FORBIDDEN, "TEUM4030", "정보에 대한 권한이 없습니다."),
     INVALID_TEUM_TIME(HttpStatus.BAD_REQUEST, "TEUM4001", "시작 시간과 종료 시간이 유효하지 않습니다."),
     DUPLICATE_RECEIVER(HttpStatus.CONFLICT, "TEUM4090", "수신자 목록에 중복된 사용자가 포함되어 있습니다."),
     CANNOT_REQUEST_SELF(HttpStatus.CONFLICT, "TEUM4091", "자기 자신에게 틈 요청을 보낼 수 없습니다."),

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -29,7 +29,7 @@ public interface TeumService {
 
     List<ScheduledTeumResponseDto> getScheduledTeums(Long userId, String date);
 
-    ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long teumId, Long userId);
+    ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long scheduleId, Long userId);
 
     ScheduledTeumExitResponseDto exitScheduledTeum(Long teumId, Long userId);
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.teum.converter.TeumConverter;
 import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeRequestDto;
@@ -28,8 +29,10 @@ import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
 import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
+import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.DayOfWeek;
@@ -169,10 +172,16 @@ public class TeumServiceImpl implements TeumService {
         return List.of();
     }
 
-    @Override
-    public ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long teumId, Long userId) {
-        // TODO: 약속된 틈 상세 조회 로직 추후 구현
-        return null;
+    public ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long scheduleId, Long userId) {
+        Schedule schedule = getScheduleOrThrow(scheduleId);
+        validateScheduleAccessible(schedule, userId);
+
+        List<Schedule> relatedSchedules = scheduleRepository.findByTeumRequestAndStatusIn(
+                schedule.getTeumRequest(),
+                List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
+        );
+
+        return TeumConverter.toScheduledTeumDetailDto(schedule, relatedSchedules, s3Util);
     }
 
     @Override
@@ -247,9 +256,54 @@ public class TeumServiceImpl implements TeumService {
         return null;
     }
 
+    /**
+     * 주어진 ID에 해당하는 User를 조회합니다.
+     * - User 객체 자체가 필요한 경우에 사용합니다.
+     * - 존재하지 않으면 예외를 던집니다.
+     */
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE));
+    }
+
+    /**
+     * 주어진 ID에 해당하는 User가 존재하는지만 확인합니다.
+     * - 객체 자체가 필요하지 않고, 존재 여부만 확인할 때 사용합니다.
+     * - 존재하지 않으면 예외를 던집니다.
+     */
+    private void validateUserExists(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new GlobalHandler(UserErrorStatus.USER_NOT_FOUND);
+        }
+    }
+
+    private void validateScheduleAccessible(Schedule schedule, Long userId) {
+        validateScheduleOwner(schedule, userId);
+        validateScheduleTypeIsTeum(schedule);
+        validateScheduleStatusValid(schedule);
+    }
+
+    private void validateScheduleOwner(Schedule schedule, Long userId) {
+        if (!schedule.getUser().getId().equals(userId)) {
+            throw new GlobalHandler(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
+    }
+
+    private void validateScheduleTypeIsTeum(Schedule schedule) {
+        if (schedule.getType() != ScheduleType.TEUM) {
+            throw new GlobalHandler(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND);
+        }
+    }
+
+    private void validateScheduleStatusValid(Schedule schedule) {
+        if (!(schedule.getStatus() == ScheduleStatus.ACTIVE || schedule.getStatus() == ScheduleStatus.COMPLETED)) {
+            throw new GlobalHandler(TeumErrorStatus.TEUM_SCHEDULE_NOT_FOUND);
+        }
+    }
+
+    private Schedule getScheduleOrThrow(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+            .orElseThrow(() -> new GlobalHandler(TeumErrorStatus.TEUM_SCHEDULE_NOT_FOUND));
     }
 
     private TeumResponse getResponseOrThrow(Long responseId) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -291,7 +291,7 @@ public class TeumServiceImpl implements TeumService {
 
     private void validateScheduleTypeIsTeum(Schedule schedule) {
         if (schedule.getType() != ScheduleType.TEUM) {
-            throw new GlobalHandler(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND);
+            throw new GlobalHandler(TeumErrorStatus.TEUM_SCHEDULE_NOT_FOUND);
         }
     }
 

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -18,15 +18,21 @@ public class S3Util {
     private final S3Presigner s3Presigner;
 
     public String toPresignedUrl(String key, Duration duration) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-            .bucket(bucketName)
-            .key(key).build();
+                .bucket(bucketName)
+                .key(key)
+                .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-            .signatureDuration(duration)
-            .getObjectRequest(getObjectRequest)
-            .build();
+                .signatureDuration(duration)
+                .getObjectRequest(getObjectRequest)
+                .build();
 
         return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
+
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#73 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 약속된 틈 상세조회 API 구현 (`GET /api/teums/scheduled/{teumId}`)
- 로그인 유저의 스케줄 여부 검증
- Schedule.status 기반 조건 필터링 (ACTIVE | COMPLETED)
- 참여자 목록 응답 포함 (본인 포함)
- 프로필 이미지 presigned URL 발급 처리
- `status` 필드 응답에 추가 (`isPast` 제거)
- 예외 메시지 및 성공 메시지 수정

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 개발용 액세스 토큰 발급으로 생기는 유저는 `profileImageKey == null` 상태이므로 null-safe presigned 처리 적용함

### 📷 테스트

#### 약속된 틈 상세 조회
```json
{
  "isSuccess": true,
  "code": "TEUM2009",
  "message": "약속된 틈 상세 정보가 조회되었습니다.",
  "result": {
    "teumId": 100,
    "title": "스터디 모임",
    "date": "2025-07-26",
    "startTime": "14:00",
    "endTime": "15:00",
    "status": "ACTIVE",
    "participants": [
      {
        "userId": 1,
        "nickname": null,
        "profileImageUrl": null
      },
      {
        "userId": 2,
        "nickname": "응답자",
        "profileImageUrl": null
      }
    ]
  }
}
```

#### 존재하지 않은 약속된 틈
1. 스케줄 아이디 자체가 없음
2. TEUM 타입이 아님
3. CANCELLED 상태임
```json
{
  "isSuccess": false,
  "code": "TEUM4042",
  "message": "약속된 틈이 존재하지 않습니다."
}
```

#### 본인의 스케줄이 아닌 경우
```json
{
  "isSuccess": false,
  "code": "TEUM4030",
  "message": "권한이 없습니다."
}
```
> https://excessive-pedestrian-954.notion.site/22666802aaae8059a8ccd7aaa559a76c
테스트용 DDL은 API 명세서에 포함되어 있습니다.