### PR TITLE
Feat: 특정 날짜의 약속된 틈 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -73,6 +73,18 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("statuses") List<ScheduleStatus> statuses
     );
 
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.date = :date
+      AND s.status IN :statuses
+      AND s.isDeleted = false
+""")
+    List<Schedule> findByUserIdAndDateAndStatusIn(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("statuses") List<ScheduleStatus> statuses
+    );
 
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -158,9 +158,11 @@ public class TeumController {
     @GetMapping(value = "/scheduled", produces = "application/json")
     public ApiResponse<List<ScheduledTeumResponseDto>> getScheduledTeums(
             @Parameter(description = "조회할 날짜 (YYYY-MM-DD)", example = "2025-05-02")
-            @RequestParam("date") String date
+            @RequestParam("date") String date,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        return ApiResponse.onSuccess(null);
+        List<ScheduledTeumResponseDto> result = teumService.getScheduledTeums(user.getId(), date);
+        return ApiResponse.of(TeumSuccessStatus._SCHEDULED_LIST_LOADED, result);
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -7,6 +7,7 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
+import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumReceivedResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumRequestDto;
 import umc.teumteum.server.domain.teum.dto.teum.TeumResendRequestDto;
@@ -234,5 +235,18 @@ public class TeumConverter {
                         .collect(Collectors.toList()))
                 .build();
     }
+
+    public static ScheduledTeumResponseDto toScheduledTeumResponseDto(Schedule schedule) {
+        return ScheduledTeumResponseDto.builder()
+                .teumId(schedule.getId())
+                .title(schedule.getTitle())
+                .date(schedule.getDate().toString())
+                .time(List.of(new TimeSlot(
+                        schedule.getStartTime().toLocalTime().toString(),
+                        schedule.getEndTime().toLocalTime().toString()
+                )))
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/schedule/ScheduledTeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/schedule/ScheduledTeumResponseDto.java
@@ -5,6 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -22,9 +25,6 @@ public class ScheduledTeumResponseDto {
     @Schema(description = "날짜", example = "YYYY-MM-DD")
     private String date;
 
-    @Schema(description = "시작 시간", example = "00:00")
-    private String startTime;
-
-    @Schema(description = "종료 시간", example = "00:00")
-    private String endTime;
+    @Schema(description = "시간대")
+    private List<TimeSlot> time;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -167,10 +167,28 @@ public class TeumServiceImpl implements TeumService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ScheduledTeumResponseDto> getScheduledTeums(Long userId, String date) {
-        // TODO: 특정 날짜의 약속된 틈 조회 로직 추후 구현
-        return List.of();
+        LocalDate targetDate = LocalDate.parse(date);
+
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatusIn(
+                userId,
+                targetDate,
+                List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
+        );
+
+        if (schedules.isEmpty()) {
+            throw new GeneralException(TeumErrorStatus.TEUM_SCHEDULE_NOT_FOUND);
+        }
+
+        return schedules.stream()
+                .map(schedule -> {
+                    validateScheduleAccessible(schedule, userId);
+                    return TeumConverter.toScheduledTeumResponseDto(schedule);
+                })
+                .toList();
     }
+
 
     public ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long scheduleId, Long userId) {
         Schedule schedule = getScheduleOrThrow(scheduleId);

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -184,11 +184,7 @@ public class TeumServiceImpl implements TeumService {
         }
 
         return teumSchedules.stream()
-                .map(schedule -> {
-                    validateScheduleOwner(schedule, userId);
-                    validateScheduleStatusValid(schedule);
-                    return TeumConverter.toScheduledTeumResponseDto(schedule);
-                })
+                .map(TeumConverter::toScheduledTeumResponseDto)
                 .toList();
 
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -171,24 +171,27 @@ public class TeumServiceImpl implements TeumService {
     public List<ScheduledTeumResponseDto> getScheduledTeums(Long userId, String date) {
         LocalDate targetDate = LocalDate.parse(date);
 
-        List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatusIn(
-                userId,
-                targetDate,
-                List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
+        List<Schedule> allSchedules = scheduleRepository.findByUserIdAndDateAndStatusIn(
+                userId, targetDate, List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
         );
 
-        if (schedules.isEmpty()) {
+        List<Schedule> teumSchedules = allSchedules.stream()
+                .filter(schedule -> schedule.getType() == ScheduleType.TEUM)
+                .toList();
+
+        if (teumSchedules.isEmpty()) {
             throw new GeneralException(TeumErrorStatus.TEUM_SCHEDULE_NOT_FOUND);
         }
 
-        return schedules.stream()
+        return teumSchedules.stream()
                 .map(schedule -> {
-                    validateScheduleAccessible(schedule, userId);
+                    validateScheduleOwner(schedule, userId);
+                    validateScheduleStatusValid(schedule);
                     return TeumConverter.toScheduledTeumResponseDto(schedule);
                 })
                 .toList();
-    }
 
+    }
 
     public ScheduledTeumDetailResponseDto getScheduledTeumDetail(Long scheduleId, Long userId) {
         Schedule schedule = getScheduleOrThrow(scheduleId);


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#85 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `/api/teums/scheduled?date=YYYY-MM-DD` API 구현
- 로그인한 사용자의 해당 날짜 TEUM 일정 조회
- `Schedule.type != TEUM`, `Schedule.status ∉ [ACTIVE, COMPLETED]` 등 유효성 검사 포함
- 다른 타입의 일정이 섞여 있어도 `TEUM` 일정만 필터링하여 반환

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 유효한 TEUM 일정이 없을 경우 TEUM_SCHEDULE_NOT_FOUND 예외 발생

### 📷 테스트 결과
> DML은 API 명세서에 작성되어 있습니다.

#### 해당 날짜의 약속된 틈 목록 조회 성공
```Json
{
  "isSuccess": true,
  "code": "TEUM2008",
  "message": "지정한 날짜의 약속된 틈 목록이 조회되었습니다.",
  "result": [
    {
      "teumId": 201,
      "title": "스터디 준비",
      "date": "2025-07-25",
      "time": [
        {
          "start": "14:00",
          "end": "15:00"
        }
      ]
    },
    {
      "teumId": 206,
      "title": "사이드 프로젝트 킥오프",
      "date": "2025-07-25",
      "time": [
        {
          "start": "19:00",
          "end": "20:00"
        }
      ]
    }
  ]
}
```
#### 예외 처리
```json
{
  "isSuccess": false,
  "code": "TEUM4042",
  "message": "약속된 틈이 존재하지 않습니다."
}
```
1. 스케줄이 아예 없는 날짜일 때
2. 조건에 맞는 스케줄(약속된 틈)이 없을 때