### PR TITLE
Feat : 반복일정 스케줄 등록 스케줄러 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -90,4 +90,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                                        @Param("startOfToday") LocalDateTime startOfToday,
                                        @Param("startOfTomorrow") LocalDateTime startOfTomorrow);
 
+    @Query("""
+    SELECT s.routine FROM Schedule s
+    WHERE s.user = :user AND s.date = :date AND s.isDeleted = true AND s.routine IS NOT NULL""")
+    List<Routine> findDeletedRoutinesByUserAndDate(@Param("user") User user, @Param("date") LocalDate date);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -60,7 +60,6 @@ public class TeumConverter {
                             .receiverUser(receiver)
                             .status(ResponseStatus.PENDING)
                             .readAt(null)
-                            .message("")
                             .build();
                 })
                 .toList();
@@ -117,7 +116,6 @@ public class TeumConverter {
                 .teumRequest(request)
                 .receiverUser(newReceiver)
                 .status(ResponseStatus.PENDING)
-                .message("")
                 .readAt(null)
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumResponse.java
@@ -31,9 +31,6 @@ public class TeumResponse extends BaseEntity {
     @JoinColumn(name = "receiver_user_id", nullable = false)
     private User receiverUser;
 
-    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
-    private String message;
-
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/umc/teumteum/server/domain/user/entity/RemindAlarm.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/RemindAlarm.java
@@ -20,7 +20,7 @@ public class RemindAlarm extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "minutes_before", nullable = false)

--- a/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
@@ -18,6 +18,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -28,8 +30,8 @@ public class ScheduleGeneratorScheduler {
     private final ScheduleRepository scheduleRepository;
     private final RoutineRepository routineRepository;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-//    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
     public void schedule() {
         log.info("[00:00] 반복일정 스케줄 테이블에 등록 시작");
 
@@ -46,15 +48,22 @@ public class ScheduleGeneratorScheduler {
              * 등록해야할 정보
              * user, routine, title = routine.title, description = routine.description, type=ROUTINE,
              * date(YYYY-MM-DD), startTime(오늘날짜 + routine.startTIme), endTIme(오늘날짜 + routine.endTime)
+             * & schedule reminder 정보
              */
 
             Weekday todayWeekday = Weekday.valueOf(today.getDayOfWeek().name());
+            // 루틴 테이블 조회
             List<Routine> routines = routineRepository.findByUserAndWeekday(user, todayWeekday);
+
+            // Schedule 테이블에서 삭제된 루틴 조회
+            List<Routine> deletedRoutines = scheduleRepository.findDeletedRoutinesByUserAndDate(user,today);
+            Set<Long> deletedRoutineIds = deletedRoutines.stream()
+                    .map(Routine::getId)
+                    .collect(Collectors.toSet());
 
             for (Routine routine : routines) {
                 // 삭제된 반복일정이라면 스킵
-                boolean deletedRoutine = scheduleRepository.existsByUserAndDateAndRoutineAndIsDeletedTrue(user, today, routine);
-                if (deletedRoutine) continue;
+                if (deletedRoutineIds.contains(routine.getId())) continue;
 
                 Schedule routineSchedule = Schedule.builder()
                         .user(user)

--- a/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
@@ -5,20 +5,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -29,6 +31,8 @@ public class ScheduleGeneratorScheduler {
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
     private final RoutineRepository routineRepository;
+    private final RemindAlarmRepository remindAlarmRepository;
+    private final ScheduleReminderRepository scheduleReminderRepository;
 
 //    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
@@ -38,9 +42,13 @@ public class ScheduleGeneratorScheduler {
         List<User> users = userRepository.findByStatus(UserStatus.ACTIVE);
 
         LocalDate today = LocalDate.now();
+        Weekday todayWeekday = Weekday.valueOf(today.getDayOfWeek().name());
+
+        // user : remind alarm 정보 미리 조회
+        Map<Long, List<RemindAlarm>> alarmMap = remindAlarmRepository.findAll().stream()
+                .collect(Collectors.groupingBy(r -> r.getUser().getId()));
 
         for (User user : users) {
-            List<Schedule> schedulesToInsert = new ArrayList<>();
             /**
              * routine 테이블의 반복일정 등록
              * 조회방식: 오늘요일 = routine.weekday
@@ -50,8 +58,9 @@ public class ScheduleGeneratorScheduler {
              * date(YYYY-MM-DD), startTime(오늘날짜 + routine.startTIme), endTIme(오늘날짜 + routine.endTime)
              * & schedule reminder 정보
              */
+            List<Schedule> schedulesToInsert = new ArrayList<>();
+            List<ScheduleReminder> remindersToInsert = new ArrayList<>();
 
-            Weekday todayWeekday = Weekday.valueOf(today.getDayOfWeek().name());
             // 루틴 테이블 조회
             List<Routine> routines = routineRepository.findByUserAndWeekday(user, todayWeekday);
 
@@ -61,6 +70,7 @@ public class ScheduleGeneratorScheduler {
                     .map(Routine::getId)
                     .collect(Collectors.toSet());
 
+            // 스케줄 저장
             for (Routine routine : routines) {
                 // 삭제된 반복일정이라면 스킵
                 if (deletedRoutineIds.contains(routine.getId())) continue;
@@ -77,7 +87,19 @@ public class ScheduleGeneratorScheduler {
                         .build();
                 schedulesToInsert.add(routineSchedule);
             }
-            scheduleRepository.saveAll(schedulesToInsert);
+            List<Schedule> savedSchedules = scheduleRepository.saveAll(schedulesToInsert);
+            List<RemindAlarm> userAlarms = alarmMap.getOrDefault(user.getId(), Collections.emptyList()); // 유저의 리마인드 알림 정보
+
+            // 스케줄 리마인드 저장
+            for (Schedule schedule : savedSchedules) {
+                for (RemindAlarm alarm : userAlarms) {
+                    remindersToInsert.add(ScheduleReminder.builder()
+                            .schedule(schedule)
+                            .reminderTime(alarm.getMinutesBefore())
+                            .build());
+                }
+            }
+            scheduleReminderRepository.saveAll(remindersToInsert);
         }
         log.info("[00:00] 총 {}명의 유저에 대해 스케줄 생성 완료", users.size());
     }

--- a/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/ScheduleGeneratorScheduler.java
@@ -34,8 +34,8 @@ public class ScheduleGeneratorScheduler {
     private final RemindAlarmRepository remindAlarmRepository;
     private final ScheduleReminderRepository scheduleReminderRepository;
 
-//    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 0/1 * * * *", zone = "Asia/Seoul")
     public void schedule() {
         log.info("[00:00] 반복일정 스케줄 테이블에 등록 시작");
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#88

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
리마인드알림 테이블에 user_id가 unqiue키로 저장되어 있어 여러 리마인드 알림 설정을 등록할 수 없어서 해당 부분 수정하기 위해 unique제약조건 제거했습니다.
온보딩에서 입력한 리마인드 알림 정보를 기반으로 반복일정을 등록시 스케줄 리마인더 테이블에도 해당 정보가 저장되도록 로직 추가했습니다.
조회 성능을 줄이고자 모든 유저의 리마인드 알림 정보를 map으로 조회하고 삭제된 루틴인지 조회는 routine 밖에서 set으로 조회해두고 비교하는 방식으로 수정했습니다.
(+ teum response 테이블 message 필드 제거했습니다.)
### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
X
### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF
X