### PR TITLE
Fix : 위시 등록 중복 검증 로직 제거

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -14,7 +14,6 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
     _WISH_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4043","해당 위시 정보를 찾을 수 없습니다."),
-    _WISH_CONFLICT(HttpStatus.CONFLICT, "HOME4091","이미 동일한 위시가 존재합니다."),
     _SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "HOME4092","해당 시간에 스케줄이 존재합니다.")
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -169,11 +169,6 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND);
         }
 
-        // 동일한 wish가 이미 존재하는지 확인
-        if (isDuplicateWish(user, dto, null)) {
-            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
-        }
-
         // Wish & Wish Category 저장
         Wish wish = wishConverter.toWish(dto,user);
         List<WishCategory> wishCategories = wishConverter.toWishCategories(wish,categories);
@@ -218,11 +213,6 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND);
         }
 
-        // 동일한 wish가 이미 존재하는지 확인
-        if (isDuplicateWish(user, dto, wishId)) {
-            throw new HomeException(HomeErrorStatus._WISH_CONFLICT);
-        }
-
         wish.getWishCategories().clear(); // 기존 wish category 정보 제거
         // 새로운 WishCategory 저장 & Wish 필드 업데이트
         List<WishCategory> wishCategories = wishConverter.toWishCategories(wish, categories);
@@ -233,31 +223,6 @@ public class HomeServiceImpl implements HomeService {
                 dto.getEstimatedDuration()
         );
 
-    }
-
-    private boolean isDuplicateWish(User user, WishRequestDTO dto, Long currentWishId) {
-        // 중복 검사
-        // user, title, content, duration이 같은 wish
-        List<Wish> candidates = wishRepository.findByUserAndTitleAndContentAndEstimatedDuration(
-                user, dto.getTitle(), dto.getContent(), dto.getEstimatedDuration()
-        );
-
-        for (Wish candidate : candidates) {
-            // 현재 wish id(자기자신) 제외
-            if (currentWishId != null && currentWishId.equals(candidate.getId())) continue;
-
-            // 카테고리 ID 목록 비교
-            Set<Long> dtoCategoryIds = new HashSet<>(dto.getCategories());
-
-            Set<Long> candidateCategoryIds = candidate.getWishCategories().stream()
-                    .map(wc -> wc.getCategory().getId())
-                    .collect(Collectors.toSet());
-
-            if (dtoCategoryIds.equals(candidateCategoryIds)) {
-                return true;
-            } // 카테고리까지 동일하다면 중복
-        }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#92 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
위시 등록 중 동일한 유저, 제목, 예상시간을 가진 위시는 등록할 수 없도록 충돌 방지 로직이 있었습니다. PM님 확인 결과 중복 등록이 가능하다는 답변을 받아서 해당 로직 제거했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
X
### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X