### PR TITLE
Refactor: CD 파이프라인 정비 및 스케줄러 코드 최적화, 테스트 코드 추가

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -55,37 +55,51 @@ jobs:
           username: ${{ secrets.BASTION_USERNAME }}
           key: ${{ secrets.BASTION_PRIVATE_KEY }}
           script: |
-            ssh -o StrictHostKeyChecking=no -i ~/.ssh/teumteum.pem ubuntu@${{ secrets.APP_EC2_PRIVATE_IP }} << EOF
+              docker system prune -af
+            
+              docker rm -f spring-app 2>dev/null || true
+              docker rm -f redis-container 2>dev/null || true
+                    
+              docker network inspect app-net > /dev/null 2>&1 || docker network create app-net
+              docker volume inspect redis-data > /dev/null 2>&1 || docker volume create redis-data
+                    
               docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
-            
-              docker stop spring-app || true && docker rm spring-app || true
-              docker stop redis-container || true && docker rm redis-container || true
-            
-              docker network create app-net || true
+          
 
-              docker run -d --name redis-container \
-              --network app-net \
-              -p ${{ secrets.REDIS_PORT }}:${{ secrets.REDIS_PORT }} \
-              redis:${{ secrets.REDIS_VERSION }} \
-              redis-server --requirepass ${{ secrets.REDIS_PASSWORD }}
+              docker run -d --restart unless-stopped \
+                --name redis-container \
+                --network app-net \
+                -p ${{ secrets.REDIS_PORT }}:${{ secrets.REDIS_PORT }} \
+                -v redis-data:/data \
+                redis:${{ secrets.REDIS_VERSION }} \
+                redis-server --requirepass ${{ secrets.REDIS_PASSWORD }}
               
-              docker run -d --name spring-app \
-              --network app-net \
-              -p ${{ secrets.SPRINGBOOT_PORT }}:${{ secrets.SPRINGBOOT_PORT }} \
-              -e FIREBASE_CREDENTIALS_JSON='${{ secrets.FIREBASE_CREDENTIALS_JSON }}' \
-              -e SPRINGBOOT_PORT=${{ secrets.SPRINGBOOT_PORT }} \
-              -e SPRING_REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
-              -e DB_URL=${{ secrets.DB_URL }} \
-              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
-              -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
-              -e S3_BUCKET=${{ secrets.S3_BUCKET }} \
-              -e S3_PREFIX=${{ secrets.S3_PREFIX }} \
-              ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
-
-            EOF
-
+              docker run -d --restart unless-stopped \
+                --name spring-app \
+                --network app-net \
+                -p ${{ secrets.SPRINGBOOT_PORT }}:${{ secrets.SPRINGBOOT_PORT }} \
+                -e FIREBASE_CREDENTIALS_JSON="${{ secrets.FIREBASE_CREDENTIALS_JSON }}" \
+                -e SPRINGBOOT_PORT=${{ secrets.SPRINGBOOT_PORT }} \
+                -e SPRING_REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }} \
+                -e DB_URL=${{ secrets.DB_URL }} \
+                -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+                -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+                -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
+                -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
+                -e S3_BUCKET=${{ secrets.S3_BUCKET }} \
+                -e S3_PREFIX=${{ secrets.S3_PREFIX }} \
+                ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
+            
+              docker system df
+            
+              echo "디스크 사용량 검사"
+              USAGE=$(df / | awk 'NR==2 {print $5}' | sed 's/%//')
+              if [ "$USAGE" -ge 80 ]; then
+                  echo "디스크 사용량 ${USAGE}% - 경고 알림"
+                  HOST=${{ secrets.APP_EC2_PRIVATE_IP }}
+                  curl -X POST -H "Content-Type: application/json" \
+                    -d "{\"content\": \"EC2 디스크 사용량 경고\\nHOST: ${HOST}\\nUsage: ${USAGE}%\\n→ 디스크 정리 또는 스토리지 확장 필요\"}" \
+                    ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Notify on Discord(Success)
         if: success()
@@ -98,6 +112,9 @@ jobs:
             • Repo: `${{ github.repository }}`
             • Branch: `${{ github.ref_name }}`
             • Commit: `${{ github.sha }}`
+            • Docker Image: `${{ secrets.DOCKER_USERNAME }}/${{secrets.DOCKER_REPO}}::latest`
+            • [View commit](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+            • [Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Notify on Discord(Fail)
         if: failure()
@@ -110,6 +127,8 @@ jobs:
             • Repo: `${{ github.repository }}`
             • Branch: `${{ github.ref_name }}`
             • Commit: `${{ github.sha }}`
+            • [View commit](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+            • [Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             → 로그 확인 필요!
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
@@ -80,4 +81,10 @@ task copyYml(type: Copy){
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs += [
+			"-Djdk.attach.allowAttachSelf=true",
+			"-XX:+EnableDynamicAgentLoading"]
+	filter {
+		includeTestsMatching "*"
+	}
 }

--- a/src/main/java/umc/teumteum/server/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/fcm/repository/FcmTokenRepository.java
@@ -1,8 +1,10 @@
 package umc.teumteum.server.domain.fcm.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.teumteum.server.domain.fcm.entity.FcmToken;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -13,4 +15,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
   Optional<FcmToken> findByTokenAndUser(String fcmToken, User user);
 
   List<FcmToken> findByUserAndIsActiveTrue(User user);
+
+  @Query("SELECT t FROM FcmToken t WHERE t.isActive = true AND t.user IN :users")
+  List<FcmToken> findActiveTokensByUsers(@Param("users") List<User> users);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -116,4 +116,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findAllByUserAndIncludeTeumTrueAndEndTimeBefore(User user, LocalDateTime now);
 
+    @Query("SELECT s FROM Schedule s JOIN FETCH s.user WHERE s.date = :date")
+    List<Schedule> findAllByDateWithUser(@Param("date") LocalDate today);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -107,8 +107,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
                                        @Param("startOfTomorrow") LocalDateTime startOfTomorrow);
 
 
-    List<Schedule> findByUserIdAndDate(Long id, LocalDate now);
-
     @Query("""
     SELECT s.routine FROM Schedule s
     WHERE s.user = :user AND s.date = :date AND s.isDeleted = true AND s.routine IS NOT NULL""")

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -32,7 +32,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user")
+@Table(name = "\"user\"")
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
@@ -35,18 +35,27 @@ public class DailyTodoReminerScheduler {
   public void sendDailyTodos() {
     log.info("[9am 스케줄러] 오늘의 투두 알림 메서드 호출");
 
-    List<User> users = userRepository.findAll();
+    LocalDate today = LocalDate.now();
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+    // 1. 유저 정보가 있는 Schedule 한번에 가져옴
+    List<Schedule> schedules = scheduleRepository.findAllByDateWithUser(today);
+    // 2. 유저 별로 스케줄 묶기
+    Map<User, List<Schedule>> scheduleMap = schedules.stream().collect(Collectors.groupingBy(Schedule::getUser));
+    // 3. 유저 리스트 추출
+    List<User> users = List.copyOf(scheduleMap.keySet());
+    // 4. 유저 토큰 조회
+    List<FcmToken> allTokens = fcmTokenRepository.findActiveTokensByUsers(users);
+    Map<Long, List<FcmToken>> tokenMap = allTokens.stream()
+        .collect(Collectors.groupingBy(token -> token.getUser().getId()));
+
+
+    // 5. 유저별 알림 전송
     for(User user : users) {
-      List<Schedule> todos = scheduleRepository.findByUserIdAndDate(user.getId(), LocalDate.now());
-
-      if (todos.isEmpty()) continue;
-
-      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-      String content = todos.stream().map(
-          todo -> {
-            String time = todo.getStartTime().format(formatter);
-            return time + " " + todo.getTitle();
-          }).collect(Collectors.joining("\n"));
+      List<Schedule> userSchedules = scheduleMap.get(user);
+      String content = userSchedules.stream()
+          .map(s->s.getStartTime().format(formatter)+" "+s.getTitle())
+          .collect(Collectors.joining("\n"));
 
       NotificationPayload payload = NotificationPayload.builder()
           .title(NotificationType.DAILY_TODO.getTitle())
@@ -55,11 +64,11 @@ public class DailyTodoReminerScheduler {
           .data(Map.of("userId",user.getId().toString()))
           .build();
 
-      List<FcmToken> tokens = fcmTokenRepository.findByUserAndIsActiveTrue(user);
-      for(FcmToken token : tokens) {
+      // * 활성화 토큰이 없을 경우를 대비해서.. 없을 경우 List.of()처리
+      List<FcmToken> tokens = tokenMap.getOrDefault(user.getId(), List.of());
+      for (FcmToken token : tokens) {
         fcmNotificationSender.send(token.getToken(), payload);
       }
-
 
     }
 

--- a/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
@@ -14,6 +14,7 @@ import umc.teumteum.server.domain.fcm.repository.FcmTokenRepository;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.notification.dto.NotificationPayload;
 import umc.teumteum.server.global.notification.sender.FcmNotificationSender;
@@ -24,7 +25,6 @@ import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
 @RequiredArgsConstructor
 public class DailyTodoReminerScheduler {
 
-  private final UserRepository userRepository;
   private final ScheduleRepository scheduleRepository;
   private final FcmNotificationSender fcmNotificationSender;
   private final FcmTokenRepository fcmTokenRepository;
@@ -42,10 +42,12 @@ public class DailyTodoReminerScheduler {
     List<Schedule> schedules = scheduleRepository.findAllByDateWithUser(today);
     // 2. 유저 별로 스케줄 묶기
     Map<User, List<Schedule>> scheduleMap = schedules.stream().collect(Collectors.groupingBy(Schedule::getUser));
-    // 3. 유저 리스트 추출
+    // 3. 활성화 상태의 유저 리스트 추출
     List<User> users = List.copyOf(scheduleMap.keySet());
+    List<User> activeUsers = users.stream().filter(user -> user.getStatus() == UserStatus.ACTIVE)
+        .toList();
     // 4. 유저 토큰 조회
-    List<FcmToken> allTokens = fcmTokenRepository.findActiveTokensByUsers(users);
+    List<FcmToken> allTokens = fcmTokenRepository.findActiveTokensByUsers(activeUsers);
     Map<Long, List<FcmToken>> tokenMap = allTokens.stream()
         .collect(Collectors.groupingBy(token -> token.getUser().getId()));
 

--- a/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/DailyTodoReminerScheduler.java
@@ -53,8 +53,11 @@ public class DailyTodoReminerScheduler {
 
 
     // 5. 유저별 알림 전송
-    for(User user : users) {
-      List<Schedule> userSchedules = scheduleMap.get(user);
+    for(User user : activeUsers) {
+      List<Schedule> userSchedules = scheduleMap.get(user).stream()
+          .sorted((s1, s2) -> s1.getStartTime().compareTo(s2.getStartTime()))
+          .toList();
+
       String content = userSchedules.stream()
           .map(s->s.getStartTime().format(formatter)+" "+s.getTitle())
           .collect(Collectors.joining("\n"));

--- a/src/test/java/umc/teumteum/server/unit/domain/scheduler/DailyTodoReminderSchedulerTest.java
+++ b/src/test/java/umc/teumteum/server/unit/domain/scheduler/DailyTodoReminderSchedulerTest.java
@@ -1,0 +1,199 @@
+package umc.teumteum.server.unit.domain.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.fcm.entity.FcmToken;
+import umc.teumteum.server.domain.fcm.repository.FcmTokenRepository;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserRole;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.global.notification.dto.NotificationPayload;
+import umc.teumteum.server.global.notification.sender.FcmNotificationSender;
+import umc.teumteum.server.global.scheduler.DailyTodoReminerScheduler;
+
+@ExtendWith(MockitoExtension.class)
+public class DailyTodoReminderSchedulerTest {
+  @Mock
+  private ScheduleRepository scheduleRepository;
+  @Mock
+  private FcmNotificationSender fcmNotificationSender;
+  @Mock
+  private FcmTokenRepository fcmTokenRepository;
+  @InjectMocks
+  private DailyTodoReminerScheduler scheduler;
+
+  private List<User> users;
+  private List<Schedule> schedules;
+  private List<FcmToken> tokens;
+
+
+  // 총 유저 3명 , 각 유저당 일정 3개, FCM 토큰 2개
+  @BeforeEach
+  void init() {
+    users = new ArrayList<>();
+    schedules = new ArrayList<>();
+    tokens = new ArrayList<>();
+
+    for (long i = 1; i <= 3; i++) {
+      // 1. 유저 생성 (3번 유저만 비활성화, 나머지는 활성화)
+      UserStatus status = (i == 3) ? UserStatus.INACTIVE : UserStatus.ACTIVE;
+      User user = User.builder()
+          .id(i)
+          .socialId("social" + i)
+          .socialType(SocialType.KAKAO)
+          .email("user" + i + "@test.com")
+          .nickname("user" + i)
+          .role(UserRole.ROLE_USER)
+          .status(status)
+          .build();
+      users.add(user);
+
+      // 2. 유저당 일정 3개
+      for (int j = 0; j < 3; j++) {
+        Schedule schedule = Schedule.builder()
+            .user(user)
+            .title("일정 " + (j + 1) + " - user" + i)
+            .description("테스트 일정입니다")
+            .type(ScheduleType.TODO)
+            .date(LocalDate.now())
+            .startTime(LocalDateTime.of(LocalDate.now(), LocalTime.of(9 + j, 0)))
+            .endTime(LocalDateTime.of(LocalDate.now(), LocalTime.of(10 + j, 0)))
+            .isPublic(true)
+            .includeTeum(false)
+            .status(ScheduleStatus.ACTIVE)
+            .isDeleted(false)
+            .build();
+        schedules.add(schedule);
+      }
+
+      // 3. 유저당 FCM 토큰 2개
+      for (int k = 0; k < 3; k++) {
+        FcmToken token = FcmToken.builder()
+            .user(user)
+            .token("token" + k + "-user" + i)
+            .isActive(true)
+            .registeredAt(LocalDateTime.now())
+            .build();
+        tokens.add(token);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC1 모든 유저에게 정상적으로 알림을 전송한다.")
+  void DailyTodoReminerScheduler_TC1() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(schedules);
+    when(fcmTokenRepository.findActiveTokensByUsers(
+        argThat(inputUsers -> hasSameUserIds(inputUsers, List.of(users.get(0),users.get(1))))
+    )).thenReturn(
+        tokens.stream()
+            .filter(t -> {
+              Long uid = t.getUser().getId();
+              return uid.equals(1L) || uid.equals(2L);
+            })
+            .toList()
+    );
+
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    verify(fcmNotificationSender,times(6)).send(anyString(), any(NotificationPayload.class));
+
+  }
+
+
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC2 토큰이 없는 경우 알림을 보내지 않는다.")
+  void DailyTodoReminerScheduler_TC2() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(schedules);
+    when(fcmTokenRepository.findActiveTokensByUsers(
+        argThat(inputUsers -> hasSameUserIds(inputUsers, List.of(users.get(0), users.get(1))))
+    )).thenReturn(List.of());
+
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    verify(fcmNotificationSender, never()).send(any(), any());
+
+
+  }
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC3 일정이 아예 없는 경우 알림을 보내지 않는다.")
+  void DailyTodoReminerScheduler_TC3() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(List.of());
+
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    verifyNoInteractions(fcmNotificationSender);
+
+
+  }
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC4 비활성 유저는 알림을 보내지 않는다.")
+  void DailyTodoReminderScheduler_TC4() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(schedules);
+    // 토큰 조회시, ACTIVE 유저의 토큰만 조회됨
+    when(fcmTokenRepository.findActiveTokensByUsers(
+        argThat(inputUsers -> hasSameUserIds(inputUsers, List.of(users.get(0),users.get(1))))
+    )).thenReturn(
+        tokens.stream()
+            .filter(t -> {
+              Long uid = t.getUser().getId();
+              return uid.equals(1L) || uid.equals(2L);
+            })
+            .toList()
+    );
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    // ACTIVE 유저의 토큰 6개 호출
+    verify(fcmNotificationSender, times(6)).send(anyString(), any());
+    // INACTIVE 유저의 토큰은 호출되지 않아야 함.
+    tokens.stream()
+        .filter(t->!t.getUser().getStatus().equals(UserStatus.ACTIVE))
+        .forEach(token -> verify(fcmNotificationSender, never()).send(eq(token.getToken()),any()));
+
+  }
+
+  private boolean hasSameUserIds(List<User> actual, List<User> expected) {
+    Set<Long> actualIds = actual.stream().map(User::getId).collect(Collectors.toSet());
+    Set<Long> expectedIds = expected.stream().map(User::getId).collect(Collectors.toSet());
+    return actualIds.equals(expectedIds);
+  }
+}

--- a/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
+++ b/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
@@ -1,4 +1,4 @@
-package umc.teumteum.server.unit.domain.scheduler;
+package umc.teumteum.server.unit.global.scheduler;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +31,7 @@ import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserRole;
@@ -190,10 +192,88 @@ public class DailyTodoReminderSchedulerTest {
         .forEach(token -> verify(fcmNotificationSender, never()).send(eq(token.getToken()),any()));
 
   }
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC5 유저별 일정이 startTime 순으로 정렬되어 있는지 검증한다.")
+  void DailyTodoReminderScheduler_TC5() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(schedules);
+    when(fcmTokenRepository.findActiveTokensByUsers(any())).thenReturn(tokens);
+
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    long expectedSendCount = tokens.stream()
+        .filter(t -> t.getUser().getStatus() == UserStatus.ACTIVE)
+        .count();
+
+    verify(fcmNotificationSender, times((int) expectedSendCount)).send(anyString(), argThat(payload -> {
+      String content = payload.getContent(); // 예: "09:00 일정1\n10:00 일정2\n11:00 일정3"
+      String[] lines = content.split("\n");
+
+      List<LocalTime> times = new ArrayList<>();
+      for (String line : lines) {
+        String timeStr = line.split(" ")[0]; // "09:00 일정1" → "09:00"
+        times.add(LocalTime.parse(timeStr)); // HH:mm 형식으로 LocalTime 변환
+      }
+
+      return isSorted(times);
+    }));
+  }
+
+  @Test
+  @DisplayName("[DailyTodoReminerScheduler] - TC6 payload 내용(title, content, type, data.userId)을 검증한다.")
+  void DailyTodoReminderScheduler_TC6() {
+    // given
+    when(scheduleRepository.findAllByDateWithUser(LocalDate.now())).thenReturn(schedules);
+    when(fcmTokenRepository.findActiveTokensByUsers(any())).thenReturn(tokens);
+
+    // when
+    scheduler.sendDailyTodos();
+
+    // then
+    long expectedSendCount = tokens.stream()
+        .filter(t -> t.getUser().getStatus() == UserStatus.ACTIVE)
+        .count();
+
+    // ArgumentCaptor로 실제 호출된 payload들 전부 캡처
+    ArgumentCaptor<NotificationPayload> payloadCaptor = ArgumentCaptor.forClass(NotificationPayload.class);
+    verify(fcmNotificationSender, times((int) expectedSendCount)).send(anyString(), payloadCaptor.capture());
+
+    List<NotificationPayload> payloads = payloadCaptor.getAllValues();
+
+    for (NotificationPayload payload : payloads) {
+      // 1. title 확인
+      assert payload.getTitle().equals(NotificationType.DAILY_TODO.getTitle());
+
+      // 2. type 확인
+      assert payload.getType() == NotificationType.DAILY_TODO;
+
+      // 3. data.userId 확인
+      assert payload.getData() != null;
+      assert payload.getData().containsKey("userId");
+      assert payload.getData().get("userId").matches("\\d+");
+
+      // 4. content 확인
+      assert payload.getContent() != null;
+      assert !payload.getContent().isBlank();
+    }
+  }
+
+
 
   private boolean hasSameUserIds(List<User> actual, List<User> expected) {
     Set<Long> actualIds = actual.stream().map(User::getId).collect(Collectors.toSet());
     Set<Long> expectedIds = expected.stream().map(User::getId).collect(Collectors.toSet());
     return actualIds.equals(expectedIds);
+  }
+
+  private boolean isSorted(List<LocalTime> times) {
+    for (int i = 1; i < times.size(); i++) {
+      if (times.get(i - 1).isAfter(times.get(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#103 

### ✨ 작업한 내용

- **CD 파이프라인 재정비**
  Redis, spring Container를 재시작하는 로직을 정비하였습니다. (Redis Volume이 날라가지 않도록 정비, 사용하지 않는 도커 이미지 정리)
  EC2 디스크 사용량 검사 및 디스코드 알림 보내는 로직을 추가하였습니다. (디스크가 다 차서 배포가 안되는 이슈가 생겨도 빨리 확인하기 위함입니다!) 
  서버 배포 시 전송하는 디스코드 알림 포맷 수정하였습니다.

- `DailyTodoReminerScheduler` 스케줄러 코드 최적화
    Schedule 조회 시 JOIN FETCH 로 유저 정보도 함께 조회하여 N+1 문제 해결하였습니다.
    FCM 토큰을 유저 리스트 기반 일괄 조회로 변경하였습니다.

- `DailyTodoReminerScheduler` 스케줄러 단위 테스트 코드 작성
    해당 로직이 제대로 실행되는지 확인하기 위해 단위 테스트 코드를 작성하였습니다.
    테스트 환경을 위해 build.gradle을 수정하였고, 테스트 환경(h2데이터베이스)에서 예약어이슈를 해결하기 위해  UserEntity의 테이블 명을 수정하였습니다. (MySQL이나, 다른 환경에서는 문제없이 동작합니다! )

  

<!-- 작업한 내용을 적어주세요 -->

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
배포 스크립트가 잘 동작하는지는.. 
해당 PR이 머지되면 확인해보겠습니다ㅠㅜ!

### 📷 스크린샷 또는 GIF

| 스크린샷 |
| :------: |
|  <img width="654" height="117" alt="스크린샷 2025-07-29 오전 5 36 26" src="https://github.com/user-attachments/assets/cf9be569-9a5a-4e06-8abf-f7560808d1e3" />  |

