### PR TITLE
Feat : 마이페이지 화면 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
+import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.exception.status.UserSuccessStatus;
@@ -85,10 +86,11 @@ public class UserController {
         description = "사용자의 프로필, 이름, 직업 분야, 아이디 등 마이페이지에 필요한 정보를 조회합니다."
     )
     @GetMapping(value = "/mypage", produces = "application/json")
-    public ApiResponse<Object> getMypageInfo(
+    public ApiResponse<UserResponseDTO.MyPageDTO> getMypageInfo(
+        @Parameter(hidden = true) @CurrentUser User user
     ) {
-        // TODO: 마이페이지 화면(프로필,이름,직업분야, 내 아이디) 조회 로직 구현
-        return null;
+        UserResponseDTO.MyPageDTO response = userService.getMyPage(user);
+        return ApiResponse.of(UserSuccessStatus._USER_FOUND, response);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.domain.user.converter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
@@ -21,5 +22,15 @@ public class UserConverter {
                 s3Util.toPresignedUrl(user.getProfileImageKey(), Duration.ofMinutes(30)),
                 user.getJob()
         );
+    }
+
+    public static UserResponseDTO.MyPageDTO toMyPageDTO(User user, String profileImageUrl) {
+        return UserResponseDTO.MyPageDTO.builder()
+            .userId(user.getId())
+            .nickname(user.getNickname())
+            .profileImageUrl(profileImageUrl)
+            .job(user.getJob())
+            .build();
+
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -1,4 +1,26 @@
 package umc.teumteum.server.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class UserResponseDTO {
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class MyPageDTO {
+    @Schema(description = "유저 ID", example = "1")
+    private Long userId;
+    @Schema(description = "닉네임", example = "고냐니")
+    private String nickname;
+    @Schema(description = "프로필 이미지 URL", example = "https://~")
+    private String profileImageUrl;
+    @Schema(description = "직종/분야", example = "개발자")
+    private String job;
+
+
+  }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDTO;
+import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -28,4 +29,6 @@ public interface UserService {
     void saveAgreement(UserRequestDTO.AgreeRequest request, User user);
 
     void saveNicknameAndJob(UserRequestDTO.NicknameJobRequest request, User user);
+
+    UserResponseDTO.MyPageDTO getMyPage(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.user.service;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import umc.teumteum.server.domain.user.converter.AgreementConverter;
 import umc.teumteum.server.domain.user.converter.UserConverter;
 import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDTO;
+import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
 import umc.teumteum.server.domain.user.entity.User;
@@ -21,6 +23,7 @@ import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 
 import java.util.*;
+import umc.teumteum.server.global.util.S3Util;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +33,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final AgreementRepository agreementRepository;
     private final RemindAlarmRepository remindAlarmRepository;
+    private final S3Util s3Util;
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -169,6 +173,12 @@ public class UserServiceImpl implements UserService {
 
         // 3. 닉네임과 분야/직종 수정
         user.updateNicknameAndJob(request.getNickname(), request.getJobField());
+    }
+
+    @Override
+    public UserResponseDTO.MyPageDTO getMyPage(User user) {
+        String profileImageUrl = s3Util.toPresignedUrl(user.getProfileImageKey(), Duration.ofMinutes(30));
+        return UserConverter.toMyPageDTO(user, profileImageUrl);
     }
 
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#75 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
마이페이지에서 프로필, 이름, 직업, 유저의 아이디를 조회하는 API를 구현하였습니다.
UserServiceImpl에 마이페이지 화면 조회 로직을 추가하였습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
X

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   마이페이지 조회 API   | <img width="1214" height="273" alt="스크린샷 2025-07-23 오후 4 17 39" src="https://github.com/user-attachments/assets/9c2f5f8e-0999-4d43-8eb5-6a06da1979c7" />
   |