### PR TITLE
Fix: 틈 요청 첫 수락 시 요청자 스케줄 생성

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -133,10 +133,8 @@ public class TeumConverter {
                 .startTime(start)
                 .endTime(end)
                 .user(receiver)
-                .isPublic(false)
-                .includeTeum(false)
+                .includeTeum(true)
                 .teumRequest(request)
-                .status(ScheduleStatus.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -153,15 +153,12 @@ public class TeumServiceImpl implements TeumService {
         if (isAccepted) {
             TeumRequest request = response.getTeumRequest();
 
-            // 이미 해당 요청에 대해 생성된 스케줄이 있는지 확인
-            boolean hasExistingSchedules = !request.getSchedules().isEmpty();
-
             User receiver = response.getReceiverUser();
             Schedule receiverSchedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
             scheduleRepository.save(receiverSchedule);
 
-            // 스케줄이 처음 생성되는 경우에만 요청자도 생성
-            if (!hasExistingSchedules) {
+            // 스케줄이 없는 경우에만 요청자에게 생성
+            if (request.getSchedules().isEmpty()) {
                 User requester = request.getUser();
                 Schedule requesterSchedule = TeumConverter.toScheduleFromTeumRequest(request, requester);
                 scheduleRepository.save(requesterSchedule);

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -152,17 +152,29 @@ public class TeumServiceImpl implements TeumService {
 
         if (isAccepted) {
             TeumRequest request = response.getTeumRequest();
+
+            // 이미 해당 요청에 대해 생성된 스케줄이 있는지 확인
+            boolean hasExistingSchedules = !request.getSchedules().isEmpty();
+
             User receiver = response.getReceiverUser();
+            Schedule receiverSchedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
+            scheduleRepository.save(receiverSchedule);
 
-            Schedule schedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
-            scheduleRepository.save(schedule);
+            // 스케줄이 처음 생성되는 경우에만 요청자도 생성
+            if (!hasExistingSchedules) {
+                User requester = request.getUser();
+                Schedule requesterSchedule = TeumConverter.toScheduleFromTeumRequest(request, requester);
+                scheduleRepository.save(requesterSchedule);
+            }
 
-            teumId = schedule.getId();
+            // 수신자 본인 스케줄 ID 반환
+            teumId = receiverSchedule.getId();
         }
 
-        return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
 
+        return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
     }
+
 
     @Override
     public List<String> getScheduledTeumsOfMonth(Long userId, String month) {


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#94 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 기존에 틈 요청 첫 수락 시에 수신자에게만 스케줄이 생기던 문제 해결
   - 수신자가 틈 요청을 처음 수락하는 경우 요청자와 수신자 모두에게 스케줄 생성
   - 이후 다른 수신자들이 수락할 경우 수신자 본인에게만 스케줄 생성

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 동시성 문제가 발생할 수 있을 것 같은데, 이 부분은 이전에 약속된 틈 취소의 동시성 문제와 같이 별도의 이슈에서 해결하도록 하겠습니다.
- 중복 처리에 관련한 기획에 따라 틈 응답 시에도 검증 로직이 필요한데 이것도 별도의 이슈에서 진행하도록 하겠습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 첫 수락 (1번이 응답 -> 요청자인 2번의 스케줄도 생성) |<img width="1804" height="129" alt="image" src="https://github.com/user-attachments/assets/6ddacc91-204e-4228-af30-e263b4eef8e1" />|
| 첫 수락 X (1번이 응답 -> 1번의 스케줄만 생성) |<img width="1817" height="194" alt="image" src="https://github.com/user-attachments/assets/76920028-4f5d-4a3b-b064-172a6b0fa28d" />|