### PR TITLE
Feat: 반복일정 등록 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -31,12 +31,12 @@ public class OnboardingController {
             summary = "온보딩 약관 동의",
             description = "온보딩 과정에서 약관 동의 정보를 등록합니다."
     )
-    @PostMapping(value = "/onboarding/agreement", produces = "application/json")
-    public ApiResponse<Object> saveTerms(
+    @PostMapping(value = "/onboarding/agreements", produces = "application/json")
+    public ApiResponse<Object> saveAgreements(
             @RequestBody @Valid OnboardingRequestDto.AgreeRequest request,
             @CurrentUser @Parameter(hidden = true) User user
             ) {
-        onboardingService.saveAgreement(request, user);
+        onboardingService.saveAgreements(request, user);
         return ApiResponse.of(UserSuccessStatus.AGREEMENT_SAVED, null);
     }
 
@@ -85,11 +85,13 @@ public class OnboardingController {
             summary = "온보딩 요일별 반복 일정 등록",
             description = "온보딩 과정에서 요일별 반복 일정을 등록합니다."
     )
-    @PostMapping(value = "/onboarding/routine", produces = "application/json")
-    public ApiResponse<Object> saveRoutine(
+    @PostMapping(value = "/onboarding/routines", produces = "application/json")
+    public ApiResponse<Object> saveRoutines(
+            @RequestBody @Valid OnboardingRequestDto.RoutineListRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        // TODO: 온보딩 루틴 저장 로직 구현
-        return null;
+        onboardingService.saveRoutines(request, user);
+        return ApiResponse.of(UserSuccessStatus.ROUTINE_SAVED, null);
     }
 
 
@@ -97,7 +99,7 @@ public class OnboardingController {
             summary = "온보딩 리마인드 알림 설정 등록",
             description = "온보딩 과정에서 리마인드 알림 시간 설정(1분 전/3분 전/5분 전/10분 전/30분 전)을 등록합니다."
     )
-    @PostMapping(value = "/onboarding/reminder", produces = "application/json")
+    @PostMapping(value = "/onboarding/reminders", produces = "application/json")
     public ApiResponse<Object> saveReminder(
     ) {
         // TODO: 온보딩 리마인드 알림 설정 저장 로직 구현

--- a/src/main/java/umc/teumteum/server/domain/user/converter/RoutineConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/RoutineConverter.java
@@ -1,0 +1,31 @@
+package umc.teumteum.server.domain.user.converter;
+
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.entity.Routine;
+import umc.teumteum.server.domain.user.entity.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RoutineConverter {
+
+    public static Routine toRoutine(OnboardingRequestDto.RoutineDTO request, User user) {
+        return Routine.builder()
+                .user(user)
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .weekday(request.getWeekday())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
+                .build()
+                ;
+    }
+
+    public static List<Routine> toRoutineList(List<OnboardingRequestDto.RoutineDTO> requests, User user) {
+        return requests.stream()
+                .map(request -> toRoutine(request, user))
+                .collect(Collectors.toList())
+                ;
+    }
+
+}

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
@@ -2,19 +2,20 @@ package umc.teumteum.server.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 
 import java.time.LocalTime;
+import java.util.List;
 
 public class OnboardingRequestDto {
 
+    // 온보딩 - 약관 동의
     @Getter
     @Builder
     @NoArgsConstructor
@@ -39,6 +40,7 @@ public class OnboardingRequestDto {
     }
 
 
+    // 온보딩 - 닉네임 & 분야/직종
     @Getter
     @Builder
     @NoArgsConstructor
@@ -58,6 +60,7 @@ public class OnboardingRequestDto {
     }
 
 
+    // 온보딩 - 수면패턴
     @Getter
     @Builder
     @NoArgsConstructor
@@ -73,5 +76,51 @@ public class OnboardingRequestDto {
         @JsonFormat(pattern = "HH:mm")
         @Schema(description = "기상 시간", example = "11:30")
         private LocalTime wakeTime;
+    }
+
+
+    // 온보딩 - 반복 일정
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoutineListRequest {
+
+        @NotEmpty(message = "최소 1개 이상의 반복 일정이 필요합니다")
+        @Valid
+        @Schema(description = "반복 일정 목록")
+        private List<RoutineDTO> routine;
+    }
+
+
+    // 온보딩 - 반복 일정 세부
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoutineDTO {
+
+        @NotBlank(message = "제목은 필수 입력입니다")
+        @Schema(description = "제목", example = "매주 산책")
+        private String title;
+
+        @Schema(description = "상세 내용", example = "한강에서 산책")
+        private String description;
+
+        @NotNull(message = "요일은 필수 입력입니다")
+        @Schema(description = "반복 요일", example = "WEDNESDAY",
+                allowableValues = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"})
+        private Weekday weekday;
+
+        @NotNull(message = "시작 시간은 필수 입력입니다")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(description = "시작 시간 (HH:mm 형식)", example = "13:00")
+        private LocalTime startTime;
+
+
+        @NotNull(message = "종료 시간은 필수 입력입니다")
+        @JsonFormat(pattern = "HH:mm")
+        @Schema(description = "종료 시간 (HH:mm 형식)", example = "00:00")
+        private LocalTime endTime;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/OnboardingHandler.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/OnboardingHandler.java
@@ -1,0 +1,11 @@
+package umc.teumteum.server.domain.user.exception;
+
+import umc.teumteum.server.global.apiPayload.code.BaseErrorCode;
+import umc.teumteum.server.global.exception.GeneralException;
+
+public class OnboardingHandler extends GeneralException {
+
+  public OnboardingHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -20,8 +20,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
     ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "반복 일정 간 시간 충돌이 발생했습니다."),
     ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
-    AGREEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 약관에 동의한 사용자입니다."),
-    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4092", "이미 사용 중인 닉네임입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 사용 중인 닉네임입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -17,6 +17,9 @@ public enum UserErrorStatus implements BaseErrorCode {
     INVALID_STEP(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "현재 진행할 수 있는 단계가 아닙니다."),
     TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "서비스 이용약관은 필수 동의 항목입니다."),
     PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4003", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
+    ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "반복 일정 간 시간 충돌이 발생했습니다."),
+    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
     AGREEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 약관에 동의한 사용자입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4092", "이미 사용 중인 닉네임입니다."),
     ;

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -17,6 +17,7 @@ public enum UserSuccessStatus implements BaseCode {
     AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 완료되었습니다."),
     NICKNAME_JOB_SAVED(HttpStatus.OK, "ONBOARDING2002", "닉네임과 분야/직종 등록이 완료되었습니다."),
     SLEEP_PATTERN_SAVED(HttpStatus.OK, "ONBOARDING2003", "수면 패턴 등록이 완료되었습니다."),
+    ROUTINE_SAVED(HttpStatus.OK, "ONBOARDING2004", "요일별 반복 일정 등록이 완료되었습니다."),
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -1,15 +1,19 @@
 package umc.teumteum.server.domain.user.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 
-import java.util.Date;
 import java.util.List;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
     List<Routine> findByUserAndWeekday(User user, Weekday weekday);
 
-    void deleteByUser(User user);
+    @Modifying
+    @Query("delete from Routine r where r.user = :user")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
     List<Routine> findByUserAndWeekday(User user, Weekday weekday);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
@@ -4,9 +4,11 @@ import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface OnboardingService {
-    void saveAgreement(OnboardingRequestDto.AgreeRequest request, User user);
+    void saveAgreements(OnboardingRequestDto.AgreeRequest request, User user);
 
     void saveNicknameAndJob(OnboardingRequestDto.NicknameJobRequest request, User user);
 
     void saveSleepPattern(OnboardingRequestDto.SleepPatternRequest request, User user);
+
+    void saveRoutines(OnboardingRequestDto.RoutineListRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -165,7 +165,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     // 반복일정끼리의 충돌 확인
     private void validateRoutineConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay) {
         routinesByDay.values().stream()
-                // 1. 반복일정 2개 이상인 요일만 충돌 검증
+                // 1. 반복일정 2개 이상일 때만 충돌 검증
                 .filter(dayRoutines -> dayRoutines.size() > 1)
                 .forEach(dayRoutines -> {
 
@@ -176,7 +176,6 @@ public class OnboardingServiceImpl implements OnboardingService {
 
                     timeUtil.validateTimeRangeConflicts(timeRanges, UserErrorStatus.ROUTINE_TIME_CONFLICT);
                 });
-
     }
 
     // 수면패턴과 반복일정 간의 충돌 확인
@@ -189,14 +188,13 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 2. 수면패턴을 TimeRange로 변환
         List<TimeRange> sleepTimeRanges = getSleepTimeRanges(user.getSleepTime(), user.getWakeTime());
 
-        // 3. 요일별로 반복일정과 수면패턴을 합쳐서 일정이 2개 이상인 요일만 충돌 검증
-        // 수면패턴만 2개인 경우(22:00~00:00 + 00:00~08:00) 에도 검증 진행
+        // 3. 반복일정과 수면패턴 시간 충돌 검증
         routinesByDay.values().stream()
                 .map(dayRoutines -> {
 
                     List<TimeRange> allTimeRanges = new ArrayList<>();
 
-                    // 반복일정들 추가
+                    // 반복일정 추가
                     allTimeRanges.addAll(dayRoutines.stream()
                             .map(TimeRange::from)
                             .toList());
@@ -206,7 +204,6 @@ public class OnboardingServiceImpl implements OnboardingService {
 
                     return allTimeRanges;
                 })
-                .filter(allTimeRanges -> allTimeRanges.size() > 1)
                 .forEach(allTimeRanges ->
                         timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
     }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -211,22 +211,15 @@ public class OnboardingServiceImpl implements OnboardingService {
 
     // 수면패턴을 TimeRange 리스트로 변환
     private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
-        // 1. 하루 전체 수면 (ex. 00:00~00:00)
-        if (sleepTime.equals(LocalTime.MIDNIGHT) && wakeTime.equals(LocalTime.MIDNIGHT)) {
-            return List.of(TimeRange.of(LocalTime.MIDNIGHT, LocalTime.MIDNIGHT));
-        }
-
-        // 2. 같은 날 안에서 종료되는 경우 (ex. 06:00~14:00)
-        if (sleepTime.isBefore(wakeTime)) {
-            return List.of(TimeRange.of(sleepTime, wakeTime));
-        }
-
-        // 3. 다른 날까지 이어지는 경우 (ex. 22:00~08:00)
-        else {
+        // 1. 다음 날까지 이어지는 수면 (ex. 22:00~08:00)
+        if (sleepTime.isAfter(wakeTime) && !wakeTime.equals(LocalTime.MIDNIGHT)) {
             return List.of(
                     TimeRange.of(sleepTime, LocalTime.MIDNIGHT),
                     TimeRange.of(LocalTime.MIDNIGHT, wakeTime)
             );
         }
+
+        // 2. 같은 날 안에서 끝나는 수면 (ex. 06:00~14:00, 18:00~00:00, 00:00~00:00)
+        return List.of(TimeRange.of(sleepTime, wakeTime));
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -10,6 +10,7 @@ import umc.teumteum.server.domain.user.entity.Agreement;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.UserStep;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.domain.user.exception.OnboardingHandler;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.AgreementRepository;
@@ -20,7 +21,9 @@ import umc.teumteum.server.global.util.TimeUtil;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -110,15 +113,25 @@ public class OnboardingServiceImpl implements OnboardingService {
         validateOnboardingStep(user, UserStep.ONBOARDING);
 
         // 2. 단일 일정 내에서 시작&종료시간 확인
-        request.getRoutine().forEach(this::validateSingleRoutineTimeRange);
+        List<OnboardingRequestDto.RoutineDTO> routines = request.getRoutine();
+        routines.forEach(this::validateSingleRoutineTimeRange);
 
-        // 3. 반복 일정끼리의 충돌 확인
-        validateRoutineTimeConflicts(request.getRoutine());
+        // 3. 요일별로 그룹핑 (EnumMap 사용)
+        Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay =
+                routines.stream()
+                        .collect(Collectors.groupingBy(
+                                OnboardingRequestDto.RoutineDTO::getWeekday,
+                                () -> new EnumMap<>(Weekday.class),
+                                Collectors.toList()
+                        ));
 
-        // 4. 수면패턴과의 충돌 확인
-        validateSleepPatternConflicts(request.getRoutine(), user);
+        // 4. 반복 일정끼리의 충돌 확인
+        validateRoutineConflictsByDay(routinesByDay);
 
-        // 5. 반복 일정 저장 (온보딩 중단으로 인해 기존 반복 일정이 있을 수 있으므로 삭제 필요)
+        // 5. 수면패턴과의 충돌 확인
+        validateSleepPatternConflictsByDay(routinesByDay, user);
+
+        // 6. 반복 일정 저장 (온보딩 중단으로 인해 기존 반복 일정이 있을 수 있으므로 삭제 필요)
         List<Routine> newRoutines = RoutineConverter.toRoutineList(request.getRoutine(), user);
 
         routineRepository.deleteByUser(user);
@@ -155,38 +168,35 @@ public class OnboardingServiceImpl implements OnboardingService {
 
 
     // 반복일정끼리의 충돌 확인
-    private void validateRoutineTimeConflicts(List<OnboardingRequestDto.RoutineDTO> routines) {
-        // 1. 요일별로 그룹핑해서 일정이 2개 이상인 요일만 충돌 검증
-        routines.stream()
-                .collect(Collectors.groupingBy(OnboardingRequestDto.RoutineDTO::getWeekday))
-                .values().stream()
+    private void validateRoutineConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay) {
+        routinesByDay.values().stream()
+                // 1. 반복일정 2개 이상인 요일만 충돌 검증
                 .filter(dayRoutines -> dayRoutines.size() > 1)
                 .forEach(dayRoutines -> {
 
-                    // 2. RoutineDTO를 TimeRange로 변환
+                    // 2. 반복일정을 TimeRange로 변환
                     List<TimeRange> timeRanges = dayRoutines.stream()
                             .map(TimeRange::from)
-                            .collect(Collectors.toList())
-                            ;
+                            .collect(Collectors.toList());
 
-                    // 3. 같은 요일 내에서의 시간 충돌 검증
                     timeUtil.validateTimeRangeConflicts(timeRanges, UserErrorStatus.ROUTINE_TIME_CONFLICT);
                 });
+
     }
 
-
     // 수면패턴과 반복일정 간의 충돌 확인
-    private void validateSleepPatternConflicts(List<OnboardingRequestDto.RoutineDTO> routines, User user) {
-        // 1. 수면패턴이 저장되어 있는지 확인 (선택입력이기 때문)
+    private void validateSleepPatternConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay, User user) {
+        // 1. 수면패턴 저장 여부 확인 (선택입력이기 때문)
         if (user.getSleepTime() == null && user.getWakeTime() == null) {
             return;
         }
 
-        // 2. 요일별로 그룹핑해서 반복일정과 수면패턴을 합쳐서 일정이 2개 이상인 요일만 충돌 검증
-        // (반복일정없이 수면패턴이 2개로 나뉜 경우에도 일정 2개로 판단하기 때문에 검증 진행함)
-        routines.stream()
-                .collect(Collectors.groupingBy(OnboardingRequestDto.RoutineDTO::getWeekday))
-                .values().stream()
+        // 2. 수면패턴을 TimeRange로 변환
+        List<TimeRange> sleepTimeRanges = getSleepTimeRanges(user.getSleepTime(), user.getWakeTime());
+
+        // 3. 요일별로 반복일정과 수면패턴을 합쳐서 일정이 2개 이상인 요일만 충돌 검증
+        // 수면패턴만 2개인 경우(22:00~00:00 + 00:00~08:00) 에도 검증 진행
+        routinesByDay.values().stream()
                 .map(dayRoutines -> {
 
                     List<TimeRange> allTimeRanges = new ArrayList<>();
@@ -197,13 +207,13 @@ public class OnboardingServiceImpl implements OnboardingService {
                             .toList());
 
                     // 수면패턴 추가
-                    allTimeRanges.addAll(getSleepTimeRanges(user.getSleepTime(), user.getWakeTime()));
+                    allTimeRanges.addAll(sleepTimeRanges);
 
                     return allTimeRanges;
-
                 })
                 .filter(allTimeRanges -> allTimeRanges.size() > 1)
-                .forEach(allTimeRanges -> timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
+                .forEach(allTimeRanges ->
+                        timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
     }
 
 
@@ -211,7 +221,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
         // 1. 하루 전체 수면 (ex. 00:00~00:00)
         if (sleepTime.equals(LocalTime.MIDNIGHT) && wakeTime.equals(LocalTime.MIDNIGHT)) {
-            return List.of(TimeRange.of(LocalTime.MIDNIGHT, LocalTime.MAX));
+            return List.of(TimeRange.of(LocalTime.MIDNIGHT, LocalTime.MIDNIGHT));
         }
 
         // 2. 같은 날 안에서 종료되는 경우 (ex. 06:00~14:00)

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -4,14 +4,24 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.user.converter.AgreementConverter;
+import umc.teumteum.server.domain.user.converter.RoutineConverter;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.UserStep;
-import umc.teumteum.server.domain.user.exception.UserHandler;
+import umc.teumteum.server.domain.user.exception.OnboardingHandler;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.AgreementRepository;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.dto.TimeRange;
+import umc.teumteum.server.global.util.TimeUtil;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,25 +29,28 @@ public class OnboardingServiceImpl implements OnboardingService {
 
     private final UserRepository userRepository;
     private final AgreementRepository agreementRepository;
+    private final RoutineRepository routineRepository;
+    private final TimeUtil timeUtil;
+
 
     // 온보딩 - 약관 동의
     @Override
     @Transactional
-    public void saveAgreement(OnboardingRequestDto.AgreeRequest request, User user) {
+    public void saveAgreements(OnboardingRequestDto.AgreeRequest request, User user) {
         // 1. 사용자 step 확인
         validateOnboardingStep(user, UserStep.AGREEMENT);
 
         // 2. 기존 동의 이력이 있는지 확인
         if (agreementRepository.existsByUser(user)) {
-            throw new UserHandler(UserErrorStatus.AGREEMENT_ALREADY_EXISTS);
+            throw new OnboardingHandler(UserErrorStatus.AGREEMENT_ALREADY_EXISTS);
         }
 
         // 3. 필수 항목 동의 여부 확인
         if (!request.getTosConsent()) {
-            throw new UserHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
+            throw new OnboardingHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
         }
         if (!request.getPrivacyConsent()) {
-            throw new UserHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
+            throw new OnboardingHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
         }
 
         // 4. Entity 변환
@@ -62,13 +75,13 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 기존 닉네임이 null이면(=처음 닉네임 등록) 단순 중복 체크
         if (user.getNickname() == null) {
             if (userRepository.existsByNickname(request.getNickname())) {
-                throw new UserHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
+                throw new OnboardingHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
             }
         }
         // 기존 닉네임이 있으면(=온보딩 중단으로 인한 닉네임 재등록) 본인 닉네임 이외와 중복 체크
         else {
             if (!request.getNickname().equals(user.getNickname()) && userRepository.existsByNickname(request.getNickname())) {
-                throw new UserHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
+                throw new OnboardingHandler(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
             }
         }
 
@@ -77,6 +90,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
+    // 온보딩 - 수면패턴 등록
     @Override
     @Transactional
     public void saveSleepPattern(OnboardingRequestDto.SleepPatternRequest request, User user) {
@@ -88,10 +102,129 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
+    // 온보딩 - 반복일정 등록
+    @Override
+    @Transactional
+    public void saveRoutines(OnboardingRequestDto.RoutineListRequest request, User user) {
+        // 1. 사용자 step 확인
+        validateOnboardingStep(user, UserStep.ONBOARDING);
+
+        // 2. 단일 일정 내에서 시작&종료시간 확인
+        request.getRoutine().forEach(this::validateSingleRoutineTimeRange);
+
+        // 3. 반복 일정끼리의 충돌 확인
+        validateRoutineTimeConflicts(request.getRoutine());
+
+        // 4. 수면패턴과의 충돌 확인
+        validateSleepPatternConflicts(request.getRoutine(), user);
+
+        // 5. 반복 일정 저장 (온보딩 중단으로 인해 기존 반복 일정이 있을 수 있으므로 삭제 필요)
+        List<Routine> newRoutines = RoutineConverter.toRoutineList(request.getRoutine(), user);
+
+        routineRepository.deleteByUser(user);
+        routineRepository.saveAll(newRoutines);
+    }
+
+
+
+
     // 사용자의 step을 확인
     private void validateOnboardingStep(User user, UserStep expectedStep) {
         if (user.getStep() == null || !user.getStep().equals(expectedStep)) {
-            throw new UserHandler(UserErrorStatus.INVALID_STEP);
+            throw new OnboardingHandler(UserErrorStatus.INVALID_STEP);
+        }
+    }
+
+
+    // 단일 일정의 시작시간과 종료시간이 올바른 범위인지 검증
+    private void validateSingleRoutineTimeRange(OnboardingRequestDto.RoutineDTO routine) {
+        LocalTime startTime = routine.getStartTime();
+        LocalTime endTime = routine.getEndTime();
+
+        // 1. 종료시간 00:00의 경우 무조건 허용 (=다음날 자정에 종료를 의미)
+        if (endTime.equals(LocalTime.MIDNIGHT)) {
+            return;
+        }
+
+        // 2. 기본 유효성 검증 (시작시간 < 종료시간)
+        if (!startTime.isBefore(endTime)) {
+            // ex) 13:00~03:00, 10:00~10:00 등이 해당
+            throw new OnboardingHandler(UserErrorStatus.INVALID_TIME_RANGE);
+        }
+    }
+
+
+    // 반복일정끼리의 충돌 확인
+    private void validateRoutineTimeConflicts(List<OnboardingRequestDto.RoutineDTO> routines) {
+        // 1. 요일별로 그룹핑해서 일정이 2개 이상인 요일만 충돌 검증
+        routines.stream()
+                .collect(Collectors.groupingBy(OnboardingRequestDto.RoutineDTO::getWeekday))
+                .values().stream()
+                .filter(dayRoutines -> dayRoutines.size() > 1)
+                .forEach(dayRoutines -> {
+
+                    // 2. RoutineDTO를 TimeRange로 변환
+                    List<TimeRange> timeRanges = dayRoutines.stream()
+                            .map(TimeRange::from)
+                            .collect(Collectors.toList())
+                            ;
+
+                    // 3. 같은 요일 내에서의 시간 충돌 검증
+                    timeUtil.validateTimeRangeConflicts(timeRanges, UserErrorStatus.ROUTINE_TIME_CONFLICT);
+                });
+    }
+
+
+    // 수면패턴과 반복일정 간의 충돌 확인
+    private void validateSleepPatternConflicts(List<OnboardingRequestDto.RoutineDTO> routines, User user) {
+        // 1. 수면패턴이 저장되어 있는지 확인 (선택입력이기 때문)
+        if (user.getSleepTime() == null && user.getWakeTime() == null) {
+            return;
+        }
+
+        // 2. 요일별로 그룹핑해서 반복일정과 수면패턴을 합쳐서 일정이 2개 이상인 요일만 충돌 검증
+        // (반복일정없이 수면패턴이 2개로 나뉜 경우에도 일정 2개로 판단하기 때문에 검증 진행함)
+        routines.stream()
+                .collect(Collectors.groupingBy(OnboardingRequestDto.RoutineDTO::getWeekday))
+                .values().stream()
+                .map(dayRoutines -> {
+
+                    List<TimeRange> allTimeRanges = new ArrayList<>();
+
+                    // 반복일정들 추가
+                    allTimeRanges.addAll(dayRoutines.stream()
+                            .map(TimeRange::from)
+                            .toList());
+
+                    // 수면패턴 추가
+                    allTimeRanges.addAll(getSleepTimeRanges(user.getSleepTime(), user.getWakeTime()));
+
+                    return allTimeRanges;
+
+                })
+                .filter(allTimeRanges -> allTimeRanges.size() > 1)
+                .forEach(allTimeRanges -> timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
+    }
+
+
+    // 수면패턴을 TimeRange 리스트로 변환
+    private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
+        // 1. 하루 전체 수면 (ex. 00:00~00:00)
+        if (sleepTime.equals(LocalTime.MIDNIGHT) && wakeTime.equals(LocalTime.MIDNIGHT)) {
+            return List.of(TimeRange.of(LocalTime.MIDNIGHT, LocalTime.MAX));
+        }
+
+        // 2. 같은 날 안에서 종료되는 경우 (ex. 06:00~14:00)
+        if (sleepTime.isBefore(wakeTime)) {
+            return List.of(TimeRange.of(sleepTime, wakeTime));
+        }
+
+        // 3. 다른 날까지 이어지는 경우 (ex. 22:00~08:00)
+        else {
+            return List.of(
+                    TimeRange.of(sleepTime, LocalTime.MIDNIGHT),
+                    TimeRange.of(LocalTime.MIDNIGHT, wakeTime)
+            );
         }
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -43,12 +43,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 1. 사용자 step 확인
         validateOnboardingStep(user, UserStep.AGREEMENT);
 
-        // 2. 기존 동의 이력이 있는지 확인
-        if (agreementRepository.existsByUser(user)) {
-            throw new OnboardingHandler(UserErrorStatus.AGREEMENT_ALREADY_EXISTS);
-        }
-
-        // 3. 필수 항목 동의 여부 확인
+        // 2. 필수 항목 동의 여부 확인
         if (!request.getTosConsent()) {
             throw new OnboardingHandler(UserErrorStatus.TOS_CONSENT_NOT_AGREED);
         }
@@ -56,13 +51,13 @@ public class OnboardingServiceImpl implements OnboardingService {
             throw new OnboardingHandler(UserErrorStatus.PRIVACY_CONSENT_NOT_AGREED);
         }
 
-        // 4. Entity 변환
+        // 3. Entity 변환
         Agreement agreement = AgreementConverter.toAgreement(request, user);
 
-        // 5. 저장
+        // 4. 저장
         agreementRepository.save(agreement);
 
-        // 6. 사용자 step 변경
+        // 5. 사용자 step 변경
         user.updateStep(UserStep.ONBOARDING);
     }
 

--- a/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
+++ b/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
@@ -1,0 +1,24 @@
+package umc.teumteum.server.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+public class TimeRange {
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+    // RoutineDTO에서 변환
+    public static TimeRange from(OnboardingRequestDto.RoutineDTO routine) {
+        return new TimeRange(routine.getStartTime(), routine.getEndTime());
+    }
+
+    // 수면패턴에서 변환
+    public static TimeRange of(LocalTime startTime, LocalTime endTime) {
+        return new TimeRange(startTime, endTime);
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
+++ b/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
@@ -12,12 +12,12 @@ public class TimeRange {
     private final LocalTime startTime;
     private final LocalTime endTime;
 
-    // RoutineDTO에서 변환
+    // RoutineDTO에서 TimeRange로 변환
     public static TimeRange from(OnboardingRequestDto.RoutineDTO routine) {
         return new TimeRange(routine.getStartTime(), routine.getEndTime());
     }
 
-    // 수면패턴에서 변환
+    // [시작&종료] 일정을 TimeRange로 변환
     public static TimeRange of(LocalTime startTime, LocalTime endTime) {
         return new TimeRange(startTime, endTime);
     }

--- a/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
@@ -1,0 +1,39 @@
+package umc.teumteum.server.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
+import umc.teumteum.server.global.dto.TimeRange;
+import umc.teumteum.server.global.exception.handler.GlobalHandler;
+
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TimeUtil {
+
+    // 공통 - 정렬된 일정들의 시간 충돌 확인
+    public void validateTimeRangeConflicts(List<TimeRange> timeRanges, UserErrorStatus errorStatus) {
+        // 1. 시작 시간 기준으로 정렬
+        timeRanges.sort(Comparator.comparing(TimeRange::getStartTime));
+
+        // 2. 인접한 시간 범위들 순차적으로 충돌 확인
+        for (int i = 0; i < timeRanges.size() - 1; i++) {
+            LocalTime currentEnd = convertEndTime(timeRanges.get(i).getEndTime());
+            LocalTime nextStart = timeRanges.get(i + 1).getStartTime();
+
+            // 앞일정의 종료시간 > 뒤일정의 시작시간  (=시간 충돌)
+            if (currentEnd.isAfter(nextStart)) {
+                throw new GlobalHandler(errorStatus);
+            }
+        }
+    }
+
+
+    // 공통 - 종료시간 변환 (종료시간이 00:00인 경우 LocalTime.MAX로 변환 필요)
+    public LocalTime convertEndTime(LocalTime endTime) {
+        return endTime.equals(LocalTime.MIDNIGHT) ? LocalTime.MAX : endTime;
+    }
+}

--- a/src/test/java/umc/teumteum/server/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/service/OnboardingServiceTest.java
@@ -1,0 +1,494 @@
+package umc.teumteum.server.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.exception.OnboardingHandler;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
+import umc.teumteum.server.domain.user.service.OnboardingServiceImpl;
+import umc.teumteum.server.global.exception.handler.GlobalHandler;
+import umc.teumteum.server.global.util.TimeUtil;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OnboardingService 테스트 - 수면패턴 x 반복일정 조합")
+class OnboardingServiceTest {
+
+    @InjectMocks
+    private OnboardingServiceImpl onboardingService;
+
+    @Mock
+    private RoutineRepository routineRepository;
+
+    @Spy
+    private TimeUtil timeUtil = new TimeUtil();
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .step(UserStep.ONBOARDING)
+                .email("teumteum@kakao.com")
+                .socialId(UUID.randomUUID().toString())
+                .socialType(SocialType.KAKAO)
+                .build();
+    }
+
+    // ==================== 수면패턴A (22:00-07:00) ====================
+
+    @Test
+    @DisplayName("수면패턴A(22:00-07:00) + 반복일정A(09:00-18:00) - 정상")
+    void sleepA_routineA_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+            onboardingService.saveRoutines(createRoutineA(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴A(22:00-07:00) + 반복일정B(11:00-19:00) - 정상")
+    void sleepA_routineB_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+            onboardingService.saveRoutines(createRoutineB(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴A(22:00-07:00) + 반복일정C(20:00-00:00) - CONFLICT")
+    void sleepA_routineC_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+            onboardingService.saveRoutines(createRoutineC(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    @Test
+    @DisplayName("수면패턴A(22:00-07:00) + 반복일정D(00:00-04:00) - CONFLICT")
+    void sleepA_routineD_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+            onboardingService.saveRoutines(createRoutineD(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    // ==================== 수면패턴B (18:00-00:00) ====================
+
+    @Test
+    @DisplayName("수면패턴B(18:00-00:00) + 반복일정A(09:00-18:00) - 정상")
+    void sleepB_routineA_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+            onboardingService.saveRoutines(createRoutineA(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴B(18:00-00:00) + 반복일정B(11:00-19:00) - CONFLICT")
+    void sleepB_routineB_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+            onboardingService.saveRoutines(createRoutineB(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    @Test
+    @DisplayName("수면패턴B(18:00-00:00) + 반복일정C(20:00-00:00) - CONFLICT")
+    void sleepB_routineC_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+            onboardingService.saveRoutines(createRoutineC(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    @Test
+    @DisplayName("수면패턴B(18:00-00:00) + 반복일정D(00:00-04:00) - 정상")
+    void sleepB_routineD_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+            onboardingService.saveRoutines(createRoutineD(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    // ==================== 수면패턴C (00:00-09:00) ====================
+
+    @Test
+    @DisplayName("수면패턴C(00:00-09:00) + 반복일정A(09:00-18:00) - 정상")
+    void sleepC_routineA_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+            onboardingService.saveRoutines(createRoutineA(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴C(00:00-09:00) + 반복일정B(11:00-19:00) - 정상")
+    void sleepC_routineB_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+            onboardingService.saveRoutines(createRoutineB(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴C(00:00-09:00) + 반복일정C(20:00-00:00) - 정상")
+    void sleepC_routineC_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+            onboardingService.saveRoutines(createRoutineC(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴C(00:00-09:00) + 반복일정D(00:00-04:00) - CONFLICT")
+    void sleepC_routineD_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+            onboardingService.saveRoutines(createRoutineD(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    // ==================== 수면패턴D (11:00-20:00) ====================
+
+    @Test
+    @DisplayName("수면패턴D(11:00-20:00) + 반복일정A(09:00-18:00) - CONFLICT")
+    void sleepD_routineA_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+            onboardingService.saveRoutines(createRoutineA(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    @Test
+    @DisplayName("수면패턴D(11:00-20:00) + 반복일정B(11:00-19:00) - CONFLICT")
+    void sleepD_routineB_conflict() {
+        // when & then
+        assertThatThrownBy(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+            onboardingService.saveRoutines(createRoutineB(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+        });
+    }
+
+    @Test
+    @DisplayName("수면패턴D(11:00-20:00) + 반복일정C(20:00-00:00) - 정상")
+    void sleepD_routineC_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+            onboardingService.saveRoutines(createRoutineC(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("수면패턴D(11:00-20:00) + 반복일정D(00:00-04:00) - 정상")
+    void sleepD_routineD_ok() {
+        // when & then
+        assertThatCode(() -> {
+            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+            onboardingService.saveRoutines(createRoutineD(), testUser);
+        }).doesNotThrowAnyException();
+    }
+
+    // ==================== 특이 케이스 ====================
+
+    @Test
+    @DisplayName("수면패턴 등록하지 않은 경우 반복일정 A~D - 정상")
+    void no_sleep() {
+        // when & then
+        for (OnboardingRequestDto.RoutineListRequest routine : getAllRoutines()) {
+            assertThatCode(() -> {
+                onboardingService.saveRoutines(routine, testUser);
+            }).doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    @DisplayName("반복일정E(00:00-00:00) - 24시간 일정")
+    void test_routineE() {
+        // when & then
+        // 수면패턴 등록X인 경우 정상
+        assertThatCode(() -> {
+            onboardingService.saveRoutines(createRoutineE(), testUser);
+        }).doesNotThrowAnyException();
+
+        // 수면패턴 등록한 경우 예외
+        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+            assertThatThrownBy(() -> {
+                onboardingService.saveSleepPattern(sleepPattern, testUser);
+                onboardingService.saveRoutines(createRoutineE(), testUser);
+            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("반복일정F(23:00-02:00) - 잘못된 시간범위")
+    void test_routineF() {
+        // when & then
+        // 수면패턴 등록X인 경우 예외
+        assertThatCode(() -> {
+            onboardingService.saveRoutines(createRoutineF(), testUser);
+        }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+        });
+
+        // 수면패턴 등록한 경우 예외
+        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+            assertThatThrownBy(() -> {
+                onboardingService.saveSleepPattern(sleepPattern, testUser);
+                onboardingService.saveRoutines(createRoutineF(), testUser);
+            }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("반복일정G(15:00-10:00) - 잘못된 시간범위")
+    void test_routineG() {
+        // when & then
+        // 수면패턴 등록X인 경우 예외
+        assertThatCode(() -> {
+            onboardingService.saveRoutines(createRoutineG(), testUser);
+        }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+        });
+
+        // 수면패턴 등록한 경우 예외
+        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+            assertThatThrownBy(() -> {
+                onboardingService.saveSleepPattern(sleepPattern, testUser);
+                onboardingService.saveRoutines(createRoutineG(), testUser);
+            }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("반복일정H(13:00-13:00) - 잘못된 시간범위")
+    void test_routineH() {
+        // when & then
+        // 수면패턴 등록X인 경우 예외
+        assertThatCode(() -> {
+            onboardingService.saveRoutines(createRoutineH(), testUser);
+        }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+        });
+
+        // 수면패턴 등록한 경우 예외
+        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+            assertThatThrownBy(() -> {
+                onboardingService.saveSleepPattern(sleepPattern, testUser);
+                onboardingService.saveRoutines(createRoutineH(), testUser);
+            }).isInstanceOfSatisfying(OnboardingHandler.class, ex -> {
+                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("반복일정I(같은 요일 시간 겹침) - 반복일정 충돌")
+    void test_routineI() {
+        // when & then
+        // 수면패턴 등록X인 경우 예외
+        assertThatCode(() -> {
+            onboardingService.saveRoutines(createRoutineI(), testUser);
+        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
+        });
+
+        // 수면패턴 등록한 경우 예외
+        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+            assertThatThrownBy(() -> {
+                onboardingService.saveSleepPattern(sleepPattern, testUser);
+                onboardingService.saveRoutines(createRoutineI(), testUser);
+            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
+            });
+        }
+    }
+
+    // ==================== 헬퍼 메서드 ====================
+
+    // 수면패턴 생성 메서드
+    private OnboardingRequestDto.SleepPatternRequest createSleepPatternA() {
+        // A: 22:00-07:00
+        return OnboardingRequestDto.SleepPatternRequest.builder()
+                .sleepTime(LocalTime.of(22, 0))
+                .wakeTime(LocalTime.of(7, 0))
+                .build();
+    }
+
+    private OnboardingRequestDto.SleepPatternRequest createSleepPatternB() {
+        // B: 18:00-00:00
+        return OnboardingRequestDto.SleepPatternRequest.builder()
+                .sleepTime(LocalTime.of(18, 0))
+                .wakeTime(LocalTime.MIDNIGHT)
+                .build();
+    }
+
+    private OnboardingRequestDto.SleepPatternRequest createSleepPatternC() {
+        // C: 00:00-09:00
+        return OnboardingRequestDto.SleepPatternRequest.builder()
+                .sleepTime(LocalTime.MIDNIGHT)
+                .wakeTime(LocalTime.of(9, 0))
+                .build();
+    }
+
+    private OnboardingRequestDto.SleepPatternRequest createSleepPatternD() {
+        // D: 11:00-20:00
+        return OnboardingRequestDto.SleepPatternRequest.builder()
+                .sleepTime(LocalTime.of(11, 0))
+                .wakeTime(LocalTime.of(20, 0))
+                .build();
+    }
+
+    // 반복일정 생성 메서드
+    private OnboardingRequestDto.RoutineListRequest createRoutineA() {
+        // A: 09:00-18:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), "틈틈 개발")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineB() {
+        // B: 11:00-19:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(11, 0), LocalTime.of(19, 0), "틈틈 개발")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineC() {
+        // C: 20:00-00:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(20, 0), LocalTime.MIDNIGHT, "틈틈 개발")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineD() {
+        // D: 00:00-04:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.TUESDAY, LocalTime.MIDNIGHT, LocalTime.of(4, 0), "틈틈 개발")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineE() {
+        // E: 00:00-00:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, "24시간 일정 - 하루 안에서")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineF() {
+        // F: 예외 23:00-02:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(23, 0), LocalTime.of(2, 0), "다음 날로 넘어감")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineG() {
+        // G: 예외 15:00-10:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(15, 0), LocalTime.of(10, 0), "잘못된 시간 범위")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineH() {
+        // H: 예외 13:00-13:00
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(13, 0), LocalTime.of(13, 0), "24시간 일정 - 다음 날로 넘어감")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineListRequest createRoutineI() {
+        // I: 예외 반복일정 충돌
+        List<OnboardingRequestDto.RoutineDTO> routines = Arrays.asList(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(10, 0), LocalTime.of(14, 0), "틈틈 개발"),
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), "틈틈 개발")
+        );
+        return OnboardingRequestDto.RoutineListRequest.builder().routine(routines).build();
+    }
+
+    private OnboardingRequestDto.RoutineDTO createRoutineDTO(Weekday weekday, LocalTime startTime, LocalTime endTime, String title) {
+        return OnboardingRequestDto.RoutineDTO.builder()
+                .weekday(weekday)
+                .startTime(startTime)
+                .endTime(endTime)
+                .title(title)
+                .build();
+    }
+
+    private List<OnboardingRequestDto.SleepPatternRequest> getAllSleepPatterns() {
+        return List.of(
+                createSleepPatternA(),
+                createSleepPatternB(),
+                createSleepPatternC(),
+                createSleepPatternD()
+        );
+    }
+
+    private List<OnboardingRequestDto.RoutineListRequest> getAllRoutines() {
+        return List.of(
+                createRoutineA(),
+                createRoutineB(),
+                createRoutineC(),
+                createRoutineD()
+        );
+    }
+}

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -1,4 +1,4 @@
-package umc.teumteum.server.service;
+package umc.teumteum.server.unit.user.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
### 👀 관련 이슈
#79

### ✨ 작업한 내용
- **약관 동의 API 이력 조회 삭제**
user의 step이 약관 동의 여부와 의미가 통하기 때문에 불필요한 쿼리가 발생하는 거 같아서 삭제하였습니다.

- **반복 일정 등록 API 구현**
온보딩 흐름 변화에 의해 [반복일정끼리의 시간 충돌] -> [반복일정 + 수면패턴과의 시간 충돌] 이 되면서 기존에 작업 중이던 로직을 수정하게 되었습니다.
현재 반복일정 등록 API는 다음과 같이 진행됩니다.
  1. 각 일정마다 시간&종료 시간이 올바르게 설정되었는지 체크
  2. 반복일정을 Map<요일, 일정리스트> 형태로 묶음
  3. 요일별로 반복일정끼리의 시간 충돌 체크 (`validateTimeRangeConflicts(List<TimeRange>)`)
  4. 수면패턴과 반복일정의 시간 충돌 체크 (`validateTimeRangeConflicts(List<TimeRange>)`)
  5. 기존 데이터 삭제 후 저장 (온보딩 중단 고려)

### 🌀 PR Point
- 시간 충돌 로직은 다음과 같이 구현하였습니다.
  1. `TimeRange` 객체들을 시작시간 순으로 정렬 (`TimeRange`는 시작&종료시간으로 구성)
  2. `if ( currentEnd.isAfter(nextStart) )` 로 인접한 객체들끼리 시간 충돌을 판단
ex) 15:00\~17:00 / 16:00\~18:00의 경우, `17:00.isAfter(16:00)`로 인해서 시간 충돌로 판단 O
ex) 20:00\~00:00 / 22:00\~05:00의 경우, `00:00.isAfter(22:00)`로 인해서 시간 충돌로 판단  X
-> 이를 위해서 `endTime`의 경우 `convertEndTime()`로 00:00은 `LocalTime.MAX`로 변환하여 `23:59:59.9999.isAfter(22:00)`로 시간 충돌로 판단되도록 처리하였습니다.

- 수면패턴은, 22:00\~08:00 같은 경우 22:00\~00:00 + 00:00\~08:00로 분리합니다.

- [약관 동의 -> 닉네임 -> 프로필 -> 수면패턴 -> 반복일정 -> 리마인드]로 초기 흐름이 긴만큼 변수가 많아 중간 중단을 고려하여 [기존 데이터 delete -> save]를 진행합니다. [exists 후 삭제]를 하면 그만큼 쿼리가 1개 더 나가게 되어 바로 삭제를 진행하고, 기본 JPA 메소드는 [select -> 데이터개수만큼 delete]를 하기 때문에 JPQL Bulk Delete를 사용하였습니다.

### 🍰 참고사항
시간 충돌이.. 고려해야 되는 케이스가 너무 많습니다...
정리가 안되어서 테스트 코드를 작성해보았는데요.. 효과는 봤지만 퀄리티는 별로라 넘기셔도 됩니다..
이외에도 테스트 케이스가 더 있을 거 같긴한데.. 아마 있더라도 예상 결과대로 나올 거 같아요..? 🥲🤯
https://www.notion.so/22966802aaae80a7970fc642ed60656d?source=copy_link

※ 참고)
수면패턴은 선택 입력, 다음날에 걸친 표현 가능 (22:00\~08:00), 24시간도 가능( 00:00\~00:00, 13:00\~13:00)
반복일정은 선택 입력, 같은날 안에만 표현  가능, 24시간도 가능 (But, 00:00\~00:00만 가능)

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  반복일정 등록 API  |  <img width="341" height="787" alt="스크린샷 2025-07-28 오후 6 44 09" src="https://github.com/user-attachments/assets/0812776c-dba2-4ed3-b846-9f972f0d0751" />  |