### PR TITLE
Feat : 위시 투두 등록 기능 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
@@ -9,12 +9,15 @@ import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
 import umc.teumteum.server.domain.home.dto.response.TodoIdResponseDTO;
 import umc.teumteum.server.domain.home.dto.response.TodoInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.TodyTeumResponseDTO;
+import umc.teumteum.server.domain.home.dto.response.TodayScheduleResponseDTO;
 import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
 import umc.teumteum.server.domain.home.service.HomeService;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,11 +34,12 @@ public class HomeController {
     }
 
     @GetMapping(value = "/today", produces = "application/json")
-    @Operation(summary = "오늘의 빈틈 조회 API",description = "오늘의 빈틈 시간을 조회하는 API입니다. query string으로 am 또는 pm을 입력주세요.")
-    public ApiResponse<TodyTeumResponseDTO> getTodayTeum(
-            @Parameter(name = "period", description = "조회 시간대 (오전: am, 오후: pm)", example = "am")
-            @RequestParam("period") String period){
-        return ApiResponse.onSuccess(null);
+    @Operation(summary = "오늘의 빈틈 조회 API",description = "오늘의 빈틈 시간을 조회하는 API입니다. query string으로 오늘 날짜를 입력해주세요.")
+    public ApiResponse<List<TodayScheduleResponseDTO>> getTodayTeum(
+            @Parameter(name = "date", description = "조회할 날짜", example = "2025-07-24") @RequestParam("date") LocalDate date,
+            @CurrentUser @Parameter(hidden = true) User user){
+        List<TodayScheduleResponseDTO> response = homeService.getTodaySchedule(date,user);
+        return ApiResponse.of(HomeSuccessStatus._TODAY_SCHEDULE,response);
     }
 
     @GetMapping(value = "/calendar", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
@@ -33,7 +33,7 @@ public class HomeController {
         return ApiResponse.onSuccess(null);
     }
 
-    @GetMapping(value = "/today", produces = "application/json")
+    @GetMapping(value = "/teum", produces = "application/json")
     @Operation(summary = "오늘의 빈틈 조회 API",description = "오늘의 빈틈 시간을 조회하는 API입니다. query string으로 오늘 날짜를 입력해주세요.")
     public ApiResponse<List<TodayScheduleResponseDTO>> getTodayTeum(
             @Parameter(name = "date", description = "조회할 날짜", example = "2025-07-24") @RequestParam("date") LocalDate date,

--- a/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/WishController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.home.dto.request.WishAssignRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.response.WishInfoResponseDTO;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
@@ -88,8 +89,11 @@ public class WishController {
     @PostMapping(value = "/{wishId}/assign", consumes = "application/json", produces = "application/json")
     @Operation(summary = "위시 투두 등록 API",description = "위시를 투두로 등록하는 API입니다.")
     public ApiResponse<String> assignWish(
-            @Parameter(name= "wishId", description = "투두로 등록할 위시 ID", example = "123") @PathVariable("wishId") Long wishId){
-        return ApiResponse.onSuccess(null);
+            @Parameter(name= "wishId", description = "투두로 등록할 위시 ID", example = "123") @PathVariable("wishId") Long wishId,
+            @RequestBody @Valid WishAssignRequestDTO request,
+            @CurrentUser @Parameter(hidden = true) User user){
+        homeService.assignWish(wishId, request, user);
+        return ApiResponse.of(HomeSuccessStatus._WISH_ASSIGNED,null);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -2,9 +2,12 @@ package umc.teumteum.server.domain.home.converter;
 
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
+import umc.teumteum.server.domain.home.dto.request.WishAssignRequestDTO;
+import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
 import umc.teumteum.server.domain.home.dto.response.TodoInfoResponseDTO;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
+import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -56,6 +59,19 @@ public class ScheduleConverter {
                         .map(ScheduleReminder::getReminderTime)
                         .toList())
                 .profileUrl(profileUrls)
+                .build();
+    }
+
+    // Wish -> Schedule entity
+    public Schedule toScheduleFromWish(Wish wish, WishAssignRequestDTO dto) {
+        return Schedule.builder()
+                .user(wish.getUser())
+                .title(wish.getTitle())
+                .description(wish.getContent())
+                .type(ScheduleType.WISH)
+                .date(dto.getDate())
+                .startTime(LocalDateTime.of(dto.getDate(), dto.getStartTime()))
+                .endTime(LocalDateTime.of(dto.getDate(), dto.getEndTime()))
                 .build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/WishAssignRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/WishAssignRequestDTO.java
@@ -1,0 +1,33 @@
+package umc.teumteum.server.domain.home.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "WishAssignRequestDTO : 위시 투두 등록 요청 DTO")
+public class WishAssignRequestDTO {
+
+    @NotNull
+    @Schema(description = "날짜", example = "2025-07-24")
+    private LocalDate date;
+
+    @NotNull
+    @Schema(description = "시작시간", example = "09:00")
+    private LocalTime startTime;
+
+    @NotNull
+    @Schema(description = "종료시간", example = "10:00")
+    private LocalTime endTime;
+
+    @NotNull
+    @Schema(description = "강제 등록 여부", example = "false")
+    private Boolean isForce;
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/TodayScheduleResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/TodayScheduleResponseDTO.java
@@ -1,0 +1,28 @@
+package umc.teumteum.server.domain.home.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(title = "TeumResponse : 빈틈시간 조회 응답 DTO")
+public class TodayScheduleResponseDTO {
+
+    @Schema(description = "시작 시간", example = "10:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "10:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime endTime;
+
+    @Schema(description = "타입", example = "TODO | SLEEP | EMPTY")
+    private String type;
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/TodyTeumResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/TodyTeumResponseDTO.java
@@ -1,4 +1,0 @@
-package umc.teumteum.server.domain.home.dto.response;
-
-public class TodyTeumResponseDTO {
-}

--- a/src/main/java/umc/teumteum/server/domain/home/entity/enums/ScheduleType.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/enums/ScheduleType.java
@@ -5,5 +5,6 @@ public enum ScheduleType {
     WISH,     // 위시
     TEUM,     // 틈
     ROUTINE,  // 반복일정
-    AI        // AI 추천
+    AI,       // AI 추천
+    SLEEP     // 수면패턴
 }

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -14,7 +14,8 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
     _WISH_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4043","해당 위시 정보를 찾을 수 없습니다."),
-    _WISH_CONFLICT(HttpStatus.CONFLICT, "HOME4091","이미 동일한 위시가 존재합니다.")
+    _WISH_CONFLICT(HttpStatus.CONFLICT, "HOME4091","이미 동일한 위시가 존재합니다."),
+    _SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "HOME4092","해당 시간에 스케줄이 존재합니다.")
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.domain.home.exception.status;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 import umc.teumteum.server.global.apiPayload.code.BaseCode;
 import umc.teumteum.server.global.apiPayload.code.ReasonDto;
@@ -19,7 +20,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _WISH_DELETED(HttpStatus.OK, "HOME2007","위시가 성공적으로 삭제되었습니다."),
     _WISH_UPDATED(HttpStatus.OK, "HOME2008", "위시 정보가 성공적으로 수정되었습니다."),
     _WISHLIST_LOADED(HttpStatus.OK, "HOME2009", "위시리스트가 성공적으로 조회되었습니다."),
-    _TODAY_SCHEDULE(HttpStatus.OK, "HOME20010", "오늘의 스케줄가 성공적으로 조회되었습니다.")
+    _TODAY_SCHEDULE(HttpStatus.OK, "HOME20010", "오늘의 스케줄가 성공적으로 조회되었습니다."),
+    _WISH_ASSIGNED(HttpStatus.OK, "HOME20011","선택된 위시가 투두로 등록되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -18,7 +18,9 @@ public enum HomeSuccessStatus implements BaseCode {
     _WISH_LOADED(HttpStatus.OK, "HOME2006","위시 정보가 성공적으로 조회되었습니다."),
     _WISH_DELETED(HttpStatus.OK, "HOME2007","위시가 성공적으로 삭제되었습니다."),
     _WISH_UPDATED(HttpStatus.OK, "HOME2008", "위시 정보가 성공적으로 수정되었습니다."),
-    _WISHLIST_LOADED(HttpStatus.OK, "HOME2009", "위시리스트가 성공적으로 조회되었습니다.");
+    _WISHLIST_LOADED(HttpStatus.OK, "HOME2009", "위시리스트가 성공적으로 조회되었습니다."),
+    _TODAY_SCHEDULE(HttpStatus.OK, "HOME20010", "오늘의 스케줄가 성공적으로 조회되었습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -12,7 +12,6 @@ import umc.teumteum.server.domain.user.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -78,6 +77,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     boolean existsByUserAndDateAndRoutineAndIsDeletedTrue(User user, LocalDate today, Routine routine);
 
+    List<Schedule> findByUserAndDateAndIsDeletedFalseOrderByStartTime(User user, LocalDate date);
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.user.entity.Routine;
+import umc.teumteum.server.domain.user.entity.User;
 
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -72,6 +75,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("teumRequest") TeumRequest teumRequest,
             @Param("statuses") List<ScheduleStatus> statuses
     );
+
+    boolean existsByUserAndDateAndRoutineAndIsDeletedTrue(User user, LocalDate today, Routine routine);
+
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -3,11 +3,11 @@ package umc.teumteum.server.domain.home.service;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
-import umc.teumteum.server.domain.home.dto.response.TodoIdResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.TodoInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.WishlistResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.WishInfoResponseDTO;
+import umc.teumteum.server.domain.home.dto.response.*;
 import umc.teumteum.server.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface HomeService {
     // Todo 등록
@@ -36,4 +36,7 @@ public interface HomeService {
 
     // Wishlist 조회
     WishlistResponseDTO getWishlist(String duration, Integer page, User user);
+
+    // 오늘의 시간표 조회
+    List<TodayScheduleResponseDTO> getTodaySchedule(LocalDate today, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.service;
 
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
+import umc.teumteum.server.domain.home.dto.request.WishAssignRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
 import umc.teumteum.server.domain.home.dto.response.*;
@@ -39,4 +40,7 @@ public interface HomeService {
 
     // 오늘의 시간표 조회
     List<TodayScheduleResponseDTO> getTodaySchedule(LocalDate today, User user);
+
+    // Wish 투두 등록
+    void assignWish(Long wishId, WishAssignRequestDTO dto, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.converter.ScheduleConverter;
 import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
+import umc.teumteum.server.domain.home.dto.request.WishAssignRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
 import umc.teumteum.server.domain.home.dto.response.*;
@@ -34,6 +35,7 @@ import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -348,5 +350,33 @@ public class HomeServiceImpl implements HomeService {
         }
 
         return result;
+    }
+
+    @Override
+    public void assignWish(Long wishId, WishAssignRequestDTO dto, User user) {
+        // 위시 투두 등록
+
+        // 1. 위시 조회
+        Wish wish = wishRepository.findById(wishId)
+                .orElseThrow(() -> new HomeException(HomeErrorStatus._WISH_NOT_FOUND));
+
+        // 2. 중복 스케줄 체크
+        LocalDate date = dto.getDate();
+        LocalDateTime startTime = LocalDateTime.of(date,dto.getStartTime());
+        LocalDateTime endTime = LocalDateTime.of(date,dto.getEndTime());
+
+        boolean hasConflict = scheduleRepository.existsConflictSchedule(
+                user.getId(), date, startTime, endTime
+        );
+
+        if (hasConflict && !dto.getIsForce()) {
+            // force가 false고 일정이 겹치면 예외
+            throw new HomeException(HomeErrorStatus._SCHEDULE_CONFLICT);
+        }
+
+        // 3. 스케줄 생성 & 위시 삭제
+        Schedule schedule = scheduleConverter.toScheduleFromWish(wish,dto);
+        scheduleRepository.save(schedule);
+        wishRepository.delete(wish);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -12,10 +12,7 @@ import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDTO;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDTO;
-import umc.teumteum.server.domain.home.dto.response.TodoIdResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.TodoInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.WishInfoResponseDTO;
-import umc.teumteum.server.domain.home.dto.response.WishlistResponseDTO;
+import umc.teumteum.server.domain.home.dto.response.*;
 import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
@@ -36,6 +33,8 @@ import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -288,5 +287,66 @@ public class HomeServiceImpl implements HomeService {
                 wishes.isFirst(),
                 wishes.isLast()
         );
+    }
+
+    @Override
+    public List<TodayScheduleResponseDTO> getTodaySchedule(LocalDate today, User user) {
+        // 오늘의 시간표 조회
+        List<TodayScheduleResponseDTO> sleepAndTodo = new ArrayList<>(); // 수면패턴과 투두를 등록한 배열
+
+        // 1. 수면 패턴 등록
+        LocalTime sleepTime = user.getSleepTime();
+        LocalTime wakeTime = user.getWakeTime();
+
+        if(sleepTime != null && wakeTime != null){
+            if(sleepTime.isAfter(wakeTime)){
+                // 자정 이전에 자는 경우
+                sleepAndTodo.add(new TodayScheduleResponseDTO(LocalTime.MIDNIGHT,wakeTime,"SLEEP"));
+                sleepAndTodo.add(new TodayScheduleResponseDTO(sleepTime,LocalTime.of(23,59),"SLEEP"));
+            } else{
+                // 자정 이후에 자는 경우
+                sleepAndTodo.add(new TodayScheduleResponseDTO(sleepTime,wakeTime,"SLEEP"));
+            }
+        }
+
+        // 2. 스케줄 정보 등록
+        List<Schedule> schedules = scheduleRepository.findByUserAndDateAndIsDeletedFalseOrderByStartTime(user, today);
+
+        for (Schedule schedule : schedules) {
+            sleepAndTodo.add(TodayScheduleResponseDTO.builder()
+                    .startTime(schedule.getStartTime().toLocalTime())
+                    .endTime(schedule.getEndTime().toLocalTime())
+                    .type("TODO")
+                    .build());
+        }
+
+        // 4. sleepAndTodo startTime 기준 정렬
+        sleepAndTodo.sort(Comparator.comparing(TodayScheduleResponseDTO::getStartTime));
+
+        // 4. EMPTY 채우기
+        List<TodayScheduleResponseDTO> result = new ArrayList<>(); // 응답 배열
+        LocalTime pointer = LocalTime.MIDNIGHT;
+
+        for (TodayScheduleResponseDTO dto : sleepAndTodo) {
+
+            if (pointer.isBefore(dto.getStartTime())) {
+                // 빈틈이 존재하면 EMPTY 추가
+                result.add(new TodayScheduleResponseDTO(pointer, dto.getStartTime(), "EMPTY"));
+            }
+
+            result.add(dto);
+
+            if (dto.getEndTime().isAfter(pointer)) {
+                // 포인터 뒤에 일정이 있다면 포인터 갱신
+                pointer = dto.getEndTime();
+            }
+        }
+
+        // 5. 남은 시간 마지막 EMPTY 채우기
+        if (pointer.isBefore(LocalTime.of(23,59))) {
+            result.add(new TodayScheduleResponseDTO(pointer, LocalTime.of(23,59), "EMPTY"));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -2,6 +2,12 @@ package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.Routine;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+
+import java.util.Date;
+import java.util.List;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    List<Routine> findByUserAndWeekday(User user, Weekday weekday);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.user.entity.Routine;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+}

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 
 import java.util.Optional;
 import java.util.List;
@@ -18,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    List<User> findByStatus(UserStatus status);
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
@@ -31,35 +31,16 @@ public class ScheduleGeneratorScheduler {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 //    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
     public void schedule() {
-        log.info("[00:00] 반복일정, 수면패턴 스케줄 테이블에 등록 시작");
+        log.info("[00:00] 반복일정 스케줄 테이블에 등록 시작");
 
         List<User> users = userRepository.findByStatus(UserStatus.ACTIVE);
 
         LocalDate today = LocalDate.now();
-        LocalDate tomorrow = today.plusDays(1);
 
         for (User user : users) {
             List<Schedule> schedulesToInsert = new ArrayList<>();
             /**
-             * 1. user 테이블의 수면 등록
-             * 등록해야할 정보
-             * user, title(YYYY-MM-DD 수면패턴), type=SLEEP,
-             * date(YYYY-MM-DD), startTime(오늘날짜 + user.sleep_time), endTime(오늘날짜+1 + + user.wake_time)
-             */
-
-            Schedule sleepSchedule = Schedule.builder()
-                    .user(user)
-                    .title(today + " 수면패턴")
-                    .type(ScheduleType.SLEEP)
-                    .date(today)
-                    .startTime(LocalDateTime.of(today, user.getSleepTime()))
-                    .endTime(LocalDateTime.of(tomorrow, user.getWakeTime()))
-                    .build();
-
-            schedulesToInsert.add(sleepSchedule);
-
-            /**
-             * 2. routine 테이블의 반복일정 등록
+             * routine 테이블의 반복일정 등록
              * 조회방식: 오늘요일 = routine.weekday
              * 이미 스케줄 테이블에 삭제된 루틴으로 저장된 경우 스킵
              * 등록해야할 정보

--- a/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
@@ -1,0 +1,94 @@
+package umc.teumteum.server.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.user.entity.Routine;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleGeneratorScheduler {
+
+    private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final RoutineRepository routineRepository;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
+    public void schedule() {
+        log.info("[00:00] 반복일정, 수면패턴 스케줄 테이블에 등록 시작");
+
+        List<User> users = userRepository.findByStatus(UserStatus.ACTIVE);
+
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+
+        for (User user : users) {
+            List<Schedule> schedulesToInsert = new ArrayList<>();
+            /**
+             * 1. user 테이블의 수면 등록
+             * 등록해야할 정보
+             * user, title(YYYY-MM-DD 수면패턴), type=SLEEP,
+             * date(YYYY-MM-DD), startTime(오늘날짜 + user.sleep_time), endTime(오늘날짜+1 + + user.wake_time)
+             */
+
+            Schedule sleepSchedule = Schedule.builder()
+                    .user(user)
+                    .title(today + " 수면패턴")
+                    .type(ScheduleType.SLEEP)
+                    .date(today)
+                    .startTime(LocalDateTime.of(today, user.getSleepTime()))
+                    .endTime(LocalDateTime.of(tomorrow, user.getWakeTime()))
+                    .build();
+
+            schedulesToInsert.add(sleepSchedule);
+
+            /**
+             * 2. routine 테이블의 반복일정 등록
+             * 조회방식: 오늘요일 = routine.weekday
+             * 이미 스케줄 테이블에 삭제된 루틴으로 저장된 경우 스킵
+             * 등록해야할 정보
+             * user, routine, title = routine.title, description = routine.description, type=ROUTINE,
+             * date(YYYY-MM-DD), startTime(오늘날짜 + routine.startTIme), endTIme(오늘날짜 + routine.endTime)
+             */
+
+            Weekday todayWeekday = Weekday.valueOf(today.getDayOfWeek().name());
+            List<Routine> routines = routineRepository.findByUserAndWeekday(user, todayWeekday);
+
+            for (Routine routine : routines) {
+                // 삭제된 반복일정이라면 스킵
+                boolean deletedRoutine = scheduleRepository.existsByUserAndDateAndRoutineAndIsDeletedTrue(user, today, routine);
+                if (deletedRoutine) continue;
+
+                Schedule routineSchedule = Schedule.builder()
+                        .user(user)
+                        .routine(routine)
+                        .title(routine.getTitle())
+                        .description(routine.getDescription())
+                        .type(ScheduleType.ROUTINE)
+                        .date(today)
+                        .startTime(LocalDateTime.of(today, routine.getStartTime()))
+                        .endTime(LocalDateTime.of(today, routine.getEndTime()))
+                        .build();
+                schedulesToInsert.add(routineSchedule);
+            }
+            scheduleRepository.saveAll(schedulesToInsert);
+        }
+        log.info("[00:00] 총 {}명의 유저에 대해 스케줄 생성 완료", users.size());
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#70 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

- 반복일정 등록 스케줄러
   - 빈틈 시간을 조회하기 앞서 오늘의 일정을 등록할 수 있는 스케줄러가 필요하다고 판단하여 스케줄러를 먼저 구현했습니다.
   - 매일 0시에 반복일정을 스케줄 테이블로 등록하는 스케줄러 구현했습니다.
- 위시 투두 등록 가능 시간 조회
    - startTime을 기준으로 정렬하여 각 시간 블록을 SLEEP, TODO, EMPTY(비어있는시간)으로 구분하여 반환하는 구조로 설계했습니다.
- 위시 투두 등록
   - 사용자가 위시를 투두로 등록할 때 기존 스케줄과 시간이 겹칠 수 있기 때문에 겹치는 등록을 허용할지 여부를 판단할 수 있도록 isForce 플래그를 도입했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- GET /api/home/teum?date={YYYY-MM-DD}
     - https://excessive-pedestrian-954.notion.site/22566802aaae81e89ab5e9f779cc3554
- POST /api/wishes/{wishId}/assign
    - https://excessive-pedestrian-954.notion.site/22966802aaae80708294df768604a784?pvs=74e

error status와 requese, response body는 노션을 참고해주세요.

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
화면설계서와 api 명세서를 검토해보니 위시 가능 시간 조회 API를 홈에서 사용하는 빈틈 시간 조회 API를 재활용해도 될 것 같다는 생각이 들었습니다. 처음에 위시 가능 시간 조회 api는 available time이 필요하다는 이유로 별도의 api로 분리하였는데, 위시 등록하는 과정에도 홈과 동일한 시간표가 함께 노출되어야한다는 점을 확인하지 못했습니다..🥲
/api/home/teum?date={YYYY-MM-DD}로 통일하고 해당 api 개발하였습니다.

### 📷 스크린샷 또는 GIF
X