### PR TITLE
Feat: ConflictValidator 구현 및 틈 관련 API에 중복 검사 적용

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -117,23 +117,18 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Routine> findDeletedRoutinesByUserAndDate(@Param("user") User user, @Param("date") LocalDate date);
 
     /**
-     * 사용자 일정 중 다음 조건을 모두 만족하는 일정들을 조회:
+     * 사용자 일정 중 다음 조건을 모두 만족하는 일정 조회:
      * - 해당 사용자(user)의 일정이며
-     * - 일정 타입이 TODO, WISH, AI 중 하나이며
-     * - 요청된 시간 범위(start ~ end)와 겹치는 일정
+     * - 일정 타입이 TODO, WISH, AI 중 하나
      */
     @Query("""
     SELECT s FROM Schedule s
     WHERE s.user = :user
       AND s.type IN :types
-      AND s.startTime < :end
-      AND s.endTime > :start
 """)
-    List<Schedule> findConflictingSchedules(
+    List<Schedule> findSchedulesByUserAndType(
             @Param("user") User user,
-            @Param("types") List<ScheduleType> types,
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end
+            @Param("types") List<ScheduleType> types
     );
 
     /**

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -149,4 +149,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("date") LocalDate date
     );
 
+    boolean existsByTeumRequestAndUser(TeumRequest teumRequest, User user);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
@@ -114,5 +115,24 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     WHERE s.user = :user AND s.date = :date AND s.isDeleted = true AND s.routine IS NOT NULL""")
     List<Routine> findDeletedRoutinesByUserAndDate(@Param("user") User user, @Param("date") LocalDate date);
 
+    /**
+     * 사용자 일정 중 다음 조건을 모두 만족하는 일정들을 조회:
+     * - 해당 사용자(user)의 일정이며
+     * - 일정 타입이 TODO, WISH, AI 중 하나이며
+     * - 요청된 시간 범위(start ~ end)와 겹치는 일정
+     */
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user = :user
+      AND s.type IN :types
+      AND s.startTime < :end
+      AND s.endTime > :start
+""")
+    List<Schedule> findConflictingSchedules(
+            @Param("user") User user,
+            @Param("types") List<ScheduleType> types,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -14,6 +14,7 @@ import umc.teumteum.server.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
@@ -133,6 +134,24 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("types") List<ScheduleType> types,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
+    );
+
+    /**
+     * 사용자 일정 중 다음 조건을 모두 만족하는 일정 조회:
+     * - 해당 사용자(user)의 루틴으로 생성된 일정이며
+     * - 주어진 날짜(date)에 생성된 일정
+     * - 반복 일정(Routine)의 실제 스케줄 인스턴스 존재 여부 확인에 사용
+     */
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user = :user
+      AND s.routine = :routine
+      AND s.date = :date
+""")
+    Optional<Schedule> findByUserAndRoutineAndDate(
+            @Param("user") User user,
+            @Param("routine") Routine routine,
+            @Param("date") LocalDate date
     );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumErrorStatus.java
@@ -17,7 +17,7 @@ public enum TeumErrorStatus implements BaseErrorCode {
     INVALID_TEUM_TIME(HttpStatus.BAD_REQUEST, "TEUM4001", "시작 시간과 종료 시간이 유효하지 않습니다."),
     DUPLICATE_RECEIVER(HttpStatus.CONFLICT, "TEUM4090", "수신자 목록에 중복된 사용자가 포함되어 있습니다."),
     CANNOT_REQUEST_SELF(HttpStatus.CONFLICT, "TEUM4091", "자기 자신에게 틈 요청을 보낼 수 없습니다."),
-    SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "TEUM4092", "이미 해당 시간에 다른 스케줄이 존재합니다."),
+    TEUM_REQUEST_CONFLICT(HttpStatus.CONFLICT, "TEUM4092", "해당 시간에 틈 요청이 존재합니다."),
     REQUEST_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "TEUM4002", "이미 마감된 요청입니다."),
     INVALID_PARENT_REQUEST(HttpStatus.BAD_REQUEST, "TEUM4003", "재요청의 기준이 되는 요청이 올바르지 않습니다."),
     REQUEST_NOT_ONE_TO_ONE(HttpStatus.BAD_REQUEST, "TEUM4004", "재요청은 수신자가 1명인 요청에 대해서만 가능합니다."),

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -19,16 +19,15 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
 
     /**
      * 다음 조건을 모두 만족하는 TeumRequest들을 조회:
-     * - 요청자 또는 수신자가 해당 사용자(user)인 요청
+     * - 요청자가 해당 사용자(user)인 요청
      * - 상태가 ACTIVE이고 아직 약속된 스케줄이 없음 (schedules.isEmpty)
      * - 요청 날짜(date)가 지정한 날짜와 일치
      * → 시간 겹침 여부는 자바에서 별도 검사
      */
     @Query("""
     SELECT tr FROM TeumRequest tr
-    LEFT JOIN tr.teumResponses r
     WHERE tr.status = 'ACTIVE'
-      AND (tr.user = :user OR r.receiverUser = :user)
+      AND tr.user = :user
       AND tr.schedules IS EMPTY
       AND tr.date = :date
 """)

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.user.entity.User;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> {
@@ -13,5 +16,28 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
             "(t.date < :today OR (t.date = :today AND t.startTime < :nowTime))")
     List<TeumRequest> findAllClosed(@Param("today") java.time.LocalDate today,
                                      @Param("nowTime") java.time.LocalTime nowTime);
+
+    /**
+     * 사용자와 관련된 ACTIVE 상태의 TeumRequest 중
+     * - 틈 요청에서 파생된 약속된 틈이 없으며
+     * - 날짜가 일치하고
+     * - 시간대가 겹치는 요청들을 조회
+     */
+    @Query("""
+    SELECT tr FROM TeumRequest tr
+    LEFT JOIN tr.teumResponses r
+    WHERE tr.status = 'ACTIVE'
+      AND (tr.user = :user OR r.receiverUser = :user)
+      AND tr.schedules IS EMPTY
+      AND tr.date = :date
+      AND FUNCTION('TIME', tr.startTime) < :end
+      AND FUNCTION('TIME', tr.endTime) > :start
+""")
+    List<TeumRequest> findConflictingTeumRequest(
+            @Param("user") User user,
+            @Param("date") LocalDate date,
+            @Param("start") LocalTime start,
+            @Param("end") LocalTime end
+    );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -18,10 +18,11 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
                                      @Param("nowTime") java.time.LocalTime nowTime);
 
     /**
-     * 사용자와 관련된 ACTIVE 상태의 TeumRequest 중
-     * - 틈 요청에서 파생된 약속된 틈이 없으며
-     * - 날짜가 일치하고
-     * - 시간대가 겹치는 요청들을 조회
+     * 다음 조건을 모두 만족하는 TeumRequest들을 조회:
+     * - 요청자 또는 수신자가 해당 사용자(user)인 요청
+     * - 상태가 ACTIVE이고 아직 약속된 스케줄이 없음 (schedules.isEmpty)
+     * - 요청 날짜(date)가 지정한 날짜와 일치
+     * → 시간 겹침 여부는 자바에서 별도 검사
      */
     @Query("""
     SELECT tr FROM TeumRequest tr
@@ -30,14 +31,11 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
       AND (tr.user = :user OR r.receiverUser = :user)
       AND tr.schedules IS EMPTY
       AND tr.date = :date
-      AND FUNCTION('TIME', tr.startTime) < :end
-      AND FUNCTION('TIME', tr.endTime) > :start
 """)
-    List<TeumRequest> findConflictingTeumRequest(
+    List<TeumRequest> findTeumRequestsByUserAndDate(
             @Param("user") User user,
-            @Param("date") LocalDate date,
-            @Param("start") LocalTime start,
-            @Param("end") LocalTime end
+            @Param("date") LocalDate date
     );
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -31,6 +31,7 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
+import umc.teumteum.server.global.validator.ConflictValidator;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -48,6 +49,7 @@ import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.I
 public class TeumServiceImpl implements TeumService {
 
     private final S3Util s3Util;
+    private final ConflictValidator conflictValidator;
     private final UserRepository userRepository;
     private final TeumRequestRepository teumRequestRepository;
     private final TeumResponseRepository teumResponseRepository;
@@ -56,8 +58,26 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional
     public Long createRequest(TeumRequestDto dto, User user) {
-        TeumRequest request = TeumConverter.toTeumRequest(dto, user);
+        // 시간 순서 검증
+        validateTimeOrder(dto.getStartTime(), dto.getEndTime());
 
+        // 날짜 및 시간 파싱
+        LocalDate date = LocalDate.parse(dto.getDate());
+        LocalTime startTime = LocalTime.parse(dto.getStartTime());
+        LocalTime endTime = LocalTime.parse(dto.getEndTime());
+
+        // 모든 사용자 조회 (요청자 + 수신자)
+        List<User> receivers = dto.getReceiverUserIds().stream()
+                .map(this::getUserOrThrow)
+                .toList();
+        List<User> allParticipants = new ArrayList<>(receivers);
+        allParticipants.add(user);
+
+        // Validator 호출
+        conflictValidator.validateTeumForUsers(allParticipants, date, startTime, endTime);
+
+        // 요청 객체 생성 및 저장
+        TeumRequest request = TeumConverter.toTeumRequest(dto, user);
         List<TeumResponse> responses = TeumConverter.toTeumResponses(
                 dto.getReceiverUserIds(),
                 user.getId(),
@@ -74,17 +94,27 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional
     public Long createResendRequest(Long parentRequestId, TeumResendRequestDto dto, User user) {
+        // 원본 요청 확인 및 권한 검증
         TeumRequest parent = findActiveRequestOrThrow(parentRequestId);
-
         validateResendableRequest(parent);
         validateResender(parent, user.getId());
+
+        // 시간 순서 검증
         validateTimeOrder(dto.getStartTime(), dto.getEndTime());
 
-        TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, user); // ✅ User 객체 직접 전달
+        // 시간 충돌 검증 (날짜는 부모 요청 기준)
+        LocalDate date = parent.getDate();
+        LocalTime startTime = LocalTime.parse(dto.getStartTime());
+        LocalTime endTime = LocalTime.parse(dto.getEndTime());
 
+        conflictValidator.validateTeum(user, date, startTime, endTime);
+
+        // 요청 및 응답 생성
+        TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, user);
         TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, parent.getUser());
         newRequest.getTeumResponses().add(newResponse);
 
+        // 원래 요청 상태 변경
         TeumResponse originalResponse = parent.getTeumResponses().getFirst();
         originalResponse.changeStatus(ResponseStatus.RESEND);
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -102,19 +102,22 @@ public class TeumServiceImpl implements TeumService {
         // 시간 순서 검증
         validateTimeOrder(dto.getStartTime(), dto.getEndTime());
 
-        // 시간 충돌 검증 (날짜는 부모 요청 기준)
+        // 시간 충돌 검증 (요청자 + 수신자 모두)
         LocalDate date = parent.getDate();
         LocalTime startTime = LocalTime.parse(dto.getStartTime());
         LocalTime endTime = LocalTime.parse(dto.getEndTime());
 
-        conflictValidator.validateTeum(user, date, startTime, endTime);
+        User originalSender = parent.getUser();  // 부모 요청의 작성자 → 이번 재요청의 수신자
+
+        List<User> participants = List.of(user, originalSender);
+        conflictValidator.validateTeumForUsers(participants, date, startTime, endTime);
 
         // 요청 및 응답 생성
         TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, user);
-        TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, parent.getUser());
+        TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, originalSender);
         newRequest.getTeumResponses().add(newResponse);
 
-        // 원래 요청 상태 변경
+        // 응답 상태 변경
         TeumResponse originalResponse = parent.getTeumResponses().getFirst();
         originalResponse.changeStatus(ResponseStatus.RESEND);
 
@@ -122,6 +125,7 @@ public class TeumServiceImpl implements TeumService {
 
         return newRequest.getId();
     }
+
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -203,9 +203,9 @@ public class TeumServiceImpl implements TeumService {
             Schedule receiverSchedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
             scheduleRepository.save(receiverSchedule);
 
-            // 스케줄이 없는 경우에만 요청자에게도 생성
-            if (request.getSchedules().isEmpty()) {
-                User requester = request.getUser();
+            // 요청자 본인의 스케줄이 없는 경우에만 생성
+            User requester = request.getUser();
+            if (!scheduleRepository.existsByTeumRequestAndUser(request, requester)) {
                 Schedule requesterSchedule = TeumConverter.toScheduleFromTeumRequest(request, requester);
                 scheduleRepository.save(requesterSchedule);
             }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -165,13 +165,16 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional
     public TeumStatusUpdateResponseDto updateResponseStatus(Long responseId, Long userId, TeumStatusUpdateRequestDto requestDto) {
+        // 응답 조회 및 권한 검증
         TeumResponse response = getResponseOrThrow(responseId);
         validateReceiver(response, userId);
 
+        // 이미 처리된 응답인 경우 예외
         if (response.getStatus() != ResponseStatus.PENDING) {
             throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
         }
 
+        // 요청된 응답 상태 유효성 검증
         ResponseStatus newStatus;
         try {
             newStatus = ResponseStatus.valueOf(requestDto.getStatus().toUpperCase());
@@ -179,6 +182,7 @@ public class TeumServiceImpl implements TeumService {
             throw new GeneralException(TeumErrorStatus.INVALID_RESPONSE_STATUS);
         }
 
+        // 상태 변경 적용
         response.changeStatus(newStatus);
 
         boolean isAccepted = newStatus == ResponseStatus.ACCEPTED;
@@ -186,12 +190,20 @@ public class TeumServiceImpl implements TeumService {
 
         if (isAccepted) {
             TeumRequest request = response.getTeumRequest();
-
             User receiver = response.getReceiverUser();
+
+            // 수락 시 응답자 개인 일정 충돌 검증
+            LocalDate date = request.getDate();
+            LocalTime startTime = request.getStartTime();
+            LocalTime endTime = request.getEndTime();
+
+            conflictValidator.validateTeum(receiver, date, startTime, endTime);
+
+            // 수신자(응답자) 일정 생성
             Schedule receiverSchedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
             scheduleRepository.save(receiverSchedule);
 
-            // 스케줄이 없는 경우에만 요청자에게 생성
+            // 스케줄이 없는 경우에만 요청자에게도 생성
             if (request.getSchedules().isEmpty()) {
                 User requester = request.getUser();
                 Schedule requesterSchedule = TeumConverter.toScheduleFromTeumRequest(request, requester);
@@ -202,9 +214,9 @@ public class TeumServiceImpl implements TeumService {
             teumId = receiverSchedule.getId();
         }
 
-
         return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
     }
+
 
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/user/entity/enums/Weekday.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/enums/Weekday.java
@@ -15,4 +15,8 @@ public enum Weekday {
     public boolean matches(DayOfWeek dayOfWeek) {
         return this.name().equalsIgnoreCase(dayOfWeek.name());
     }
+
+    public static Weekday from(DayOfWeek dayOfWeek) {
+        return Weekday.valueOf(dayOfWeek.name());
+    }
 }

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -21,7 +21,11 @@ public class ConflictValidator {
 
     private final ScheduleRepository scheduleRepository;
 
-    // 틈 관련 중복 검증 로직
+    /**
+     * 단일 사용자에 대한 Teum 시간 중복 검증 로직
+     * - 사용자가 일정 생성 또는 Teum 응답을 시도할 때 호출
+     * - 일정, 미확정된 틈 요청, 반복 일정, 수면 시간과 겹침 여부를 검사
+     */
     public void validateTeum(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
         LocalDateTime startDateTime = LocalDateTime.of(date, startTime);
         LocalDateTime endDateTime = LocalDateTime.of(date, endTime);
@@ -30,6 +34,16 @@ public class ConflictValidator {
         checkWithTeumRequests(user, date, startTime, endTime);
         checkWithRoutines(user, date, startTime, endTime);
         checkWithSleepPattern(user, startTime, endTime);
+    }
+
+    /**
+     * 다자간 Teum 요청 시 모든 참여자에 대해 중복 검사를 수행
+     * - 틈 요청 및 재요청 생성 시 사용되며, 요청자 + 모든 수신자 일정과 겹침이 없어야 생성 가능
+     */
+    public void validateTeumForUsers(List<User> users, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        for (User user : users) {
+            validateTeum(user, date, startTime, endTime);
+        }
     }
 
     // TODO: 다른 일정에서의 중복 검증 로직 추가

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -10,13 +10,16 @@ import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.global.exception.GeneralException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
@@ -36,7 +39,7 @@ public class ConflictValidator {
 
         checkWithSchedules(user, startDateTime, endDateTime);
         checkWithTeumRequests(user, date, startTime, endTime);
-        checkWithRoutines(user, date, startTime, endTime);
+        checkWithRoutines(user, date, startDateTime, endDateTime);
         checkWithSleepPattern(user, date, startDateTime, endDateTime);
     }
 
@@ -81,9 +84,43 @@ public class ConflictValidator {
         }
     }
 
-    private void checkWithRoutines(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
-        // TODO: 반복 일정 루틴 + 루틴 ID 기반 Schedule 조회 + isDeleted 여부로 충돌 판단
+    private void checkWithRoutines(User user, LocalDate date, LocalDateTime requestStart, LocalDateTime requestEnd) {
+        Weekday weekday = Weekday.from(date.getDayOfWeek());
+
+        List<Routine> routines = user.getRoutines().stream()
+                .filter(r -> r.getWeekday() == weekday)
+                .toList();
+
+        for (Routine routine : routines) {
+            LocalTime routineStartTime = routine.getStartTime();
+            LocalTime routineEndTime = routine.getEndTime();
+
+            // 루틴 시간 → LocalDateTime으로 조합 (자정 넘김 고려)
+            LocalDateTime routineStart = LocalDateTime.of(date, routineStartTime);
+            LocalDateTime routineEnd = routineStartTime.isBefore(routineEndTime)
+                    ? LocalDateTime.of(date, routineEndTime)
+                    : LocalDateTime.of(date.plusDays(1), routineEndTime);
+
+            // 시간 겹치는지 판단
+            if (isOverlapping(requestStart, requestEnd, routineStart, routineEnd)) {
+                // 해당 루틴 기반 스케줄이 있는지 조회
+                Optional<Schedule> existing = scheduleRepository.findByUserAndRoutineAndDate(user, routine, date);
+
+                // 반복 일정이 생성 예정 상태 → 충돌
+                if (existing.isEmpty()) {
+                    throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+                }
+
+                // Schedule이 존재하되 isDeleted == false면 → 충돌
+                if (!existing.get().getIsDeleted()) {
+                    throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+                }
+
+                // Schedule이 존재하되 isDeleted == true면 -> 충돌 아님
+            }
+        }
     }
+
 
     private void checkWithSleepPattern(User user, LocalDate date, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         LocalTime sleepTime = user.getSleepTime();

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -14,6 +14,7 @@ import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.global.exception.GeneralException;
+import umc.teumteum.server.global.validator.exception.status.ConflictErrorStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,7 +64,7 @@ public class ConflictValidator {
 
         for (Schedule schedule : schedules) {
             if (isOverlapping(requestStart, requestEnd, schedule.getStartTime(), schedule.getEndTime())) {
-                throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+                throw new GeneralException(ConflictErrorStatus.SCHEDULE_CONFLICT);
             }
         }
     }
@@ -76,7 +77,7 @@ public class ConflictValidator {
             LocalDateTime teumEnd = LocalDateTime.of(request.getDate(), request.getEndTime());
 
             if (isOverlapping(requestStart, requestEnd, teumStart, teumEnd)) {
-                throw new GeneralException(TeumErrorStatus.TEUM_REQUEST_CONFLICT);
+                throw new GeneralException(ConflictErrorStatus.TEUM_REQUEST_CONFLICT);
             }
         }
     }
@@ -105,12 +106,12 @@ public class ConflictValidator {
 
                 // 반복 일정이 생성 예정 상태 → 충돌
                 if (existing.isEmpty()) {
-                    throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+                    throw new GeneralException(ConflictErrorStatus.ROUTINE_CONFLICT);
                 }
 
                 // Schedule이 존재하되 isDeleted == false면 → 충돌
                 if (!existing.get().getIsDeleted()) {
-                    throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+                    throw new GeneralException(ConflictErrorStatus.ROUTINE_CONFLICT);
                 }
 
                 // Schedule이 존재하되 isDeleted == true면 -> 충돌 아님
@@ -129,7 +130,7 @@ public class ConflictValidator {
                 : LocalDateTime.of(date.plusDays(1), wakeTime);  // 자정 넘기는 경우 다음 날로
 
         if (isOverlapping(startDateTime, endDateTime, sleepStart, sleepEnd)) {
-            throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+            throw new GeneralException(ConflictErrorStatus.SLEEP_PATTERN_CONFLICT);
         }
     }
 

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -1,12 +1,25 @@
 package umc.teumteum.server.global.validator;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.exception.GeneralException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
+@RequiredArgsConstructor
+@Component
 public class ConflictValidator {
+
+    private final ScheduleRepository scheduleRepository;
 
     // 틈 관련 중복 검증 로직
     public void validateTeum(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
@@ -23,8 +36,20 @@ public class ConflictValidator {
 
     // 내부 충돌 검사 메서드들
     private void checkWithSchedules(User user, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        // TODO: Schedule 테이블에서 ACTIVE && 시간 겹침 검사
+        List<ScheduleType> types = List.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI);
+
+        List<Schedule> conflicts = scheduleRepository.findConflictingSchedules(
+                user,
+                types,
+                startDateTime,
+                endDateTime
+        );
+
+        if (!conflicts.isEmpty()) {
+            throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+        }
     }
+
 
     private void checkWithTeumRequests(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
         // TODO: 확정되지 않은 ACTIVE TeumRequest && 시간 겹침 검사

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -37,7 +37,7 @@ public class ConflictValidator {
         checkWithSchedules(user, startDateTime, endDateTime);
         checkWithTeumRequests(user, date, startTime, endTime);
         checkWithRoutines(user, date, startTime, endTime);
-        checkWithSleepPattern(user, startTime, endTime);
+        checkWithSleepPattern(user, date, startDateTime, endDateTime);
     }
 
     /**
@@ -85,7 +85,28 @@ public class ConflictValidator {
         // TODO: 반복 일정 루틴 + 루틴 ID 기반 Schedule 조회 + isDeleted 여부로 충돌 판단
     }
 
-    private void checkWithSleepPattern(User user, LocalTime startTime, LocalTime endTime) {
-        // TODO: sleepTime, wakeTime과 시간 겹침 판단
+    private void checkWithSleepPattern(User user, LocalDate date, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        LocalTime sleepTime = user.getSleepTime();
+        LocalTime wakeTime = user.getWakeTime();
+
+        LocalDateTime sleepStart = LocalDateTime.of(date, sleepTime);
+        LocalDateTime sleepEnd = sleepTime.isBefore(wakeTime)
+                ? LocalDateTime.of(date, wakeTime)
+                : LocalDateTime.of(date.plusDays(1), wakeTime);  // 자정 넘기는 경우 다음 날로
+
+        if (isOverlapping(startDateTime, endDateTime, sleepStart, sleepEnd)) {
+            throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+        }
     }
+
+    /**
+     * 두 시간 구간이 겹치는지 여부를 반환
+     * 겹침 기준: [start1, end1) 과 [start2, end2) 가 교차하는 경우
+     * - start1 < end2 && end1 > start2 일 때 겹침으로 간주
+     * - 끝점이 정확히 맞닿는 경우 (예: end1 == start2)는 겹치지 않는 것으로 판단
+     */
+    private boolean isOverlapping(LocalDateTime start1, LocalDateTime end1, LocalDateTime start2, LocalDateTime end2) {
+        return start1.isBefore(end2) && end1.isAfter(start2);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -72,7 +72,7 @@ public class ConflictValidator {
     }
 
     private void checkWithTeumRequests(User user, LocalDateTime requestStart, LocalDateTime requestEnd) {
-        List<TeumRequest> requests = teumRequestRepository.findRelatedTeumRequestsByUserAndDate(user, requestStart.toLocalDate());
+        List<TeumRequest> requests = teumRequestRepository.findTeumRequestsByUserAndDate(user, requestStart.toLocalDate());
 
         for (TeumRequest request : requests) {
             LocalDateTime teumStart = LocalDateTime.of(request.getDate(), request.getStartTime());

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -120,19 +120,29 @@ public class ConflictValidator {
     }
 
 
-    private void checkWithSleepPattern(User user, LocalDate date, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    private void checkWithSleepPattern(User user, LocalDate date, LocalDateTime requestStart, LocalDateTime requestEnd) {
         LocalTime sleepTime = user.getSleepTime();
         LocalTime wakeTime = user.getWakeTime();
 
-        LocalDateTime sleepStart = LocalDateTime.of(date, sleepTime);
-        LocalDateTime sleepEnd = sleepTime.isBefore(wakeTime)
+        // 수면 시간은 이전 날짜 기준으로도 체크 필요
+        // 1) 오늘 기준 수면 시간
+        LocalDateTime sleepStartToday = LocalDateTime.of(date, sleepTime);
+        LocalDateTime sleepEndToday = sleepTime.isBefore(wakeTime)
                 ? LocalDateTime.of(date, wakeTime)
-                : LocalDateTime.of(date.plusDays(1), wakeTime);  // 자정 넘기는 경우 다음 날로
+                : LocalDateTime.of(date.plusDays(1), wakeTime);
 
-        if (isOverlapping(startDateTime, endDateTime, sleepStart, sleepEnd)) {
+        // 2) 전날 기준 수면 시간 (자정 넘긴 부분 때문에)
+        LocalDateTime sleepStartPrev = LocalDateTime.of(date.minusDays(1), sleepTime);
+        LocalDateTime sleepEndPrev = sleepTime.isBefore(wakeTime)
+                ? LocalDateTime.of(date.minusDays(1), wakeTime)
+                : LocalDateTime.of(date, wakeTime);
+
+        if (isOverlapping(requestStart, requestEnd, sleepStartToday, sleepEndToday)
+                || isOverlapping(requestStart, requestEnd, sleepStartPrev, sleepEndPrev)) {
             throw new GeneralException(ConflictErrorStatus.SLEEP_PATTERN_CONFLICT);
         }
     }
+
 
     /**
      * 두 시간 구간이 겹치는지 여부를 반환

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -1,0 +1,40 @@
+package umc.teumteum.server.global.validator;
+
+import umc.teumteum.server.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class ConflictValidator {
+
+    // 틈 관련 중복 검증 로직
+    public void validateTeum(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        LocalDateTime startDateTime = LocalDateTime.of(date, startTime);
+        LocalDateTime endDateTime = LocalDateTime.of(date, endTime);
+
+        checkWithSchedules(user, startDateTime, endDateTime);
+        checkWithTeumRequests(user, date, startTime, endTime);
+        checkWithRoutines(user, date, startTime, endTime);
+        checkWithSleepPattern(user, startTime, endTime);
+    }
+
+    // TODO: 다른 일정에서의 중복 검증 로직 추가
+
+    // 내부 충돌 검사 메서드들
+    private void checkWithSchedules(User user, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        // TODO: Schedule 테이블에서 ACTIVE && 시간 겹침 검사
+    }
+
+    private void checkWithTeumRequests(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        // TODO: 확정되지 않은 ACTIVE TeumRequest && 시간 겹침 검사
+    }
+
+    private void checkWithRoutines(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        // TODO: 반복 일정 루틴 + 루틴 ID 기반 Schedule 조회 + isDeleted 여부로 충돌 판단
+    }
+
+    private void checkWithSleepPattern(User user, LocalTime startTime, LocalTime endTime) {
+        // TODO: sleepTime, wakeTime과 시간 겹침 판단
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -56,18 +56,15 @@ public class ConflictValidator {
     // TODO: 다른 일정에서의 중복 검증 로직 추가
 
     // 내부 충돌 검사 메서드들
-    private void checkWithSchedules(User user, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    private void checkWithSchedules(User user, LocalDateTime requestStart, LocalDateTime requestEnd) {
         List<ScheduleType> types = List.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI);
 
-        List<Schedule> conflicts = scheduleRepository.findConflictingSchedules(
-                user,
-                types,
-                startDateTime,
-                endDateTime
-        );
+        List<Schedule> schedules = scheduleRepository.findSchedulesByUserAndType(user, types);
 
-        if (!conflicts.isEmpty()) {
-            throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+        for (Schedule schedule : schedules) {
+            if (isOverlapping(requestStart, requestEnd, schedule.getStartTime(), schedule.getEndTime())) {
+                throw new GeneralException(HomeErrorStatus._SCHEDULE_CONFLICT);
+            }
         }
     }
 

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -38,7 +38,7 @@ public class ConflictValidator {
         LocalDateTime endDateTime = LocalDateTime.of(date, endTime);
 
         checkWithSchedules(user, startDateTime, endDateTime);
-        checkWithTeumRequests(user, date, startTime, endTime);
+        checkWithTeumRequests(user, startDateTime, endDateTime);
         checkWithRoutines(user, date, startDateTime, endDateTime);
         checkWithSleepPattern(user, date, startDateTime, endDateTime);
     }
@@ -71,16 +71,16 @@ public class ConflictValidator {
         }
     }
 
-    private void checkWithTeumRequests(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
-        List<TeumRequest> conflicts = teumRequestRepository.findConflictingTeumRequest(
-                user,
-                date,
-                startTime,
-                endTime
-        );
+    private void checkWithTeumRequests(User user, LocalDateTime requestStart, LocalDateTime requestEnd) {
+        List<TeumRequest> requests = teumRequestRepository.findRelatedTeumRequestsByUserAndDate(user, requestStart.toLocalDate());
 
-        if (!conflicts.isEmpty()) {
-            throw new GeneralException(TeumErrorStatus.TEUM_REQUEST_CONFLICT);
+        for (TeumRequest request : requests) {
+            LocalDateTime teumStart = LocalDateTime.of(request.getDate(), request.getStartTime());
+            LocalDateTime teumEnd = LocalDateTime.of(request.getDate(), request.getEndTime());
+
+            if (isOverlapping(requestStart, requestEnd, teumStart, teumEnd)) {
+                throw new GeneralException(TeumErrorStatus.TEUM_REQUEST_CONFLICT);
+            }
         }
     }
 

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -7,6 +7,9 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
+import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.exception.GeneralException;
 
@@ -20,6 +23,7 @@ import java.util.List;
 public class ConflictValidator {
 
     private final ScheduleRepository scheduleRepository;
+    private final TeumRequestRepository teumRequestRepository;
 
     /**
      * 단일 사용자에 대한 Teum 시간 중복 검증 로직
@@ -64,9 +68,17 @@ public class ConflictValidator {
         }
     }
 
-
     private void checkWithTeumRequests(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
-        // TODO: 확정되지 않은 ACTIVE TeumRequest && 시간 겹침 검사
+        List<TeumRequest> conflicts = teumRequestRepository.findConflictingTeumRequest(
+                user,
+                date,
+                startTime,
+                endTime
+        );
+
+        if (!conflicts.isEmpty()) {
+            throw new GeneralException(TeumErrorStatus.TEUM_REQUEST_CONFLICT);
+        }
     }
 
     private void checkWithRoutines(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {

--- a/src/main/java/umc/teumteum/server/global/validator/exception/status/ConflictErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/validator/exception/status/ConflictErrorStatus.java
@@ -1,0 +1,43 @@
+package umc.teumteum.server.global.validator.exception.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc.teumteum.server.global.apiPayload.code.BaseErrorCode;
+import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
+
+@Getter
+@AllArgsConstructor
+public enum ConflictErrorStatus implements BaseErrorCode {
+
+    /**
+     * 중복 시간 관련 충돌 예외
+     */
+    SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "CONFLICT4091", "해당 시간에는 일정이 존재합니다."),
+    TEUM_REQUEST_CONFLICT(HttpStatus.CONFLICT, "CONFLICT4092", "해당 시간에는 틈 요청이 존재합니다."),
+    ROUTINE_CONFLICT(HttpStatus.CONFLICT, "CONFLICT4093", "해당 시간에는 반복 일정이 존재합니다."),
+    SLEEP_PATTERN_CONFLICT(HttpStatus.CONFLICT, "CONFLICT4094", "해당 시간에는 수면 패턴이 존재합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#100 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `ConflictValidator` 생성 및 중복 검사 책임 분리
- 중복 검사 대상: 스케줄, 틈 요청, 루틴, 수면 패턴
- 시간 비교 기준을 `LocalDateTime`으로 통일
- `isOverlapping()` 메서드 구현
- 틈 요청/재요청/응답 시 `ConflictValidator` 적용

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- `ConflictValidator`는 다양한 중복 검사 항목을 개별 메서드로 분리하고, 각 정책별로 필요한 조합만 골라 쓸 수 있도록 설계되어 있습니다. 구조적으로 이 방식이 유지보수성과 확장성 면에서 적절한지에 대한 피드백을 받고 싶습니다.
- 현재는 검증 중 첫 번째 충돌 발생 시 바로 예외를 던지도록 구성되어 있어, 다중 충돌 발생 시 첫 항목만 노출됩니다. 이 구조로 충분할지, 아니면 모든 충돌 항목을 수집해서 보여주는 방식이 더 나을지도 의견 주시면 감사하겠습니다.

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
#### 1. 일반 스케줄 (투두, 위시, 채움 활동)
- 스케줄의 타입이 TODO, WISH, AI인 스케줄

#### 2. 확정되지 않은 틈 요청
- 틈 요청의 상태가 ACTIVE이며
- 틈 요청에서 파생된 약속된 틈이 없고
- 본인이 요청자인 틈 요청


#### 3. 반복 일정 (Routine → Schedule로 변환될 예정)

- 반복 일정의 weekday가 틈 요청 날짜의 요일과 일치

- 해당 반복 일정 ID로 생성된 Schedule이 틈 요청 날짜에 존재하는지 확인
    - 존재하지 않으면 → 반복 일정은 예정된 것으로 간주 → 충돌
    - 존재하고 `isDeleted == false` → 충돌
    - 존재하고 `isDeleted == true` → 반복 일정이 삭제된 상태 → 충돌 아님
- 반복 일정과 요일/시간이 맞으면 기본적으로 충돌, 단 삭제된 날은 예외

#### 4. 수면 패턴


- 수면이 하루 안에 끝나는 경우
    - sleepTime < wakeTime → 단일 시간 구간과 겹치는지 확인
- 수면이 자정을 넘기는 경우
    - sleepTime > wakeTime
    - sleepTime ~ 24:00 + 00:00 ~ wakeTime의 두 구간과 비교

구현 시작 전에 작성해둔 것인데 이를 바탕으로 구현하였으니 코드와 함께 보시면 좋을 것 같습니다....

### 📷 테스트 결과

#### 수면 패턴과 중복
```json
{
  "isSuccess": false,
  "code": "CONFLICT4094",
  "message": "해당 시간에는 수면 패턴이 존재합니다."
}
```
#### 일반 스케줄(TODO, WISH, AI)와의 중복
```json
{
  "isSuccess": false,
  "code": "CONFLICT4091",
  "message": "해당 시간에는 일정이 존재합니다."
}
```
#### 틈 요청과 중복
```json
{
  "isSuccess": false,
  "code": "CONFLICT4092",
  "message": "해당 시간에는 틈 요청이 존재합니다."
}
```
#### 반복 일정과의 중복 (스케줄로 등록되지 않은 반복 일정과 스케줄로 등록되었지만 isDeleted == false인 반복 일정)
```json
{
  "isSuccess": false,
  "code": "CONFLICT4093",
  "message": "해당 시간에는 반복 일정이 존재합니다."
}
```
#### 중복 스케줄 없음 (+ 반복 일정이 스케줄로 등록되었으며 isDeleted == true인 경우)
```json
{
  "isSuccess": true,
  "code": "TEUM2004",
  "message": "틈 응답 상태가 성공적으로 변경되었습니다.",
  "result": {
    "status": "ACCEPTED",
    "teumCreated": true,
    "teumId": 2
  }
}
```
- 틈 요청, 재요청, 응답 모두에 대해 테스트를 진행하였으나 테스트 결과가 너무 많아 틈 응답에 대한 결과만 붙여놓겠습니다.
- 틈 요청과 재요청은 본인뿐만 아니라 요청자, 수신자 모두에 대해 검사를 진행해야 하는데, 테스트 결과 제대로 동작하였습니다.