### PR TITLE
Fix: 친구의 빈틈 시간 조회 API 조건 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -2,12 +2,8 @@ package umc.teumteum.server.domain.friend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.domain.friend.exception.status.FriendSuccessStatus;

--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -123,11 +123,11 @@ public class FriendController {
             description = "친구의 스케줄 중에서 includeTeum == true 인 일정들의 시간을 합산하여 반환합니다."
     )
     @GetMapping(value = "/{userId}/teum-time", produces = "application/json")
-    public ApiResponse<Long> getFriendTeumTime(
+    public ApiResponse<FriendTeumTimeResponseDto> getFriendTeumTime(
             @Parameter(hidden = true) @CurrentUser User loginUser,
             @Parameter(name = "userId", description = "조회할 친구 ID") @PathVariable("userId") Long targetUserId
     ) {
-        Long result = friendService.getFriendTeumTime(loginUser.getId(), targetUserId);
+        FriendTeumTimeResponseDto result = friendService.getFriendTeumTime(loginUser.getId(), targetUserId);
         return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_TEUM_TIME_SUCCESS, result);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -120,7 +120,7 @@ public class FriendController {
 
     @Operation(
             summary = "친구의 빈틈 시간 조회",
-            description = "isIncludeTeumTime == true 인 일정들의 시간을 합산하여 반환합니다."
+            description = "친구의 스케줄 중에서 includeTeum == true 인 일정들의 시간을 합산하여 반환합니다."
     )
     @GetMapping(value = "/{userId}/teum-time", produces = "application/json")
     public ApiResponse<Long> getFriendTeumTime(

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
 import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
 import umc.teumteum.server.domain.friend.dto.FriendProfileResponseDto;
+import umc.teumteum.server.domain.friend.dto.FriendTeumTimeResponseDto;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
@@ -73,5 +74,13 @@ public class FriendConverter {
                 .mapToLong(s -> Duration.between(s.getStartTime(), s.getEndTime()).toMinutes())
                 .sum();
     }
+
+    public FriendTeumTimeResponseDto toFriendTeumTimeResponse(long totalMinutes) {
+        int days = (int) (totalMinutes / (60 * 24));
+        int hours = (int) ((totalMinutes % (60 * 24)) / 60);
+        int minutes = (int) (totalMinutes % 60);
+        return new FriendTeumTimeResponseDto(days, hours, minutes, totalMinutes);
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/dto/FriendTeumTimeResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/dto/FriendTeumTimeResponseDto.java
@@ -1,0 +1,27 @@
+package umc.teumteum.server.domain.friend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(title = "FriendTeumTimeResponse : 친구 빈틈 시간 응답 DTO")
+public class FriendTeumTimeResponseDto {
+
+    @Schema(description = "일 단위 빈틈 시간", example = "0")
+    private int days;
+
+    @Schema(description = "시간 단위 빈틈 시간", example = "0")
+    private int hours;
+
+    @Schema(description = "분 단위 빈틈 시간", example = "0")
+    private int minutes;
+
+    @Schema(description = "총 빈틈 시간 (분)", example = "60")
+    private long totalMinutes;
+}

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -1,7 +1,5 @@
 package umc.teumteum.server.domain.friend.service;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -22,6 +22,6 @@ public interface FriendService {
 
     FriendProfileResponseDto getFriendProfile(Long loginUserId, Long targetUserId);
 
-    Long getFriendTeumTime(Long loginUserId, Long targetUserId);
+    FriendTeumTimeResponseDto getFriendTeumTime(Long loginUserId, Long targetUserId);
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -12,6 +12,8 @@ import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.friend.exception.status.FriendErrorStatus;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
@@ -20,6 +22,7 @@ import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -116,12 +119,26 @@ public class FriendServiceImpl implements FriendService {
     @Override
     public Long getFriendTeumTime(Long loginUserId, Long targetUserId) {
         validateNotSelf(loginUserId, targetUserId);
-        validateUserExists(loginUserId);
+        validateUserExists(targetUserId);
 
-        List<Schedule> schedules = scheduleRepository.findByUserIdAndIncludeTeumIsTrue(targetUserId);
-        return friendConverter.calculateTeumTime(schedules);
+        LocalDateTime now = LocalDateTime.now();
+
+        List<ScheduleType> targetTypes = List.of(
+                ScheduleType.AI,
+                ScheduleType.WISH,
+                ScheduleType.TODO,
+                ScheduleType.TEUM
+        );
+
+        List<Schedule> rawSchedules = scheduleRepository.findSchedulesForTeumTime(targetUserId, now, targetTypes);
+
+        // TEUM 타입은 COMPLETED 상태인 것만 필터링
+        List<Schedule> filtered = rawSchedules.stream()
+                .filter(s -> s.getType() != ScheduleType.TEUM || s.getStatus() == ScheduleStatus.COMPLETED)
+                .collect(Collectors.toList());
+
+        return friendConverter.calculateTeumTime(filtered);
     }
-
 
     /**
      * 주어진 ID에 해당하는 User를 조회합니다.

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -117,7 +117,7 @@ public class FriendServiceImpl implements FriendService {
 
 
     @Override
-    public Long getFriendTeumTime(Long loginUserId, Long targetUserId) {
+    public FriendTeumTimeResponseDto getFriendTeumTime(Long loginUserId, Long targetUserId) {
         validateNotSelf(loginUserId, targetUserId);
         validateUserExists(targetUserId);
 
@@ -132,12 +132,12 @@ public class FriendServiceImpl implements FriendService {
 
         List<Schedule> rawSchedules = scheduleRepository.findSchedulesForTeumTime(targetUserId, now, targetTypes);
 
-        // TEUM 타입은 COMPLETED 상태인 것만 필터링
         List<Schedule> filtered = rawSchedules.stream()
                 .filter(s -> s.getType() != ScheduleType.TEUM || s.getStatus() == ScheduleStatus.COMPLETED)
                 .collect(Collectors.toList());
 
-        return friendConverter.calculateTeumTime(filtered);
+        long totalMinutes = friendConverter.calculateTeumTime(filtered);
+        return friendConverter.toFriendTeumTimeResponse(totalMinutes);
     }
 
     /**

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -115,7 +115,6 @@ public class FriendServiceImpl implements FriendService {
         return friendConverter.toFriendProfileResponse(targetUser, followRelationOpt.orElse(null));
     }
 
-
     @Override
     public FriendTeumTimeResponseDto getFriendTeumTime(Long loginUserId, Long targetUserId) {
         validateNotSelf(loginUserId, targetUserId);
@@ -133,7 +132,10 @@ public class FriendServiceImpl implements FriendService {
         List<Schedule> rawSchedules = scheduleRepository.findSchedulesForTeumTime(targetUserId, now, targetTypes);
 
         List<Schedule> filtered = rawSchedules.stream()
-                .filter(s -> s.getType() != ScheduleType.TEUM || s.getStatus() == ScheduleStatus.COMPLETED)
+                .filter(s ->
+                        (s.getType() == ScheduleType.TEUM && s.getStatus() == ScheduleStatus.COMPLETED) ||
+                                (s.getType() != ScheduleType.TEUM && s.getStatus() == ScheduleStatus.ACTIVE)
+                )
                 .collect(Collectors.toList());
 
         long totalMinutes = friendConverter.calculateTeumTime(filtered);

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import umc.teumteum.server.domain.friend.controller.FriendController;
 import umc.teumteum.server.domain.friend.converter.FriendConverter;
 import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.domain.friend.entity.Friend;
@@ -21,9 +20,7 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -117,8 +117,6 @@ public class FriendServiceImpl implements FriendService {
         validateNotSelf(loginUserId, targetUserId);
         validateUserExists(targetUserId);
 
-        LocalDateTime now = LocalDateTime.now();
-
         List<ScheduleType> targetTypes = List.of(
                 ScheduleType.AI,
                 ScheduleType.WISH,
@@ -126,7 +124,11 @@ public class FriendServiceImpl implements FriendService {
                 ScheduleType.TEUM
         );
 
-        List<Schedule> rawSchedules = scheduleRepository.findSchedulesForTeumTime(targetUserId, now, targetTypes);
+        List<Schedule> rawSchedules = scheduleRepository.findSchedulesForTeumTime(
+                targetUserId,
+                LocalDateTime.now(),
+                targetTypes
+        );
 
         List<Schedule> filtered = rawSchedules.stream()
                 .filter(s ->
@@ -138,6 +140,7 @@ public class FriendServiceImpl implements FriendService {
         long totalMinutes = friendConverter.calculateTeumTime(filtered);
         return friendConverter.toFriendTeumTimeResponse(totalMinutes);
     }
+
 
     /**
      * 주어진 ID에 해당하는 User를 조회합니다.

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -153,4 +153,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
            
     List<Schedule> findAllByUserAndIncludeTeumTrueAndEndTimeBefore(User user, LocalDateTime now);
 
+    @Query("""
+	SELECT s
+	FROM Schedule s
+	WHERE s.user.id = :userId
+	  AND s.includeTeum = true
+	  AND s.endTime < :now
+	  AND s.type IN :types
+""")
+    List<Schedule> findSchedulesForTeumTime(
+            @Param("userId") Long userId,
+            @Param("now") LocalDateTime now,
+            @Param("types") List<ScheduleType> types
+    );
+
+
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#110 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 친구 빈틈 시간(TeumTime) 계산 로직 개선
- `endTime < now` 조건이 제대로 반영되지 않아 미래 일정이 포함되던 문제 해결
- TEUM은 `COMPLETED`, 그 외는 `ACTIVE` 상태만 포함되도록 필터링 분기 정비
- `includeTeum = true`인 일정만 포함
- 테스트용 DML로 각 조건별 동작 검증

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 필터링 조건이 제대로 동작하는

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 친구의 빈틈 시간 조회 |<img width="1160" height="438" alt="image" src="https://github.com/user-attachments/assets/ab1c59eb-33c9-4b6e-9f3a-be333b8787d4" />|
#### 조회 성공
```json
{
  "isSuccess": true,
  "code": "FRIEND2004",
  "message": "친구 빈틈 시간 조회에 성공하였습니다.",
  "result": {
    "days": 1,
    "hours": 3,
    "minutes": 40,
    "totalMinutes": 1660
  }
}
```