### PR TITLE
Refactor: 소셜 로그인 API 및 S3Util 수정 

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -48,8 +48,8 @@ public class AuthController {
             summary = "토큰 재발급",
             description = "리프레시 토큰을 사용하여 새로운 액세스 토큰&리프레시 토큰을 발급받습니다."
     )
-    @PostMapping(value = "/refresh", produces = "application/json")
-    public ApiResponse<Object> refreshToken(
+    @PostMapping(value = "/reissue", produces = "application/json")
+    public ApiResponse<Object> reissueToken(
     ) {
         // TODO: 토큰 재발급 로직 구현
         return null;

--- a/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.auth.converter;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
 
 public class AuthConverter {
 
@@ -15,7 +16,7 @@ public class AuthConverter {
                 ;
     }
 
-    public static AuthResponseDTO.LoginResponse toLoginResponse(String accessToken, String refreshToken, String nextStep) {
+    public static AuthResponseDTO.LoginResponse toLoginResponse(String accessToken, String refreshToken, UserStep nextStep) {
         return AuthResponseDTO.LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
 
 public class AuthResponseDTO {
 
@@ -14,7 +15,7 @@ public class AuthResponseDTO {
     public static class LoginResponse {
         private String accessToken;     // 액세스토큰
         private String refreshToken;    // 리프레시토큰
-        private String nextStep;        // 다음 화면 단계
+        private UserStep nextStep;        // 다음 화면 단계
     }
 
     @Getter

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -15,7 +15,9 @@ import umc.teumteum.server.domain.auth.exception.AuthHandler;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.service.UserService;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.jwt.JwtProvider;
 
 import java.time.Duration;
@@ -45,20 +47,25 @@ public class AuthServiceImpl implements AuthService {
         // 2. 사용자 조회 (없으면 생성)
         User user = userService.findOrCreateUser(userInfo);
 
-        // 3. 토큰 생성
+        // 3. 사용자 status 확인
+        if (user.getStatus().equals(UserStatus.INACTIVE)) {
+            throw new AuthHandler(ErrorStatus.INACTIVE_USER);
+        }
+
+        // 4. 토큰 생성
         String accessToken = jwtProvider.generateAccessToken(user.getId());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
         // TODO 기기별 분리 저장 필요
-        // 4. 리프레시 토큰 저장
+        // 5. 리프레시 토큰 저장
         String key = user.getId().toString();
         Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
         rtRedisTemplate.opsForValue().set(key, refreshToken, refreshDuration);
 
-        // 5. 다음 단계 결정
+        // 6. 다음 단계 결정
         String nextStep = String.valueOf(user.getStep());
 
-        // 6. converter 작업
+        // 7. converter 작업
         return AuthConverter.toLoginResponse(accessToken, refreshToken, nextStep);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -16,9 +16,11 @@ import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
 import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.jwt.JwtProvider;
+import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
 
@@ -31,6 +33,7 @@ public class AuthServiceImpl implements AuthService {
     private final NaverOAuthService naverOAuthService;
     private final UserService userService;
     private final JwtProvider jwtProvider;
+    private final S3Util s3Util;
 
     @Resource(name = "rtRedisTemplate")
     private RedisTemplate<String, String> rtRedisTemplate;
@@ -62,8 +65,18 @@ public class AuthServiceImpl implements AuthService {
         Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
         rtRedisTemplate.opsForValue().set(key, refreshToken, refreshDuration);
 
-        // 6. 다음 단계 결정
-        String nextStep = String.valueOf(user.getStep());
+        // 6. 온보딩 중단 예외 고려
+        UserStep nextStep = user.getStep();
+        if (nextStep == UserStep.ONBOARDING) {
+            // 기본 이미지가 아닌 업로드된 이미지가 있다면 S3에서 삭제 후 초기화
+            String currentProfileImage = user.getProfileImageName();
+            boolean isCustomImage = !User.DEFAULT_PROFILE_IMAGE.equals(currentProfileImage);
+
+            if (isCustomImage) {
+                s3Util.deleteObject("profile/" + currentProfileImage);
+                user.updateProfileImageName(User.DEFAULT_PROFILE_IMAGE);
+            }
+        }
 
         // 7. converter 작업
         return AuthConverter.toLoginResponse(accessToken, refreshToken, nextStep);

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.entity.enums.UserStep;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.jwt.JwtProvider;
@@ -34,6 +35,7 @@ public class AuthServiceImpl implements AuthService {
     private final UserService userService;
     private final JwtProvider jwtProvider;
     private final S3Util s3Util;
+    private final RoutineRepository routineRepository;
 
     @Resource(name = "rtRedisTemplate")
     private RedisTemplate<String, String> rtRedisTemplate;
@@ -51,7 +53,7 @@ public class AuthServiceImpl implements AuthService {
         User user = userService.findOrCreateUser(userInfo);
 
         // 3. 사용자 status 확인
-        if (user.getStatus().equals(UserStatus.INACTIVE)) {
+        if (user.getStatus() == UserStatus.INACTIVE) {
             throw new AuthHandler(ErrorStatus.INACTIVE_USER);
         }
 
@@ -65,10 +67,11 @@ public class AuthServiceImpl implements AuthService {
         Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
         rtRedisTemplate.opsForValue().set(key, refreshToken, refreshDuration);
 
-        // 6. 온보딩 중단 예외 고려
+        // 6. 다음 전환할 화면
         UserStep nextStep = user.getStep();
+        // 온보딩 중단 예외 고려
         if (nextStep == UserStep.ONBOARDING) {
-            // 기본 이미지가 아닌 업로드된 이미지가 있다면 S3에서 삭제 후 초기화
+            // 1) 기본 이미지가 아닌 업로드된 이미지가 있다면 S3에서 삭제 후 초기화
             String currentProfileImage = user.getProfileImageName();
             boolean isCustomImage = !User.DEFAULT_PROFILE_IMAGE.equals(currentProfileImage);
 
@@ -76,6 +79,12 @@ public class AuthServiceImpl implements AuthService {
                 s3Util.deleteObject("profile/" + currentProfileImage);
                 user.updateProfileImageName(User.DEFAULT_PROFILE_IMAGE);
             }
+
+            // 2) 수면패턴 초기화
+            user.clearSleepPattern();
+
+            // 3) 반복일정 초기화
+            routineRepository.deleteByUser(user);
         }
 
         // 7. converter 작업

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -22,7 +22,7 @@ public class FriendConverter {
 
     public FollowingUserResponseDto toFollowingUserResponse(Friend friend) {
         User following = friend.getFollowing();
-        String imageUrl = s3Util.toPresignedUrl(following.getProfileImageKey(), Duration.ofMinutes(30));
+        String imageUrl = s3Util.toPresignedUrl("profile/" + following.getProfileImageName(), Duration.ofMinutes(30));
 
         return new FollowingUserResponseDto(
                 following.getId(),
@@ -40,7 +40,7 @@ public class FriendConverter {
 
     public FollowerUserResponseDto toFollowerUserResponse(Friend friend) {
         User follower = friend.getFollower();
-        String imageUrl = s3Util.toPresignedUrl(follower.getProfileImageKey(), Duration.ofMinutes(30));
+        String imageUrl = s3Util.toPresignedUrl("profile/" + follower.getProfileImageName(), Duration.ofMinutes(30));
 
         return new FollowerUserResponseDto(
                 follower.getId(),
@@ -56,7 +56,7 @@ public class FriendConverter {
     }
 
     public FriendProfileResponseDto toFriendProfileResponse(User targetUser, Friend followRelation) {
-        String imageUrl = s3Util.toPresignedUrl(targetUser.getProfileImageKey(), Duration.ofMinutes(30));
+        String imageUrl = s3Util.toPresignedUrl("profile/" + targetUser.getProfileImageName(), Duration.ofMinutes(30));
 
         return FriendProfileResponseDto.builder()
                 .userId(targetUser.getId())

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -89,8 +89,8 @@ public class HomeServiceImpl implements HomeService {
         if(schedule.getType() == ScheduleType.TEUM){ // TEUM 타입인 경우
             profileUrls = getTeumProfileUrls(schedule);
         } else{
-            String profileImageKey = schedule.getUser().getProfileImageKey();
-            profileUrls = profileImageKey != null ? List.of(s3Util.toPresignedUrl(profileImageKey, Duration.ofMinutes(30))) : List.of();
+            String profileImageName = schedule.getUser().getProfileImageName();
+            profileUrls = profileImageName != null ? List.of(s3Util.toPresignedUrl("profile/" + profileImageName, Duration.ofMinutes(30))) : List.of();
         }
 
         return scheduleConverter.toTodoInfoResponse(schedule,reminders, profileUrls);
@@ -117,9 +117,9 @@ public class HomeServiceImpl implements HomeService {
         userIds.add(requestUserId);
 
         return userRepository.findAllById(userIds).stream()
-                .map(User::getProfileImageKey)
+                .map(User::getProfileImageName)
                 .filter(Objects::nonNull)
-                .map(key -> s3Util.toPresignedUrl(key, Duration.ofMinutes(30)))
+                .map(name -> s3Util.toPresignedUrl("profile/" + name, Duration.ofMinutes(30)))
                 .toList();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/service/NotificationServiceImpl.java
@@ -46,7 +46,7 @@ public class NotificationServiceImpl implements NotificationService {
         .filter(n->isValidNotification(n, relatedUserMap))
         .map(n-> {
           User friend = relatedUserMap.get(n.getId());
-          String profileImageUrl = s3Util.toPresignedUrl(friend.getProfileImageKey(), Duration.ofMinutes(30));
+          String profileImageUrl = s3Util.toPresignedUrl("profile/" + friend.getProfileImageName(), Duration.ofMinutes(30));
           return NotificationConverter.toNotificationDto(n, friend, profileImageUrl);
         })
         .toList();

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -3,7 +3,6 @@ package umc.teumteum.server.domain.teum.converter;
 import java.time.Duration;
 
 import umc.teumteum.server.domain.home.entity.Schedule;
-import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
@@ -81,7 +80,7 @@ public class TeumConverter {
                 .senderUser(ParticipantDto.builder()
                         .userId(sender.getId())
                         .nickname(sender.getNickname())
-                        .profileImageUrl(s3Util.toPresignedUrl(sender.getProfileImageKey(),
+                        .profileImageUrl(s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(),
                             Duration.ofMinutes(30)))
                         .build())
                 .date(request.getDate().toString())
@@ -225,7 +224,7 @@ public class TeumConverter {
                 .participants(relatedSchedules.stream()
                         .map(s -> {
                             var u = s.getUser();
-                            String presignedUrl = s3Util.toPresignedUrl(u.getProfileImageKey(), Duration.ofMinutes(30));
+                            String presignedUrl = s3Util.toPresignedUrl("profile/" + u.getProfileImageName(), Duration.ofMinutes(30));
                             return new ParticipantDto(u.getId(), u.getNickname(), presignedUrl);
                         })
                         .collect(Collectors.toList()))

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -19,7 +19,7 @@ public class UserConverter {
         return new UserSearchResponseDto(
                 user.getId(),
                 user.getNickname(),
-                s3Util.toPresignedUrl(user.getProfileImageKey(), Duration.ofMinutes(30)),
+                s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30)),
                 user.getJob()
         );
     }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -30,6 +30,9 @@ import java.util.List;
 @AllArgsConstructor
 @Table(name = "user")
 public class User extends BaseEntity {
+
+    public static final String DEFAULT_PROFILE_IMAGE = "default.svg";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -61,8 +64,9 @@ public class User extends BaseEntity {
     @Column(name = "job")
     private String job;
 
+    @Builder.Default
     @Column(name = "profile_image_name")
-    private String profileImageName;
+    private String profileImageName = DEFAULT_PROFILE_IMAGE;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
@@ -130,5 +134,9 @@ public class User extends BaseEntity {
     public void updateSleepPattern(LocalTime sleepTime, LocalTime wakeTime) {
         this.sleepTime = sleepTime;
         this.wakeTime = wakeTime;
+    }
+
+    public void updateProfileImageName(String profileImageName) {
+        this.profileImageName = profileImageName;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -139,4 +139,9 @@ public class User extends BaseEntity {
     public void updateProfileImageName(String profileImageName) {
         this.profileImageName = profileImageName;
     }
+
+    public void clearSleepPattern() {
+        this.sleepTime = null;
+        this.wakeTime = null;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -2,10 +2,6 @@ package umc.teumteum.server.domain.user.entity;
 
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,8 +61,8 @@ public class User extends BaseEntity {
     @Column(name = "job")
     private String job;
 
-    @Column(name = "profile_image_key")
-    private String profileImageKey;
+    @Column(name = "profile_image_name")
+    private String profileImageName;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -95,7 +95,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 1. 사용자 step 확인
         validateOnboardingStep(user, UserStep.ONBOARDING);
 
-        // 2. 수면패턴 수정 (온보딩 중단으로 인한 재등록도 처리 가능)
+        // 2. 수면패턴 수정
         user.updateSleepPattern(request.getSleepTime(), request.getWakeTime());
     }
 
@@ -126,10 +126,8 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 5. 수면패턴과의 충돌 확인
         validateSleepPatternConflictsByDay(routinesByDay, user);
 
-        // 6. 반복 일정 저장 (온보딩 중단으로 인해 기존 반복 일정이 있을 수 있으므로 삭제 필요)
+        // 6. 반복 일정 저장
         List<Routine> newRoutines = RoutineConverter.toRoutineList(request.getRoutine(), user);
-
-        routineRepository.deleteByUser(user);
         routineRepository.saveAll(newRoutines);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,5 @@
 package umc.teumteum.server.domain.user.service;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.stereotype.Service;
@@ -12,12 +11,11 @@ import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
-import umc.teumteum.server.domain.user.repository.AgreementRepository;
-import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
-
-import java.util.*;
 import umc.teumteum.server.global.util.S3Util;
+
+import java.time.Duration;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +23,6 @@ public class UserServiceImpl implements UserService {
 
     private final UserConverter userConverter;
     private final UserRepository userRepository;
-    private final AgreementRepository agreementRepository;
-    private final RemindAlarmRepository remindAlarmRepository;
     private final S3Util s3Util;
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -115,7 +115,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserResponseDTO.MyPageDTO getMyPage(User user) {
-        String profileImageUrl = s3Util.toPresignedUrl(user.getProfileImageKey(), Duration.ofMinutes(30));
+        String profileImageUrl = s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
         return UserConverter.toMyPageDTO(user, profileImageUrl);
     }
 }

--- a/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
@@ -21,12 +21,12 @@ public enum ErrorStatus implements BaseErrorCode {
   EMPTY_JWT_CLAIMS(HttpStatus.BAD_REQUEST, "AUTH4103", "JWT 클레임이 비어 있습니다."),
   INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4111", "유효하지 않은 JWT 서명입니다."),
   EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4112", "JWT 토큰이 만료되었습니다."),
-  ACCOUNT_DISABLED(HttpStatus.UNAUTHORIZED, "AUTH4113", "비활성화된 계정입니다."),
   INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH4114", "유효하지 않은 토큰 타입입니다."),
   MISSING_JWT(HttpStatus.UNAUTHORIZED, "AUTH4115", "JWT 토큰이 없습니다."),
 
   // 사용자 관련
   USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4111", "존재하지 않는 사용자입니다."),
+  INACTIVE_USER(HttpStatus.FORBIDDEN, "AUTH4131", "비활성화된 사용자입니다."),
 
 
   // 회원 관련

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -70,7 +70,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         // 2. 사용자 인증 과정 예외
         if (ex instanceof DisabledException) {
-            return ErrorStatus.ACCOUNT_DISABLED;
+            return ErrorStatus.INACTIVE_USER;
         }
         if (ex instanceof UsernameNotFoundException) {
             return ErrorStatus.USER_NOT_FOUND;

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -15,6 +15,9 @@ public class S3Util {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${cloud.aws.s3.bucket-path}")
+    private String bucketPath;
+
     private final S3Presigner s3Presigner;
 
     public String toPresignedUrl(String key, Duration duration) {
@@ -24,7 +27,7 @@ public class S3Util {
 
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
-                .key(key)
+                .key(bucketPath + key)
                 .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -19,6 +21,7 @@ public class S3Util {
     private String bucketPath;
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
     public String toPresignedUrl(String key, Duration duration) {
         if (key == null || key.isBlank()) {
@@ -38,4 +41,16 @@ public class S3Util {
         return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 
+    public void deleteObject(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(bucketPath + key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#99

### ✨ 작업한 내용
- **토큰 재발급 API 엔드포인트 수정**
`/api/auth/refresh` -> `/api/auth/reissue` 노션 API 명세서도 최신화했습니다.

- **로그인 시, 사용자 status 확인**
`UserStatus.INACTIVE` 체크가 누락되어 추가하였습니다.

- **S3Util 관련 수정**
기존에는 S3 객체의 이미지 키 전부를 DB에 저장하는 것으로 설계되었으나 다현님의 피드백을 통해 변경사항이 생겼습니다.
  1) 프로필 이미지의 경우, DB에 파일 이름만을 저장
  2) 이후, `toPresignEdUrl()` 호출 시 `"profile/" + user.getProfileImageName()` 형태를 key로 전달
  3) `toPresignedUrl()` 내부 로직에서 환경에 맞게 `{bucketPath} + {전달받은 key}`로 URL을 발급

  ‼️ 따라서, 본인 로컬 DB에는 profile_image_name에 `default.svg`가 저장되어 있어야 합니다. ‼️

- **기본 프로필 이미지 설정 & 온보딩 입력값 초기화 위치 수정**
처음 사용자 레코드 생성 시에만 기본 이미지로 설정하면
[온보딩에서 개인 이미지 업로드 -> 반복일정 등록 중 앱 종료 -> 온보딩에서 개인 이미지 업로드 X]의 경우 이전에 업로드했던 개인 이미지가 유지되는 문제가 있습니다.
그래서 소셜 로그인 시, 사용자의 step이 ONBOARDING인 경우에 확인 과정을 거쳐 초기화하도록 하였습니다.
  1) 이전에 업로드한 개인 이미지 삭제
  2) 기본 이미지로 초기화

  그리고 수면패턴과 반복일정 또한 선택입력인 점을 고려하여 동일한 단계에 초기화 작업을 하도록 수정하였습니다.
  (필수입력인 닉네임 & 분야/직종은 해당 등록 API에서 재등록을 판단하도록 하겠습니다.)

### 🌀 PR Point
X

### 🍰 참고사항
- 수면패턴의 경우, 이후에 문제가 생기지 않기 때문에 초기화에서 `!= null` 확인하지 않고 바로 null 초기화하도록 해봤습니다.
(체크하는 것 또한 일종의 비용이라는 생각에..)
- `toPresignEdUrl()` 호출하는 곳들 다 수정했는데 혹시나 누락된 곳 발견하시면 매개변수에서 `"profile/" + user.getProfileImageName()` 넘기는 거로 수정부탁드립니다..!

### 📷 스크린샷 또는 GIF
X