### PR TITLE
Feat: 프로필 이미지 업로드용 프리사인드 URL 발급 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -76,7 +76,15 @@ public class AuthServiceImpl implements AuthService {
             boolean isCustomImage = !User.DEFAULT_PROFILE_IMAGE.equals(currentProfileImage);
 
             if (isCustomImage) {
-                s3Util.deleteObject("profile/" + currentProfileImage);
+                try {
+                    s3Util.deleteObject("profile/" + currentProfileImage);
+                } catch (Exception e) {
+                    // 삭제 실패 시 로그
+                    log.error("S3 프로필 이미지 삭제 실패 - userId : {}, imageName : {}, error : {}",
+                            user.getId(), currentProfileImage, e.getMessage());
+                }
+
+                // 삭제 성공/실패와 관계없이 DB 프로필 이미지명 초기화
                 user.updateProfileImageName(User.DEFAULT_PROFILE_IMAGE);
             }
 

--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.exception.status.UserSuccessStatus;
 import umc.teumteum.server.domain.user.service.OnboardingService;
@@ -56,13 +57,28 @@ public class OnboardingController {
 
 
     @Operation(
+            summary = "온보딩 프로필 이미지 업로드용 Presigned URL 발급",
+            description = "온보딩 과정에서 프로필 이미지를 S3에 직접 업로드할 수 있는 Presigned URL을 발급합니다."
+    )
+    @PostMapping(value = "/onboarding/profile-image/presigned-url", produces = "application/json")
+    public ApiResponse<OnboardingResponseDto.ProfileImagePresignedUrlResponse> getProfileImagePresignedUrl(
+            @RequestBody @Valid OnboardingRequestDto.ProfileImagePresignedUrlRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ) {
+        OnboardingResponseDto.ProfileImagePresignedUrlResponse response =
+                onboardingService.generateProfileImagePresignedUrl(request, user);
+        return ApiResponse.of(UserSuccessStatus.PRESIGNED_URL_ISSUED, response);
+    }
+
+
+    @Operation(
             summary = "온보딩 프로필 이미지 등록",
-            description = "온보딩 과정에서 S3에 업로드된 프로필 이미지의 키를 등록합니다."
+            description = "온보딩 과정에서 S3에 업로드된 프로필 이미지의 파일명를 등록합니다."
     )
     @PostMapping(value = "/onboarding/profile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
     ) {
-        // TODO: 온보딩 프로필 이미지 키 저장 로직 구현
+        // TODO: 온보딩 프로필 이미지 파일명 저장 로직 구현
         return null;
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/converter/OnboardingConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/OnboardingConverter.java
@@ -1,0 +1,17 @@
+package umc.teumteum.server.domain.user.converter;
+
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
+
+public class OnboardingConverter {
+
+    public static OnboardingResponseDto.ProfileImagePresignedUrlResponse toProfileImagePresignedUrlResponse(
+            String presignedUrl,
+            String fileName
+    ) {
+        return OnboardingResponseDto.ProfileImagePresignedUrlResponse.builder()
+                .presignedUrl(presignedUrl)
+                .fileName(fileName)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
@@ -65,6 +65,19 @@ public class OnboardingRequestDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ProfileImagePresignedUrlRequest {
+
+        @NotBlank
+        @Schema(description = "업로드할 파일의 MIME 타입", example = "image/png")
+        private String contentType;
+    }
+
+
+    // 온보딩 - 수면패턴
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class SleepPatternRequest {
 
         @NotNull(message = "취침 시간은 필수 입력입니다")

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
@@ -60,7 +60,7 @@ public class OnboardingRequestDto {
     }
 
 
-    // 온보딩 - 수면패턴
+    // 온보딩 - 프로필 이미지 업로드용 URl 발급
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingResponseDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 public class OnboardingResponseDto {
 
-    // 온보딩 - 수면패턴
+    // 온보딩 - 프로필 이미지 업로드용 URl 발급
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingResponseDto.java
@@ -1,0 +1,25 @@
+package umc.teumteum.server.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OnboardingResponseDto {
+
+    // 온보딩 - 수면패턴
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImagePresignedUrlResponse {
+
+        @Schema(description = "S3에 업로드할 수 있는 Presigned URL")
+        private String presignedUrl;
+
+        @Schema(description = "DB에 저장할 파일 이름 (UUID.확장자)")
+        private String fileName;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -17,9 +17,10 @@ public enum UserErrorStatus implements BaseErrorCode {
     INVALID_STEP(HttpStatus.BAD_REQUEST, "ONBOARDING4001", "현재 진행할 수 있는 단계가 아닙니다."),
     TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "서비스 이용약관은 필수 동의 항목입니다."),
     PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4003", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
-    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
-    ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "반복 일정 간 시간 충돌이 발생했습니다."),
-    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
+    UNSUPPORTED_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "지원하지 않는 이미지 형식입니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
+    ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "반복 일정 간 시간 충돌이 발생했습니다."),
+    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4007", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 사용 중인 닉네임입니다."),
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -16,8 +16,11 @@ public enum UserSuccessStatus implements BaseCode {
     // 사용자 온보딩
     AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 완료되었습니다."),
     NICKNAME_JOB_SAVED(HttpStatus.OK, "ONBOARDING2002", "닉네임과 분야/직종 등록이 완료되었습니다."),
-    SLEEP_PATTERN_SAVED(HttpStatus.OK, "ONBOARDING2003", "수면 패턴 등록이 완료되었습니다."),
-    ROUTINE_SAVED(HttpStatus.OK, "ONBOARDING2004", "요일별 반복 일정 등록이 완료되었습니다."),
+    PRESIGNED_URL_ISSUED(HttpStatus.OK, "ONBOARDING2003", "프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
+    PROFILE_IMAGE_SAVED(HttpStatus.OK, "ONBOARDING2004", "프로필 이미지 등록이 완료되었습니다."),
+    SLEEP_PATTERN_SAVED(HttpStatus.OK, "ONBOARDING2005", "수면 패턴 등록이 완료되었습니다."),
+    ROUTINE_SAVED(HttpStatus.OK, "ONBOARDING2006", "요일별 반복 일정 등록이 완료되었습니다."),
+
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
@@ -1,6 +1,8 @@
 package umc.teumteum.server.domain.user.service;
 
+import jakarta.validation.Valid;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface OnboardingService {
@@ -11,4 +13,6 @@ public interface OnboardingService {
     void saveSleepPattern(OnboardingRequestDto.SleepPatternRequest request, User user);
 
     void saveRoutines(OnboardingRequestDto.RoutineListRequest request, User user);
+
+    OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -1,11 +1,14 @@
 package umc.teumteum.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.user.converter.AgreementConverter;
+import umc.teumteum.server.domain.user.converter.OnboardingConverter;
 import umc.teumteum.server.domain.user.converter.RoutineConverter;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
@@ -17,13 +20,12 @@ import umc.teumteum.server.domain.user.repository.AgreementRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.TimeRange;
+import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.global.util.TimeUtil;
 
+import java.time.Duration;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,7 +36,11 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final AgreementRepository agreementRepository;
     private final RoutineRepository routineRepository;
     private final TimeUtil timeUtil;
+    private final S3Util s3Util;
 
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp", "image/svg+xml"
+    );
 
     // 온보딩 - 약관 동의
     @Override
@@ -88,6 +94,36 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
+    // 온보딩 - 프로필 이미지용 프리사인드 URL 발급
+    @Override
+    public OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user) {
+        // 1. Content-Type 검증
+        String contentType = request.getContentType().toLowerCase();
+        if (!ALLOWED_IMAGE_TYPES.contains(contentType)) {
+            throw new OnboardingHandler(UserErrorStatus.UNSUPPORTED_IMAGE_FORMAT);
+        }
+
+        // 2. 확장자 추출
+        String extension = contentType.substring(contentType.lastIndexOf("/") + 1);
+        // svg+xml의 경우 svg로 변환
+        if ("svg+xml".equals(extension)) {
+            extension = "svg";
+        }
+
+        // 3. 파일명(UUID) 생성
+        String fileName = UUID.randomUUID() + "." + extension;
+
+        // 4. S3 Key 구성 (profile/{fileName})
+        String key = "profile/" + fileName;
+
+        // 5. Presigned URL 생성
+        String presignedUrl = s3Util.toUploadPresignedUrl(key, contentType, Duration.ofMinutes(30));
+
+        // 6. 응답 DTO 반환
+        return OnboardingConverter.toProfileImagePresignedUrlResponse(presignedUrl, fileName);
+    }
+
+
     // 온보딩 - 수면패턴 등록
     @Override
     @Transactional
@@ -130,7 +166,6 @@ public class OnboardingServiceImpl implements OnboardingService {
         List<Routine> newRoutines = RoutineConverter.toRoutineList(request.getRoutine(), user);
         routineRepository.saveAll(newRoutines);
     }
-
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -96,29 +96,32 @@ public class OnboardingServiceImpl implements OnboardingService {
     // 온보딩 - 프로필 이미지용 프리사인드 URL 발급
     @Override
     public OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user) {
-        // 1. Content-Type 검증
+        // 1. 사용자 step 확인
+        validateOnboardingStep(user, UserStep.ONBOARDING);
+
+        // 2. Content-Type 검증
         String contentType = request.getContentType().toLowerCase();
         if (!ALLOWED_IMAGE_TYPES.contains(contentType)) {
             throw new OnboardingHandler(UserErrorStatus.UNSUPPORTED_IMAGE_FORMAT);
         }
 
-        // 2. 확장자 추출
+        // 3. 확장자 추출
         String extension = contentType.substring(contentType.lastIndexOf("/") + 1);
         // svg+xml의 경우 svg로 변환
         if ("svg+xml".equals(extension)) {
             extension = "svg";
         }
 
-        // 3. 파일명(UUID) 생성
+        // 4. 파일명(UUID) 생성
         String fileName = UUID.randomUUID() + "." + extension;
 
-        // 4. S3 Key 구성 (profile/{fileName})
+        // 5. S3 Key 구성 (profile/{fileName})
         String key = "profile/" + fileName;
 
-        // 5. Presigned URL 생성
+        // 6. Presigned URL 생성
         String presignedUrl = s3Util.toUploadPresignedUrl(key, contentType, Duration.ofMinutes(30));
 
-        // 6. 응답 DTO 반환
+        // 7. 응답 DTO 반환
         return OnboardingConverter.toProfileImagePresignedUrlResponse(presignedUrl, fileName);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -1,7 +1,6 @@
 package umc.teumteum.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.user.converter.AgreementConverter;

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -93,7 +93,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
-    // 온보딩 - 프로필 이미지용 프리사인드 URL 발급
+    // 온보딩 - 프로필 이미지 업로드용 URl 발급
     @Override
     public OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user) {
         // 1. 사용자 step 확인

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -1,6 +1,5 @@
 package umc.teumteum.server.global.util;
 
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -11,6 +10,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/umc/teumteum/server/global/util/S3Util.java
+++ b/src/main/java/umc/teumteum/server/global/util/S3Util.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Component
 @RequiredArgsConstructor
@@ -23,6 +25,7 @@ public class S3Util {
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
 
+    // GET용 프리사인드 URL 발급
     public String toPresignedUrl(String key, Duration duration) {
         if (key == null || key.isBlank()) {
             return null;
@@ -41,6 +44,30 @@ public class S3Util {
         return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 
+    // PUT용 프리사인드 URL 발급
+    public String toUploadPresignedUrl(String key, String contentType, Duration duration) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(bucketPath + key)
+                .contentType(contentType)
+                .build()
+                ;
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(duration)
+                .putObjectRequest(putObjectRequest)
+                .build()
+                ;
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+
+
+    // S3 객체 삭제
     public void deleteObject(String key) {
         if (key == null || key.isBlank()) {
             return;


### PR DESCRIPTION
### 👀 관련 이슈
#108

### ✨ 작업한 내용
해당 API는 아래와 같이 진행됩니다.
  1) `FE -> BE` : 업로드하려는 파일의 타입을 전달
FE가 파일을 직접 업로드하기 때문에, 파일에 어느 정도 제약이 필요하다고 생각하여 현재는 `jpeg`, `png`, `webp`, `svg`만 가능합니다.
  2) `BE -> FE` : 해당 타입의 파일에 대해서 UUID로 파일명을 생성, 이후 URL을 발급하여 파일명과 URL을 전달
  
<br>
  
**‼️ 이후부터는 API 구현 테스트 과정입니다 ‼️**
  1) 해당 URL로 `FE`에서 파일 업로드 (저는 터미널 명령어로 업로드하였습니다.)
  
  2) S3 업로드 확인
<img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/09cbaf9d-abc7-4156-b6bc-db14a64061fc" />

  3) DB에 파일명을 넣어서 이미지 조회
<img src="https://github.com/user-attachments/assets/cc4bcc22-110b-404d-8ae4-af87fa98bdfd" width="300"/><img src="https://github.com/user-attachments/assets/1ea0fd04-b072-48f8-8384-ea144775a69e" width="250"/>



### 🌀 PR Point
X

### 🍰 참고사항
- 이전 PR에서 다현님이 말씀해주신대로 S3 객체 삭제 시에 예외 발생하면 로그를 찍도록 하였습니다.
- 혹시 더 필요한 이미지 타입이 있다면 말씀해주시면 반영하겠습니다.

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
|  업로드용 URL 발급 API  |  <img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/d7097738-cbeb-4333-8001-5c5128b80a5c" />  |