### PR TITLE
Feat: 틈 관련 API의 날짜 걸침 일정 및 자정 처리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -19,7 +19,19 @@ import java.util.Optional;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
 
-    List<Schedule> findByUserIdAndDateAndStatus(Long userId, LocalDate date, ScheduleStatus status);
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.status = :status
+      AND s.endTime >= :startOfDay
+      AND s.startTime < :endOfDay
+""")
+    List<Schedule> findOverlappingSchedules(
+            @Param("userId") Long userId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("status") ScheduleStatus status
+    );
 
     @Query("""
         SELECT COUNT(s) > 0 FROM Schedule s

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -2,6 +2,8 @@ package umc.teumteum.server.domain.teum.converter;
 
 import java.time.Duration;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
@@ -19,6 +21,7 @@ import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
 import umc.teumteum.server.global.util.S3Util;
+import umc.teumteum.server.global.util.TimeUtil;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,9 +33,13 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Component
+@RequiredArgsConstructor
 public class TeumConverter {
 
-    public static TeumRequest toTeumRequest(TeumRequestDto dto, User sender) {
+    private final TimeUtil timeUtil;
+
+    public TeumRequest toTeumRequest(TeumRequestDto dto, User sender) {
         return TeumRequest.builder()
                 .title(dto.getTitle())
                 .description(dto.getDescription())
@@ -44,7 +51,7 @@ public class TeumConverter {
                 .build();
     }
 
-    public static List<TeumResponse> toTeumResponses(
+    public List<TeumResponse> toTeumResponses(
             List<Long> receiverUserIds, Long senderId,
             TeumRequest request, Function<Long, User> userFetcher
     ) {
@@ -65,7 +72,7 @@ public class TeumConverter {
                 .toList();
     }
 
-    public static TeumReceivedResponseDto toReceivedResponseDto(TeumResponse response, S3Util s3Util) {
+    public TeumReceivedResponseDto toReceivedResponseDto(TeumResponse response, S3Util s3Util) {
         TeumRequest request = response.getTeumRequest();
         User sender = request.getUser();
 
@@ -86,19 +93,19 @@ public class TeumConverter {
                 .date(request.getDate().toString())
                 .timeSlot(TimeSlot.builder()
                         .start(request.getStartTime().toString())
-                        .end(request.getEndTime().toString())
+                        .end(timeUtil.formatEndTime(request.getEndTime()))
                         .build())
                 .build();
     }
 
 
-    public static List<TeumReceivedResponseDto> toReceivedResponseDtoList(List<TeumResponse> responses, S3Util s3Util) {
+    public List<TeumReceivedResponseDto> toReceivedResponseDtoList(List<TeumResponse> responses, S3Util s3Util) {
         return responses.stream()
                 .map(response -> toReceivedResponseDto(response, s3Util))
                 .toList();
     }
 
-    public static TeumRequest toResendTeumRequest(TeumRequest parent, TeumResendRequestDto dto, User resender) {
+    public TeumRequest toResendTeumRequest(TeumRequest parent, TeumResendRequestDto dto, User resender) {
         return TeumRequest.builder()
                 .title(parent.getTitle())
                 .description(parent.getDescription())
@@ -111,7 +118,7 @@ public class TeumConverter {
                 .build();
     }
 
-    public static TeumResponse toResendTeumResponse(TeumRequest request, User newReceiver) {
+    public TeumResponse toResendTeumResponse(TeumRequest request, User newReceiver) {
         return TeumResponse.builder()
                 .teumRequest(request)
                 .receiverUser(newReceiver)
@@ -120,7 +127,7 @@ public class TeumConverter {
                 .build();
     }
 
-    public static Schedule toScheduleFromTeumRequest(TeumRequest request, User receiver) {
+    public Schedule toScheduleFromTeumRequest(TeumRequest request, User receiver) {
         LocalDateTime start = LocalDateTime.of(request.getDate(), request.getStartTime());
         LocalDateTime end = LocalDateTime.of(request.getDate(), request.getEndTime());
 
@@ -137,7 +144,7 @@ public class TeumConverter {
                 .build();
     }
 
-    public static TeumStatusUpdateResponseDto toStatusUpdateResponseDto(ResponseStatus status, boolean isAccepted, Long teumId) {
+    public TeumStatusUpdateResponseDto toStatusUpdateResponseDto(ResponseStatus status, boolean isAccepted, Long teumId) {
         return TeumStatusUpdateResponseDto.builder()
                 .status(status)
                 .teumCreated(isAccepted)
@@ -145,14 +152,14 @@ public class TeumConverter {
                 .build();
     }
 
-    public static TimeSlot fromSchedule(Schedule schedule) {
+    public TimeSlot fromSchedule(Schedule schedule) {
         return new TimeSlot(
                 schedule.getStartTime().toLocalTime().toString(),
                 schedule.getEndTime().toLocalTime().toString()
         );
     }
 
-    public static List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> scheduledSlots) {
+    public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> scheduledSlots) {
         if (scheduledSlots.isEmpty()) return Collections.emptyList();
 
         List<TimeSlot> sorted = new ArrayList<>(scheduledSlots);
@@ -181,7 +188,7 @@ public class TeumConverter {
         return merged;
     }
 
-    public static List<TimeSlot> invertScheduledToAvailable(List<TimeSlot> scheduledSlots) {
+    public List<TimeSlot> invertScheduledToAvailable(List<TimeSlot> scheduledSlots) {
         List<TimeSlot> available = new ArrayList<>();
         LocalTime startOfDay = LocalTime.of(0, 0);
         LocalTime endOfDay = LocalTime.of(23, 59);
@@ -203,13 +210,13 @@ public class TeumConverter {
         return available;
     }
 
-    public static List<String> toDateStringList(List<LocalDate> dates) {
+    public List<String> toDateStringList(List<LocalDate> dates) {
         return dates.stream()
                 .map(LocalDate::toString)
                 .toList();
     }
 
-    public static ScheduledTeumDetailResponseDto toScheduledTeumDetailDto(
+    public ScheduledTeumDetailResponseDto toScheduledTeumDetailDto(
             Schedule baseSchedule,
             List<Schedule> relatedSchedules,
             S3Util s3Util
@@ -219,7 +226,7 @@ public class TeumConverter {
                 .title(baseSchedule.getTitle())
                 .date(baseSchedule.getDate().toString())
                 .startTime(baseSchedule.getStartTime().toLocalTime().toString())
-                .endTime(baseSchedule.getEndTime().toLocalTime().toString())
+                .endTime(timeUtil.formatEndTime(baseSchedule.getEndTime().toLocalTime()))
                 .status(baseSchedule.getStatus())
                 .participants(relatedSchedules.stream()
                         .map(s -> {
@@ -231,14 +238,14 @@ public class TeumConverter {
                 .build();
     }
 
-    public static ScheduledTeumResponseDto toScheduledTeumResponseDto(Schedule schedule) {
+    public ScheduledTeumResponseDto toScheduledTeumResponseDto(Schedule schedule) {
         return ScheduledTeumResponseDto.builder()
                 .teumId(schedule.getId())
                 .title(schedule.getTitle())
                 .date(schedule.getDate().toString())
                 .time(List.of(new TimeSlot(
                         schedule.getStartTime().toLocalTime().toString(),
-                        schedule.getEndTime().toLocalTime().toString()
+                        timeUtil.formatEndTime(schedule.getEndTime().toLocalTime())
                 )))
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -162,30 +162,27 @@ public class TeumConverter {
     }
 
     // TimeSlot 변환 (Schedule → TimeSlot)
-    public TimeSlot fromSchedule(Schedule schedule) {
-        LocalDate startDate = schedule.getStartTime().toLocalDate();
-        LocalDate endDate = schedule.getEndTime().toLocalDate();
+    public TimeSlot sliceScheduleToDate(Schedule schedule, LocalDate targetDate) {
+        LocalDateTime start = schedule.getStartTime();
+        LocalDateTime end = schedule.getEndTime();
 
-        LocalTime startTime = schedule.getStartTime().toLocalTime();
-        LocalTime endTime = schedule.getEndTime().toLocalTime();
+        LocalDateTime dayStart = LocalDateTime.of(targetDate, LocalTime.MIN);
+        LocalDateTime dayEnd = LocalDateTime.of(targetDate, LocalTime.MAX);
 
-        // endDate가 다음 날이면 → 자정(24:00)까지만 포함
-        if (!startDate.isEqual(endDate)) {
-            return new TimeSlot(
-                    startTime.format(DateTimeFormatter.ofPattern("HH:mm")),
-                    "24:00"
-            );
+        // 잘라낸 시작/종료 시간
+        LocalDateTime slicedStart = start.isBefore(dayStart) ? dayStart : start;
+        LocalDateTime slicedEnd = end.isAfter(dayEnd) ? dayEnd : end;
+
+        if (!slicedStart.isBefore(slicedEnd)) {
+            return null; // 무효한 일정
         }
 
-        // 일반적인 하루 안 일정
-        String end = endTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+        String startStr = slicedStart.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
+        String endStr = slicedEnd.toLocalTime().equals(LocalTime.MAX) ? "24:00"
+                : slicedEnd.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"));
 
-        return new TimeSlot(
-                startTime.format(DateTimeFormatter.ofPattern("HH:mm")),
-                end
-        );
+        return new TimeSlot(startStr, endStr);
     }
-
 
     // 바쁜 시간대 병합 (겹치거나 인접한 TimeSlot 병합)
     public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> slots) {

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -161,6 +161,7 @@ public class TeumConverter {
                 .build();
     }
 
+    // TimeSlot 변환 (Schedule → TimeSlot)
     public TimeSlot fromSchedule(Schedule schedule) {
         LocalDate startDate = schedule.getStartTime().toLocalDate();
         LocalDate endDate = schedule.getEndTime().toLocalDate();
@@ -179,7 +180,7 @@ public class TeumConverter {
         );
     }
 
-
+    // 바쁜 시간대 병합 (겹치거나 인접한 TimeSlot 병합)
     public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> slots) {
         if (slots.isEmpty()) return List.of();
 
@@ -207,6 +208,7 @@ public class TeumConverter {
         return merged;
     }
 
+    // 병합된 바쁜 시간대를 반전하여 비어 있는 시간 구간(available)을 계산
     public List<TimeSlot> invertScheduledToAvailable(List<TimeSlot> scheduledSlots) {
         List<TimeSlot> available = new ArrayList<>();
         LocalTime startOfDay = LocalTime.MIN;
@@ -221,6 +223,7 @@ public class TeumConverter {
             LocalTime scheduledStart = timeUtil.parseTimeForCompare(scheduled.getStart());
             LocalTime scheduledEnd = timeUtil.parseTimeForCompare(scheduled.getEnd());
 
+            // 비어 있는 구간 발견 시 추가
             if (current.isBefore(scheduledStart)) {
                 available.add(new TimeSlot(
                         current.format(DateTimeFormatter.ofPattern("HH:mm")),
@@ -228,11 +231,13 @@ public class TeumConverter {
                 ));
             }
 
+            // 다음 시작 위치 업데이트
             if (current.isBefore(scheduledEnd)) {
                 current = scheduledEnd;
             }
         }
 
+        // 하루의 끝까지 비어 있다면 마지막 구간 추가
         if (current.isBefore(endOfDay)) {
             available.add(new TimeSlot(
                     current.format(DateTimeFormatter.ofPattern("HH:mm")),

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -162,32 +162,42 @@ public class TeumConverter {
     }
 
     public TimeSlot fromSchedule(Schedule schedule) {
+        LocalDate startDate = schedule.getStartTime().toLocalDate();
+        LocalDate endDate = schedule.getEndTime().toLocalDate();
+
+        LocalTime startTime = schedule.getStartTime().toLocalTime();
+        LocalTime endTime = schedule.getEndTime().toLocalTime();
+
+        // end가 00:00이고 날짜가 다음 날이면 → 24:00으로 표시
+        String end = (endTime.equals(LocalTime.MIDNIGHT) && !startDate.equals(endDate))
+                ? "24:00"
+                : endTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+
         return new TimeSlot(
-                schedule.getStartTime().toLocalTime().toString(),
-                schedule.getEndTime().toLocalTime().toString()
+                startTime.format(DateTimeFormatter.ofPattern("HH:mm")),
+                end
         );
     }
 
-    public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> scheduledSlots) {
-        if (scheduledSlots.isEmpty()) return Collections.emptyList();
 
-        List<TimeSlot> sorted = new ArrayList<>(scheduledSlots);
-        sorted.sort(Comparator.comparing(slot -> LocalTime.parse(slot.getStart())));
+    public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> slots) {
+        if (slots.isEmpty()) return List.of();
+
+        List<TimeSlot> sorted = new ArrayList<>(slots);
+        sorted.sort(Comparator.comparing(slot -> timeUtil.parseTimeForCompare(slot.getStart())));
 
         List<TimeSlot> merged = new ArrayList<>();
         TimeSlot current = sorted.get(0);
 
         for (int i = 1; i < sorted.size(); i++) {
             TimeSlot next = sorted.get(i);
-            LocalTime currEnd = LocalTime.parse(current.getEnd());
-            LocalTime nextStart = LocalTime.parse(next.getStart());
+            LocalTime currEnd = timeUtil.parseTimeForCompare(current.getEnd());
+            LocalTime nextStart = timeUtil.parseTimeForCompare(next.getStart());
+            LocalTime nextEnd = timeUtil.parseTimeForCompare(next.getEnd());
 
             if (!currEnd.isBefore(nextStart)) {
-                current = new TimeSlot(
-                        current.getStart(),
-                        LocalTime.parse(current.getEnd()).isAfter(LocalTime.parse(next.getEnd()))
-                                ? current.getEnd() : next.getEnd()
-                );
+                String newEnd = currEnd.isAfter(nextEnd) ? current.getEnd() : next.getEnd();
+                current = new TimeSlot(current.getStart(), newEnd);
             } else {
                 merged.add(current);
                 current = next;
@@ -202,21 +212,22 @@ public class TeumConverter {
         LocalTime startOfDay = LocalTime.MIN;
         LocalTime endOfDay = LocalTime.MAX;
 
-        // 먼저 scheduled를 시간 순서대로 정렬
         List<TimeSlot> sorted = new ArrayList<>(scheduledSlots);
-        sorted.sort(Comparator.comparing(slot -> LocalTime.parse(slot.getStart())));
+        sorted.sort(Comparator.comparing(slot -> timeUtil.parseTimeForCompare(slot.getStart())));
 
         LocalTime current = startOfDay;
 
         for (TimeSlot scheduled : sorted) {
-            LocalTime scheduledStart = LocalTime.parse(scheduled.getStart());
-            LocalTime scheduledEnd = LocalTime.parse(scheduled.getEnd());
+            LocalTime scheduledStart = timeUtil.parseTimeForCompare(scheduled.getStart());
+            LocalTime scheduledEnd = timeUtil.parseTimeForCompare(scheduled.getEnd());
 
             if (current.isBefore(scheduledStart)) {
-                available.add(new TimeSlot(current.toString(), scheduledStart.toString()));
+                available.add(new TimeSlot(
+                        current.format(DateTimeFormatter.ofPattern("HH:mm")),
+                        scheduledStart.format(DateTimeFormatter.ofPattern("HH:mm"))
+                ));
             }
 
-            // 다음 구간 시작 위치를 scheduledEnd 기준으로 계속 갱신
             if (current.isBefore(scheduledEnd)) {
                 current = scheduledEnd;
             }
@@ -225,7 +236,7 @@ public class TeumConverter {
         if (current.isBefore(endOfDay)) {
             available.add(new TimeSlot(
                     current.format(DateTimeFormatter.ofPattern("HH:mm")),
-                    timeUtil.formatEndTime(endOfDay) // 24:00 처리
+                    timeUtil.formatEndTime(endOfDay)
             ));
         }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -169,16 +169,23 @@ public class TeumConverter {
         LocalTime startTime = schedule.getStartTime().toLocalTime();
         LocalTime endTime = schedule.getEndTime().toLocalTime();
 
-        // end가 00:00이고 날짜가 다음 날이면 → 24:00으로 표시
-        String end = (endTime.equals(LocalTime.MIDNIGHT) && !startDate.equals(endDate))
-                ? "24:00"
-                : endTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+        // endDate가 다음 날이면 → 자정(24:00)까지만 포함
+        if (!startDate.isEqual(endDate)) {
+            return new TimeSlot(
+                    startTime.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    "24:00"
+            );
+        }
+
+        // 일반적인 하루 안 일정
+        String end = endTime.format(DateTimeFormatter.ofPattern("HH:mm"));
 
         return new TimeSlot(
                 startTime.format(DateTimeFormatter.ofPattern("HH:mm")),
                 end
         );
     }
+
 
     // 바쁜 시간대 병합 (겹치거나 인접한 TimeSlot 병합)
     public List<TimeSlot> mergeScheduledTimeSlots(List<TimeSlot> slots) {

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -26,6 +26,7 @@ import umc.teumteum.server.global.util.TimeUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -93,7 +94,7 @@ public class TeumConverter {
                 .date(request.getDate().toString())
                 .timeSlot(TimeSlot.builder()
                         .start(request.getStartTime().toString())
-                        .end(timeUtil.formatEndTime(request.getEndTime()))
+                        .end(timeUtil.parseAndFormatEndTime(request.getEndTime()))
                         .build())
                 .build();
     }
@@ -128,16 +129,24 @@ public class TeumConverter {
     }
 
     public Schedule toScheduleFromTeumRequest(TeumRequest request, User receiver) {
-        LocalDateTime start = LocalDateTime.of(request.getDate(), request.getStartTime());
-        LocalDateTime end = LocalDateTime.of(request.getDate(), request.getEndTime());
+        LocalDate date = request.getDate();
+        LocalTime start = request.getStartTime();
+        LocalTime end = timeUtil.convertEndTime(request.getEndTime());
+
+        LocalDateTime startDateTime = LocalDateTime.of(date, start);
+
+        // 00:00이 들어와서 LocalTime.MAX로 바뀐 경우 → 다음 날 00:00으로 endTime을 표현
+        LocalDateTime endDateTime = end.equals(LocalTime.MAX)
+                ? LocalDateTime.of(date.plusDays(1), LocalTime.MIDNIGHT)
+                : LocalDateTime.of(date, end);
 
         return Schedule.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .type(ScheduleType.TEUM)
-                .date(request.getDate())
-                .startTime(start)
-                .endTime(end)
+                .date(date)
+                .startTime(startDateTime)
+                .endTime(endDateTime)
                 .user(receiver)
                 .includeTeum(true)
                 .teumRequest(request)
@@ -190,21 +199,34 @@ public class TeumConverter {
 
     public List<TimeSlot> invertScheduledToAvailable(List<TimeSlot> scheduledSlots) {
         List<TimeSlot> available = new ArrayList<>();
-        LocalTime startOfDay = LocalTime.of(0, 0);
-        LocalTime endOfDay = LocalTime.of(23, 59);
+        LocalTime startOfDay = LocalTime.MIN;
+        LocalTime endOfDay = LocalTime.MAX;
 
-        for (TimeSlot scheduled : scheduledSlots) {
+        // 먼저 scheduled를 시간 순서대로 정렬
+        List<TimeSlot> sorted = new ArrayList<>(scheduledSlots);
+        sorted.sort(Comparator.comparing(slot -> LocalTime.parse(slot.getStart())));
+
+        LocalTime current = startOfDay;
+
+        for (TimeSlot scheduled : sorted) {
             LocalTime scheduledStart = LocalTime.parse(scheduled.getStart());
             LocalTime scheduledEnd = LocalTime.parse(scheduled.getEnd());
 
-            if (startOfDay.isBefore(scheduledStart)) {
-                available.add(new TimeSlot(startOfDay.toString(), scheduledStart.toString()));
+            if (current.isBefore(scheduledStart)) {
+                available.add(new TimeSlot(current.toString(), scheduledStart.toString()));
             }
-            startOfDay = scheduledEnd;
+
+            // 다음 구간 시작 위치를 scheduledEnd 기준으로 계속 갱신
+            if (current.isBefore(scheduledEnd)) {
+                current = scheduledEnd;
+            }
         }
 
-        if (startOfDay.isBefore(endOfDay)) {
-            available.add(new TimeSlot(startOfDay.toString(), endOfDay.toString()));
+        if (current.isBefore(endOfDay)) {
+            available.add(new TimeSlot(
+                    current.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    timeUtil.formatEndTime(endOfDay) // 24:00 처리
+            ));
         }
 
         return available;
@@ -226,7 +248,7 @@ public class TeumConverter {
                 .title(baseSchedule.getTitle())
                 .date(baseSchedule.getDate().toString())
                 .startTime(baseSchedule.getStartTime().toLocalTime().toString())
-                .endTime(timeUtil.formatEndTime(baseSchedule.getEndTime().toLocalTime()))
+                .endTime(timeUtil.parseAndFormatEndTime(baseSchedule.getEndTime().toLocalTime()))
                 .status(baseSchedule.getStatus())
                 .participants(relatedSchedules.stream()
                         .map(s -> {
@@ -245,7 +267,7 @@ public class TeumConverter {
                 .date(schedule.getDate().toString())
                 .time(List.of(new TimeSlot(
                         schedule.getStartTime().toLocalTime().toString(),
-                        timeUtil.formatEndTime(schedule.getEndTime().toLocalTime())
+                        timeUtil.parseAndFormatEndTime(schedule.getEndTime().toLocalTime())
                 )))
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.teum.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,19 +32,18 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
+import umc.teumteum.server.global.util.TimeUtil;
 import umc.teumteum.server.global.validator.ConflictValidator;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TeumServiceImpl implements TeumService {
@@ -55,6 +55,7 @@ public class TeumServiceImpl implements TeumService {
     private final TeumResponseRepository teumResponseRepository;
     private final ScheduleRepository scheduleRepository;
     private final TeumConverter teumConverter;
+    private final TimeUtil timeUtil;
 
     @Override
     @Transactional
@@ -306,9 +307,8 @@ public class TeumServiceImpl implements TeumService {
         DayOfWeek targetDay = date.getDayOfWeek();
         List<TimeSlot> scheduledSlots = new ArrayList<>();
 
-        // 요청자 ID 자동 포함
         Set<Long> userIdSet = new HashSet<>(requestDto.getUserIds());
-        userIdSet.add(user.getId());
+        userIdSet.add(user.getId()); // 요청자 포함
 
         for (Long userId : userIdSet) {
             User targetUser = getUserOrThrow(userId);
@@ -317,9 +317,12 @@ public class TeumServiceImpl implements TeumService {
             List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatus(
                     userId, date, ScheduleStatus.ACTIVE
             );
+
             schedules.stream()
+                    .filter(schedule -> schedule.getStartTime().toLocalDate().isEqual(date))
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
                     .map(teumConverter::fromSchedule)
+                    .peek(slot -> log.info("Scheduled TimeSlot for user {}: {} ~ {}", userId, slot.getStart(), slot.getEnd()))
                     .forEach(scheduledSlots::add);
 
             // 수면 시간
@@ -354,11 +357,21 @@ public class TeumServiceImpl implements TeumService {
             }
         }
 
-        List<TimeSlot> merged = teumConverter.mergeScheduledTimeSlots(scheduledSlots);
-        List<TimeSlot> available = teumConverter.invertScheduledToAvailable(merged);
+        // 병합 → 반전 → 병합
+        List<TimeSlot> mergedBusy = teumConverter.mergeScheduledTimeSlots(scheduledSlots);
+        List<TimeSlot> rawAvailable = teumConverter.invertScheduledToAvailable(mergedBusy);
+        List<TimeSlot> cleanAvailable = teumConverter.mergeScheduledTimeSlots(rawAvailable);
 
-        return new AvailableTimeResponseDto(date.toString(), available);
+        // 리스트 복사 후 정렬 (정렬 보장)
+        List<TimeSlot> sortedAvailable = new ArrayList<>(cleanAvailable);
+        sortedAvailable.sort(Comparator.comparing(slot -> timeUtil.parseTimeForSort(slot.getStart())));
+
+        sortedAvailable.forEach(slot ->
+                log.info("최종 Available (정렬됨): {} ~ {}", slot.getStart(), slot.getEnd()));
+
+        return new AvailableTimeResponseDto(date.toString(), sortedAvailable);
     }
+
 
     @Override
     public SharedTeumResponseDto getSharedTeumStats(Long userId, Long friendId) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -54,6 +54,7 @@ public class TeumServiceImpl implements TeumService {
     private final TeumRequestRepository teumRequestRepository;
     private final TeumResponseRepository teumResponseRepository;
     private final ScheduleRepository scheduleRepository;
+    private final TeumConverter teumConverter;
 
     @Override
     @Transactional
@@ -77,8 +78,8 @@ public class TeumServiceImpl implements TeumService {
         conflictValidator.validateTeumForUsers(allParticipants, date, startTime, endTime);
 
         // 요청 객체 생성 및 저장
-        TeumRequest request = TeumConverter.toTeumRequest(dto, user);
-        List<TeumResponse> responses = TeumConverter.toTeumResponses(
+        TeumRequest request = teumConverter.toTeumRequest(dto, user);
+        List<TeumResponse> responses = teumConverter.toTeumResponses(
                 dto.getReceiverUserIds(),
                 user.getId(),
                 request,
@@ -113,8 +114,8 @@ public class TeumServiceImpl implements TeumService {
         conflictValidator.validateTeumForUsers(participants, date, startTime, endTime);
 
         // 요청 및 응답 생성
-        TeumRequest newRequest = TeumConverter.toResendTeumRequest(parent, dto, user);
-        TeumResponse newResponse = TeumConverter.toResendTeumResponse(newRequest, originalSender);
+        TeumRequest newRequest = teumConverter.toResendTeumRequest(parent, dto, user);
+        TeumResponse newResponse = teumConverter.toResendTeumResponse(newRequest, originalSender);
         newRequest.getTeumResponses().add(newResponse);
 
         // 응답 상태 변경
@@ -146,7 +147,7 @@ public class TeumServiceImpl implements TeumService {
         );
 
         List<TeumReceivedResponseDto> dtoList = pageData.getContent().stream()
-                .map(response -> TeumConverter.toReceivedResponseDto(response, s3Util))
+                .map(response -> teumConverter.toReceivedResponseDto(response, s3Util))
                 .toList();
 
         return new PageImpl<>(dtoList, pageable, pageData.getTotalElements());
@@ -200,13 +201,13 @@ public class TeumServiceImpl implements TeumService {
             conflictValidator.validateTeum(receiver, date, startTime, endTime);
 
             // 수신자(응답자) 일정 생성
-            Schedule receiverSchedule = TeumConverter.toScheduleFromTeumRequest(request, receiver);
+            Schedule receiverSchedule = teumConverter.toScheduleFromTeumRequest(request, receiver);
             scheduleRepository.save(receiverSchedule);
 
             // 요청자 본인의 스케줄이 없는 경우에만 생성
             User requester = request.getUser();
             if (!scheduleRepository.existsByTeumRequestAndUser(request, requester)) {
-                Schedule requesterSchedule = TeumConverter.toScheduleFromTeumRequest(request, requester);
+                Schedule requesterSchedule = teumConverter.toScheduleFromTeumRequest(request, requester);
                 scheduleRepository.save(requesterSchedule);
             }
 
@@ -214,7 +215,7 @@ public class TeumServiceImpl implements TeumService {
             teumId = receiverSchedule.getId();
         }
 
-        return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
+        return teumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
     }
 
 
@@ -223,7 +224,7 @@ public class TeumServiceImpl implements TeumService {
     public List<String> getScheduledTeumsOfMonth(Long userId, String month) {
         List<ScheduleStatus> validStatuses = List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
         List<LocalDate> dates = scheduleRepository.findScheduledTeumsByMonth(userId, validStatuses, month);
-        return TeumConverter.toDateStringList(dates);
+        return teumConverter.toDateStringList(dates);
     }
 
     @Override
@@ -244,7 +245,7 @@ public class TeumServiceImpl implements TeumService {
         }
 
         return teumSchedules.stream()
-                .map(TeumConverter::toScheduledTeumResponseDto)
+                .map(teumConverter::toScheduledTeumResponseDto)
                 .toList();
 
     }
@@ -258,7 +259,7 @@ public class TeumServiceImpl implements TeumService {
                 List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
         );
 
-        return TeumConverter.toScheduledTeumDetailDto(schedule, relatedSchedules, s3Util);
+        return teumConverter.toScheduledTeumDetailDto(schedule, relatedSchedules, s3Util);
     }
 
     @Override
@@ -318,7 +319,7 @@ public class TeumServiceImpl implements TeumService {
             );
             schedules.stream()
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
-                    .map(TeumConverter::fromSchedule)
+                    .map(teumConverter::fromSchedule)
                     .forEach(scheduledSlots::add);
 
             // 수면 시간
@@ -353,8 +354,8 @@ public class TeumServiceImpl implements TeumService {
             }
         }
 
-        List<TimeSlot> merged = TeumConverter.mergeScheduledTimeSlots(scheduledSlots);
-        List<TimeSlot> available = TeumConverter.invertScheduledToAvailable(merged);
+        List<TimeSlot> merged = teumConverter.mergeScheduledTimeSlots(scheduledSlots);
+        List<TimeSlot> available = teumConverter.invertScheduledToAvailable(merged);
 
         return new AvailableTimeResponseDto(date.toString(), available);
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -454,7 +454,8 @@ public class TeumServiceImpl implements TeumService {
 
     private void validateTimeOrder(String startTime, String endTime) {
         LocalTime start = LocalTime.parse(startTime);
-        LocalTime end = LocalTime.parse(endTime);
+        LocalTime end = endTime.equals("00:00") ? LocalTime.MAX : LocalTime.parse(endTime);
+
         if (!start.isBefore(end)) {
             throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
         }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -301,6 +301,7 @@ public class TeumServiceImpl implements TeumService {
                 .build();
     }
 
+    // 공통 가능한 시간대 계산
     @Override
     public AvailableTimeResponseDto getAvailableTime(User user, AvailableTimeRequestDto requestDto) {
         LocalDate date = LocalDate.parse(requestDto.getDate());
@@ -322,7 +323,6 @@ public class TeumServiceImpl implements TeumService {
                     .filter(schedule -> schedule.getStartTime().toLocalDate().isEqual(date))
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
                     .map(teumConverter::fromSchedule)
-                    .peek(slot -> log.info("Scheduled TimeSlot for user {}: {} ~ {}", userId, slot.getStart(), slot.getEnd()))
                     .forEach(scheduledSlots::add);
 
             // 수면 시간
@@ -365,9 +365,6 @@ public class TeumServiceImpl implements TeumService {
         // 리스트 복사 후 정렬 (정렬 보장)
         List<TimeSlot> sortedAvailable = new ArrayList<>(cleanAvailable);
         sortedAvailable.sort(Comparator.comparing(slot -> timeUtil.parseTimeForSort(slot.getStart())));
-
-        sortedAvailable.forEach(slot ->
-                log.info("최종 Available (정렬됨): {} ~ {}", slot.getStart(), slot.getEnd()));
 
         return new AvailableTimeResponseDto(date.toString(), sortedAvailable);
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -324,10 +324,6 @@ public class TeumServiceImpl implements TeumService {
             );
 
             schedules.stream()
-                    .filter(schedule ->
-                            !schedule.getEndTime().toLocalDate().isBefore(date) &&
-                                    schedule.getStartTime().toLocalDate().isBefore(date.plusDays(1))
-                    )
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
                     .map(schedule -> teumConverter.sliceScheduleToDate(schedule, date))
                     .filter(Objects::nonNull)
@@ -365,13 +361,12 @@ public class TeumServiceImpl implements TeumService {
             }
         }
 
-        // 병합 → 반전 → 병합
+        // 병합 → 반전
         List<TimeSlot> mergedBusy = teumConverter.mergeScheduledTimeSlots(scheduledSlots);
-        List<TimeSlot> rawAvailable = teumConverter.invertScheduledToAvailable(mergedBusy);
-        List<TimeSlot> cleanAvailable = teumConverter.mergeScheduledTimeSlots(rawAvailable);
+        List<TimeSlot> availableTime = teumConverter.invertScheduledToAvailable(mergedBusy);
 
-        // 리스트 복사 후 정렬 (정렬 보장)
-        List<TimeSlot> sortedAvailable = new ArrayList<>(cleanAvailable);
+        // 리스트 복사 후 정렬
+        List<TimeSlot> sortedAvailable = new ArrayList<>(availableTime);
         sortedAvailable.sort(Comparator.comparing(slot -> timeUtil.parseTimeForSort(slot.getStart())));
 
         return new AvailableTimeResponseDto(date.toString(), sortedAvailable);

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -42,6 +42,7 @@ import java.time.LocalTime;
 import java.util.*;
 
 import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
+import static umc.teumteum.server.domain.user.entity.enums.UserStatus.ACTIVE;
 
 @Slf4j
 @Service
@@ -315,14 +316,21 @@ public class TeumServiceImpl implements TeumService {
             User targetUser = getUserOrThrow(userId);
 
             // 일반 일정
-            List<Schedule> schedules = scheduleRepository.findByUserIdAndDateAndStatus(
-                    userId, date, ScheduleStatus.ACTIVE
+            LocalDateTime startOfDay = date.atStartOfDay();
+            LocalDateTime endOfDay = LocalDateTime.of(date, LocalTime.MAX);
+
+            List<Schedule> schedules = scheduleRepository.findOverlappingSchedules(
+                    userId, startOfDay, endOfDay, ScheduleStatus.ACTIVE
             );
 
             schedules.stream()
-                    .filter(schedule -> schedule.getStartTime().toLocalDate().isEqual(date))
+                    .filter(schedule ->
+                            !schedule.getEndTime().toLocalDate().isBefore(date) &&
+                                    schedule.getStartTime().toLocalDate().isBefore(date.plusDays(1))
+                    )
                     .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
-                    .map(teumConverter::fromSchedule)
+                    .map(schedule -> teumConverter.sliceScheduleToDate(schedule, date))
+                    .filter(Objects::nonNull)
                     .forEach(scheduledSlots::add);
 
             // 수면 시간

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -332,7 +332,7 @@ public class TeumServiceImpl implements TeumService {
                 if (sleep.isBefore(wake)) {
                     scheduledSlots.add(new TimeSlot(sleep.toString(), wake.toString()));
                 } else {
-                    scheduledSlots.add(new TimeSlot(sleep.toString(), "23:59"));
+                    scheduledSlots.add(new TimeSlot(sleep.toString(), "24:00"));
                     scheduledSlots.add(new TimeSlot("00:00", wake.toString()));
                 }
             }

--- a/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
@@ -47,4 +47,16 @@ public class TimeUtil {
         return formatEndTime(convertEndTime(endTime));
     }
 
+    public LocalTime parseTimeForCompare(String time) {
+        return "24:00".equals(time) ? LocalTime.MAX : LocalTime.parse(time);
+    }
+
+    public LocalTime parseTimeForSort(String time) {
+        return switch (time) {
+            case "24:00" -> LocalTime.MAX;
+            case "00:00" -> LocalTime.MIN;
+            default -> LocalTime.parse(time);
+        };
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
@@ -47,10 +47,12 @@ public class TimeUtil {
         return formatEndTime(convertEndTime(endTime));
     }
 
+    // 비교용 (병합/반전용) - 24:00만 LocalTime.MAX로 처리
     public LocalTime parseTimeForCompare(String time) {
         return "24:00".equals(time) ? LocalTime.MAX : LocalTime.parse(time);
     }
 
+    // 정렬용 - 00:00 → MIN, 24:00 → MAX
     public LocalTime parseTimeForSort(String time) {
         return switch (time) {
             case "24:00" -> LocalTime.MAX;

--- a/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
@@ -32,8 +32,14 @@ public class TimeUtil {
     }
 
 
-    // 공통 - 종료시간 변환 (종료시간이 00:00인 경우 LocalTime.MAX로 변환 필요)
+    // 공통 - 종료시간 입력 시 변환 (종료시간이 00:00인 경우 LocalTime.MAX로 변환 필요)
     public LocalTime convertEndTime(LocalTime endTime) {
         return endTime.equals(LocalTime.MIDNIGHT) ? LocalTime.MAX : endTime;
     }
+
+    // 공통 - 종료시간 반환 시 변환 (종료시간이 LocalTime.MAX인 경우 24:00로 변환 필요)
+    public String formatEndTime(LocalTime endTime) {
+        return endTime.equals(LocalTime.MAX) ? "24:00" : endTime.toString();
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/TimeUtil.java
@@ -42,4 +42,9 @@ public class TimeUtil {
         return endTime.equals(LocalTime.MAX) ? "24:00" : endTime.toString();
     }
 
+    // 공통 - DB에서 가져온 값을 바로 응답용 문자열로 (통합 처리)
+    public String parseAndFormatEndTime(LocalTime endTime) {
+        return formatEndTime(convertEndTime(endTime));
+    }
+
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#114 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 종료 시간이 `00:00`일 경우 `24:00`으로 반환, DB 상으로는 다음 날 `00:00`
- `parseTimeForCompare`, `parseTimeForSort` 함수 분리로 정렬/병합 용도 분리
- 수면 시간이 `23:00 ~ 07:00`처럼 하루를 넘는 경우, `24:00`까지 정확히 반영되도록 수정
- `fromSchedule()` → `sliceScheduleToDate()`로 대체
  - 하루를 넘는 일정인 경우 해당 날짜에 해당하는 구간만 슬라이스하여 TimeSlot 반환
- `Schedule` 조회 로직 수정
  - 기존 `startTime.date == date`에서 `start < 내일 && end ≥ 오늘` 조건으로 조회 범위 확장

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 하루를 넘는 일정이 제대로 잘려 반영되는지
- 자정 처리 관련해서 문제가 없는지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 지난 회의 때 얘기 나왔던 것 중에 자정 처리만 하면 된다고 생각하고 이슈를 팠다가 날짜 걸침 일정까지 한꺼번에 고려하게 되면서 공통 시간대 조회 API가 좀 많이 복잡해졌습니다...
- 프론트 측에서 종료 시각의 자정은 입력 시 `00:00`, 반환 시 `24:00`로 달라고 하여서 그거 반영해서 구현했습니다!
- `23:00 ~ 01:00` 일정은 → `"23:00 ~ 24:00"`, `"00:00 ~ 01:00"`으로 각 날짜에 나눠 반영됨
- `sliceScheduleToDate()`는 날짜 단위로 자르고, 정렬/병합은 시간 단위로 수행됨

### 📷 테스트

#### 틈 요청 시 종료 시각에 00:00 입력
```json
{
  "isSuccess": true,
  "code": "TEUM2000",
  "message": "틈 요청이 성공적으로 생성되었습니다.",
  "result": 1
}
```
#### 틈 요청 조회 시 종료 시각에 24:00 반환
```json
{
  "isSuccess": true,
  "code": "TEUM2002",
  "message": "받은 틈 요청 목록이 조회되었습니다.",
  "result": {
    "content": [
      {
        "responseId": 1,
        "requestId": 1,
        "title": "string",
        "description": "string",
        "graphicId": 1,
        "senderUser": {
          "userId": 2,
          "nickname": "유저2",
          "profileImageUrl": "https://teumteum..."
        },
        "receiverCount": 1,
        "date": "2025-08-09",
        "timeSlot": {
          "start": "23:00",
          "end": "24:00"  // 24시 반환
        },
        "read": false
      }
    ], 
    // 중략...
}
```
#### 약속된 틈 조회 시 종료 시각에 24:00 반환
```json
{
  "isSuccess": true,
  "code": "TEUM2009",
  "message": "약속된 틈 상세 정보가 조회되었습니다.",
  "result": {
    "teumId": 1,
    "title": "string",
    "date": "2025-08-09",
    "startTime": "23:00",
    "endTime": "24:00",  // 24시 반환
    "status": "ACTIVE",
    "participants": [
      {
        "userId": 1,
        "nickname": null,
        "profileImageUrl": "https://teumteum..."
      },
      {
        "userId": 2,
        "nickname": "유저2",
        "profileImageUrl": "https://teumteum..."
      }
    ]
  }
}
```

#### 공통 시간대 조회 (날짜 걸침 일정 고려)
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-08-01",
    "availableTime": [
      {
        "start": "00:00",
        "end": "02:10"
      },
      {
        "start": "08:10",
        "end": "23:00"
      },
      {
        "start": "23:30",
        "end": "23:40"
      }
    ]
  }
}
```
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-08-02",
    "availableTime": [
      {
        "start": "00:30",
        "end": "02:10"
      },
      {
        "start": "08:10",
        "end": "24:00"  // 24시 반환
      }
    ]
  }
}
```
- 8월 1일 23시 40분 ~ 8월 2일 0시 30분까지의 스케줄이 존재한다는 전제