### PR TITLE
Fix: 반복일정 Schedule 저장 및 소셜 로그인 시 Schedule 초기화

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -88,11 +88,11 @@ public class AuthServiceImpl implements AuthService {
             // 2) 수면패턴 초기화
             user.clearSleepPattern();
 
-            // 3) 반복일정 초기화
-            routineRepository.deleteByUser(user);
-
-            // 4) 스케줄 초기화
+            // 3) 스케줄 초기화 (외래키로 인해 먼저 삭제)
             scheduleRepository.deleteByUser(user);
+
+            // 4) 반복일정 초기화
+            routineRepository.deleteByUser(user);
         }
 
         // 7. converter 작업

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -13,6 +13,7 @@ import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.auth.exception.AuthHandler;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
@@ -33,15 +34,19 @@ public class AuthServiceImpl implements AuthService {
     private final KakaoOAuthService kakaoOAuthService;
     private final NaverOAuthService naverOAuthService;
     private final UserService userService;
+
     private final JwtProvider jwtProvider;
     private final S3Util s3Util;
+
     private final RoutineRepository routineRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Resource(name = "rtRedisTemplate")
     private RedisTemplate<String, String> rtRedisTemplate;
 
     @Value("${jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
+
 
     @Override
     @Transactional
@@ -85,6 +90,9 @@ public class AuthServiceImpl implements AuthService {
 
             // 3) 반복일정 초기화
             routineRepository.deleteByUser(user);
+
+            // 4) 스케줄 초기화
+            scheduleRepository.deleteByUser(user);
         }
 
         // 7. converter 작업

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
@@ -9,7 +10,6 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
-
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -153,4 +153,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
            
     List<Schedule> findAllByUserAndIncludeTeumTrueAndEndTimeBefore(User user, LocalDateTime now);
 
+
+    @Modifying
+    @Query("delete from Schedule s where s.user = :user")
+    void deleteByUser(@Param("user") User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/OnboardingConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/OnboardingConverter.java
@@ -1,0 +1,34 @@
+package umc.teumteum.server.domain.user.converter;
+
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.user.entity.Routine;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class OnboardingConverter {
+
+    // 온보딩 - 반복일정 -> Schedule
+    public static List<Schedule> toScheduleList(List<Routine> routines, User user, LocalDate today) {
+        Weekday todayWeekday = Weekday.from(today.getDayOfWeek());
+
+        return routines.stream()
+                .filter(routine -> routine.getWeekday() == todayWeekday)
+                .map(routine -> Schedule.builder()
+                        .title(routine.getTitle())
+                        .description(routine.getDescription())
+                        .type(ScheduleType.ROUTINE)
+                        .date(today)
+                        .startTime(LocalDateTime.of(today, routine.getStartTime()))
+                        .endTime(LocalDateTime.of(today, routine.getEndTime()))
+                        .user(user)
+                        .routine(routine)
+                        .build()
+                )
+                .toList();
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -1,9 +1,9 @@
 package umc.teumteum.server.domain.user.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -3,7 +3,10 @@ package umc.teumteum.server.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.converter.AgreementConverter;
+import umc.teumteum.server.domain.user.converter.OnboardingConverter;
 import umc.teumteum.server.domain.user.converter.RoutineConverter;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.Agreement;
@@ -19,6 +22,7 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.TimeRange;
 import umc.teumteum.server.global.util.TimeUtil;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -34,6 +38,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final AgreementRepository agreementRepository;
     private final RoutineRepository routineRepository;
     private final TimeUtil timeUtil;
+    private final ScheduleRepository scheduleRepository;
 
 
     // 온보딩 - 약관 동의
@@ -129,7 +134,12 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 6. 반복 일정 저장
         List<Routine> newRoutines = RoutineConverter.toRoutineList(request.getRoutine(), user);
         routineRepository.saveAll(newRoutines);
+
+        // 7. 오늘 요일의 일정은 스케줄에 추가
+        List<Schedule> routineSchedules = OnboardingConverter.toScheduleList(newRoutines, user, LocalDate.now());
+        scheduleRepository.saveAll(routineSchedules);
     }
+
 
 
 
@@ -175,6 +185,7 @@ public class OnboardingServiceImpl implements OnboardingService {
                     timeUtil.validateTimeRangeConflicts(timeRanges, UserErrorStatus.ROUTINE_TIME_CONFLICT);
                 });
     }
+
 
     // 수면패턴과 반복일정 간의 충돌 확인
     private void validateSleepPatternConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay, User user) {

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
@@ -36,6 +37,9 @@ class OnboardingServiceTest {
 
     @Mock
     private RoutineRepository routineRepository;
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
 
     @Spy
     private TimeUtil timeUtil = new TimeUtil();


### PR DESCRIPTION
### 👀 관련 이슈
#115 

### ✨ 작업한 내용
FE에서 반복일정 연동 작업 중, 등록 이후에 일정으로 조회되지 않는다는 소식을 전해듣고 급히 수정했습니다,,

온보딩에서 등록한 반복일정 중 오늘에 해당하는 일정은 해당 API에서 바로 스케줄에 넣어 일정 조회가 가능합니다.
그리고 온보딩 재시작 시 진행하는 초기화에도 스케줄 삭제를 추가하였습니다.

이후에 리마인드 알림 등록 API 개발할 때에는 [`Schedule` 조회 -> 있으면 `ScheduleReminder`까지 저장] 작업이 예상됩니다.
그리고 `리마인드 API 완료` = `온보딩 완료`이기 때문에 초기화는 X

### 🌀 PR Point
X

### 🍰 참고사항
해당 API에서 `Routine 저장` & `Schedule 저장`까지 각 레코드마다 Insert 쿼리가 나갑니다..
API 개발이 끝나고 시간이 생기면 가장 먼저 수정해보겠습니다... 🥲


### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
|  반복일정 등록 API  |  <img width="300" height="832" alt="image" src="https://github.com/user-attachments/assets/15f71fed-d523-452f-8b3f-fbaccc2caa69" />  |
|  Routine 저장  |  <img width="1490" height="592" alt="image" src="https://github.com/user-attachments/assets/c078e4f7-4a4c-4a4d-8fe0-27bca7a33915" />  |
|  Schedule 저장  |  <img width="1388" height="100" alt="image" src="https://github.com/user-attachments/assets/b1042d2f-5a18-42e7-b340-ae3ab018cc35" />  |
|  초기화 시, 삭제  |  <img width="1276" height="922" alt="image" src="https://github.com/user-attachments/assets/bb137165-d3ce-4fa9-9f88-ad3485413942" />  |