### PR TITLE
Feat: 프로필 이미지 등록 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/OnboardingController.java
@@ -73,13 +73,15 @@ public class OnboardingController {
 
     @Operation(
             summary = "온보딩 프로필 이미지 등록",
-            description = "온보딩 과정에서 S3에 업로드된 프로필 이미지의 파일명를 등록합니다."
+            description = "온보딩 과정에서 S3에 업로드된 프로필 이미지의 파일명을 등록합니다."
     )
     @PostMapping(value = "/onboarding/profile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
+            @RequestBody @Valid OnboardingRequestDto.ProfileImageRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        // TODO: 온보딩 프로필 이미지 파일명 저장 로직 구현
-        return null;
+        onboardingService.saveProfileImage(request, user);
+        return ApiResponse.of(UserSuccessStatus.PROFILE_IMAGE_SAVED, null);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
@@ -73,6 +73,19 @@ public class OnboardingRequestDto {
     }
 
 
+    // 온보딩 - 프로필 이미지
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImageRequest {
+
+        @NotBlank
+        @Schema(description = "업로드한 파일의 이름", example = "550e8400-e29b.jpg")
+        private String fileName;
+    }
+
+
     // 온보딩 - 수면패턴
     @Getter
     @Builder

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -18,9 +18,10 @@ public enum UserErrorStatus implements BaseErrorCode {
     TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "서비스 이용약관은 필수 동의 항목입니다."),
     PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4003", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
     UNSUPPORTED_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "지원하지 않는 이미지 형식입니다."),
-    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
-    ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "반복 일정 간 시간 충돌이 발생했습니다."),
-    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4007", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
+    EXPIRED_OR_INVALID_UPLOAD(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "등록 유효시간이 만료되었거나, 발급된 파일명과 일치하지 않는 업로드 요청입니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
+    ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4007", "반복 일정 간 시간 충돌이 발생했습니다."),
+    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4008", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "ONBOARDING4091", "이미 사용 중인 닉네임입니다."),
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -18,7 +18,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     TOS_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4002", "서비스 이용약관은 필수 동의 항목입니다."),
     PRIVACY_CONSENT_NOT_AGREED(HttpStatus.BAD_REQUEST, "ONBOARDING4003", "개인정보 수집 및 이용은 필수 동의 항목입니다."),
     UNSUPPORTED_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "ONBOARDING4004", "지원하지 않는 이미지 형식입니다."),
-    EXPIRED_OR_INVALID_UPLOAD(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "등록 유효시간이 만료되었거나, 발급된 파일명과 일치하지 않는 업로드 요청입니다."),
+    INVALID_IMAGE_NAME(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "잘못된 파일명에 대한 등록 요청입니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
     ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4007", "반복 일정 간 시간 충돌이 발생했습니다."),
     ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4008", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingService.java
@@ -15,4 +15,6 @@ public interface OnboardingService {
     void saveRoutines(OnboardingRequestDto.RoutineListRequest request, User user);
 
     OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user);
+
+    void saveProfileImage(OnboardingRequestDto.ProfileImageRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -121,8 +121,29 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 6. Presigned URL 생성
         String presignedUrl = s3Util.toUploadPresignedUrl(key, contentType, Duration.ofMinutes(30));
 
-        // 7. 응답 DTO 반환
+
+        // 7. TODO S3 업로드 예정인 파일이름 REDIS에 저장
+
+        // 8. 응답 DTO 반환
         return OnboardingConverter.toProfileImagePresignedUrlResponse(presignedUrl, fileName);
+    }
+
+
+    // 온보딩 - 프로필 이미지 등록
+    @Override
+    @Transactional
+    public void saveProfileImage(OnboardingRequestDto.ProfileImageRequest request, User user) {
+        // 1. 사용자 step 확인
+        validateOnboardingStep(user, UserStep.ONBOARDING);
+
+        // 2. TODO REDIS에서 조회 및 만료 시 삭제
+        // - 1) 사용자가 잘못된 파일명을 전달해주고 이를 DB에 저장한다면 이미지 조회 시 오류가 발생 (파일명 확인 필요)
+        // throw new OnboardingHandler(UserErrorStatus.EXPIRED_OR_INVALID_UPLOAD);
+        // - 2) 프론트에서 S3에 파일을 업로드한 뒤, 해당 API가 호출되지 않으면 S3에 불필요한 파일이 존재하게 됨
+        // REDIS 만료 시 S3 객체 삭제 로직 필요
+
+        // 3. 사용자 프로필 이미지 이름 업데이트
+        user.updateProfileImageName(request.getFileName());
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -121,7 +121,6 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 6. Presigned URL 생성
         String presignedUrl = s3Util.toUploadPresignedUrl(key, contentType, Duration.ofMinutes(30));
 
-
         // 7. TODO S3 업로드 예정인 파일이름 REDIS에 저장
 
         // 8. 응답 DTO 반환
@@ -136,13 +135,10 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 1. 사용자 step 확인
         validateOnboardingStep(user, UserStep.ONBOARDING);
 
-        // 2. TODO REDIS에서 조회 및 만료 시 삭제
-        // - 1) 사용자가 잘못된 파일명을 전달해주고 이를 DB에 저장한다면 이미지 조회 시 오류가 발생 (파일명 확인 필요)
-        // throw new OnboardingHandler(UserErrorStatus.EXPIRED_OR_INVALID_UPLOAD);
-        // - 2) 프론트에서 S3에 파일을 업로드한 뒤, 해당 API가 호출되지 않으면 S3에 불필요한 파일이 존재하게 됨
-        // REDIS 만료 시 S3 객체 삭제 로직 필요
+        // 2. TODO REDIS 조회하여 비교
+        // throw new OnboardingHandler(UserErrorStatus.INVALID_IMAGE_NAME);
 
-        // 3. 사용자 프로필 이미지 이름 업데이트
+        // 2. 사용자 프로필 이미지 이름 업데이트
         user.updateProfileImageName(request.getFileName());
     }
 


### PR DESCRIPTION
### 👀 관련 이슈
#111

### ✨ 작업한 내용
(‼️ 이전 PR 머지가 안되어 프리사인드 URL 발급 브랜치에서 분기해서 작업했습니다. ‼️)

현재 작업한 내용은 **단순하게 파일명을 받아서 DB에 저장**하는 로직입니다.

그런데 TODO로 작성해놨듯, **이전에 발급한 파일명을 Redis에 저장**해놓고
해당 API에서 **비교를 통한 검증**이 있어야 이후에 이미지 조회 시의 오류를 방지할 수 있다고 생각하여 주석으로나마 그 내용을 작성해놓았습니다.

이후에,
1차 - `Redis 인덱스 분리 맟 저장&조회 및 비교 예외 처리`
2차 - `Redis 객체 만료 시, S3 객체 삭제하는 로직`

같은 식을 생각하고 있습니다. 현재는 다른 API 개발이 우선시되어야 할 거 같습니다ㅏ..

### 🌀 PR Point
X

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  이미지 등록 API  |  <img width="362" height="735" alt="스크린샷 2025-07-30 오후 7 01 39" src="https://github.com/user-attachments/assets/2691e851-1318-44d3-8c16-d2013e17a6d4" />. |