### PR TITLE
Feat: 친구 공개 투두 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -127,5 +127,49 @@ public class FriendController {
         return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_TEUM_TIME_SUCCESS, result);
     }
 
+    @Operation(
+            summary = "최근 공개 투두 2개 조회",
+            description = "특정 유저의 최근 공개 투두 2개를 반환합니다."
+    )
+    @GetMapping(value = "/{userId}/todos/public/recent", produces = "application/json")
+    public ApiResponse<List<FriendPublicTodoResponseDto>> getRecentPublicTodos(
+            @Parameter(hidden = true) @CurrentUser User loginUser,
+            @Parameter(name = "userId", description = "조회할 친구 ID", example = "1")
+            @PathVariable("userId") Long targetUserId
+    ) {
+        List<FriendPublicTodoResponseDto> result = friendService.getRecentPublicTodos(loginUser.getId(), targetUserId);
+        return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_PUBLIC_TODO_SUCCESS, result);
+    }
+
+    @Operation(
+            summary = "특정 날짜의 공개 투두 조회",
+            description = "특정 유저의 특정 날짜에 해당하는 모든 공개 투두를 반환합니다."
+    )
+    @GetMapping(value = "/{userId}/todos/public", produces = "application/json")
+    public ApiResponse<List<FriendPublicTodoResponseDto>> getDailyPublicTodos(
+            @Parameter(description = "조회할 유저 ID", example = "1")
+            @PathVariable("userId") Long userId,
+
+            @Parameter(description = "조회할 날짜 (YYYY-MM-DD)", example = "2024-07-12")
+            @RequestParam("date") String date
+    ) {
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
+            summary = "공개 투두가 있는 날짜(월별) 조회",
+            description = "특정 유저의 특정 월에 공개 투두가 존재하는 날짜 목록을 반환합니다."
+    )
+    @GetMapping(value = "/{userId}/todos/public/calendar", produces = "application/json")
+    public ApiResponse<List<String>> getTodoDatesOfMonth(
+            @Parameter(description = "조회할 유저 ID", required = true, example = "1")
+            @PathVariable("userId") Long userId,
+
+            @Parameter(description = "조회할 월 (YYYY-MM)", required = true, example = "2024-07")
+            @RequestParam("month") String month
+    ) {
+        return ApiResponse.onSuccess(null);
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -3,15 +3,13 @@ package umc.teumteum.server.domain.friend.converter;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import umc.teumteum.server.domain.friend.dto.FollowerUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FollowingUserResponseDto;
-import umc.teumteum.server.domain.friend.dto.FriendProfileResponseDto;
-import umc.teumteum.server.domain.friend.dto.FriendTeumTimeResponseDto;
+import umc.teumteum.server.domain.friend.dto.*;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,6 +78,18 @@ public class FriendConverter {
         int hours = (int) ((totalMinutes % (60 * 24)) / 60);
         int minutes = (int) (totalMinutes % 60);
         return new FriendTeumTimeResponseDto(days, hours, minutes, totalMinutes);
+    }
+
+    public List<FriendPublicTodoResponseDto> toFriendPublicTodoResponse(List<Schedule> schedules) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        return schedules.stream()
+                .map(s -> new FriendPublicTodoResponseDto(
+                        s.getTitle(),
+                        s.getStartTime().format(formatter),
+                        s.getEndTime().format(formatter)
+                ))
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/friend/dto/FriendPublicTodoResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/dto/FriendPublicTodoResponseDto.java
@@ -1,4 +1,4 @@
-package umc.teumteum.server.domain.user.dto;
+package umc.teumteum.server.domain.friend.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Schema(title = "PublicTodoResponseDto : 공개 투두 응답 DTO")
-public class PublicTodoResponseDto {
+public class FriendPublicTodoResponseDto {
 
     @Schema(description = "투두 제목", example = "string")
     private String title;

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
@@ -12,7 +12,7 @@ public enum FriendErrorStatus implements BaseErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4040", "존재하지 않는 유저입니다."),
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FRIEND4001", "이미 팔로우한 유저입니다."),
-    CANNOT_VIEW_SELF(HttpStatus.BAD_REQUEST, "FRIEND4002", "자기 자신의 프로필은 친구 프로필 API에서 조회할 수 없습니다."),
+    CANNOT_VIEW_SELF(HttpStatus.BAD_REQUEST, "FRIEND4002", "자기 자신은 조회할 수 없습니다."),
     CANNOT_FOLLOW_SELF(HttpStatus.CONFLICT, "FRIEND4090", "자기 자신은 팔로우할 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
@@ -13,7 +13,8 @@ public enum FriendSuccessStatus implements BaseCode {
     _UNFOLLOW_SUCCESS(HttpStatus.OK, "FRIEND2001", "언팔로우가 성공적으로 완료되었습니다."),
     _GET_FRIENDS_SUCCESS(HttpStatus.OK, "FRIEND2002", "친구 목록 조회에 성공하였습니다."),
     _FAVORITE_UPDATE_SUCCESS(HttpStatus.OK, "FRIEND2003", "즐겨찾기 설정이 완료되었습니다."),
-    GET_FRIEND_TEUM_TIME_SUCCESS(HttpStatus.OK, "FRIEND2004", "친구 빈틈 시간 조회에 성공하였습니다.");
+    GET_FRIEND_TEUM_TIME_SUCCESS(HttpStatus.OK, "FRIEND2004", "친구 빈틈 시간 조회에 성공하였습니다."),
+    GET_FRIEND_PUBLIC_TODO_SUCCESS(HttpStatus.OK, "FRIEND2005", "친구의 공개 투두 조회에 성공하였습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -22,4 +22,10 @@ public interface FriendService {
 
     FriendTeumTimeResponseDto getFriendTeumTime(Long loginUserId, Long targetUserId);
 
+    List<FriendPublicTodoResponseDto> getRecentPublicTodos(Long loginUserId, Long targetUserId);
+
+    List<FriendPublicTodoResponseDto> getDailyPublicTodos(Long userId, String date);
+
+    List<String> getTodoDatesOfMonth(Long userId, String month);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -15,7 +15,6 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.entity.User;
-import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
@@ -141,6 +140,41 @@ public class FriendServiceImpl implements FriendService {
         return friendConverter.toFriendTeumTimeResponse(totalMinutes);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<FriendPublicTodoResponseDto> getRecentPublicTodos(Long loginUserId, Long targetUserId) {
+        validateNotSelf(loginUserId, targetUserId);
+        validateUserExists(targetUserId);
+
+        List<Schedule> rawSchedules = scheduleRepository.findAllPublicByUserId(targetUserId);
+
+        List<Schedule> filtered = rawSchedules.stream()
+                .filter(s -> {
+                    if (s.getType() == ScheduleType.TEUM) {
+                        return s.getStatus() == ScheduleStatus.ACTIVE || s.getStatus() == ScheduleStatus.COMPLETED;
+                    } else {
+                        return s.getStatus() == ScheduleStatus.ACTIVE &&
+                                List.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI).contains(s.getType());
+                    }
+                })
+                .limit(2)
+                .collect(Collectors.toList());
+
+        return friendConverter.toFriendPublicTodoResponse(filtered);
+    }
+
+    @Override
+    public List<FriendPublicTodoResponseDto> getDailyPublicTodos(Long userId, String date) {
+        // TODO : 특정 날짜의 공개 투두 조회 로직 구현
+        return List.of();
+    }
+
+    @Override
+    public List<String> getTodoDatesOfMonth(Long userId, String month) {
+        // TODO : 공개 투두가 있는 날짜 조회 로직 구현
+        return List.of();
+    }
+
 
     /**
      * 주어진 ID에 해당하는 User를 조회합니다.
@@ -159,7 +193,7 @@ public class FriendServiceImpl implements FriendService {
      */
     private void validateUserExists(Long userId) {
         if (!userRepository.existsById(userId)) {
-            throw new GlobalHandler(UserErrorStatus.USER_NOT_FOUND);
+            throw new GlobalHandler(FriendErrorStatus.USER_NOT_FOUND);
         }
     }
 

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -167,4 +167,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s JOIN FETCH s.user WHERE s.date = :date")
     List<Schedule> findAllByDateWithUser(@Param("date") LocalDate today);
+
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.isPublic = true
+      AND s.isDeleted = false
+    ORDER BY s.createdAt DESC
+""")
+    List<Schedule> findAllPublicByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -37,49 +36,6 @@ public class UserController {
         List<UserSearchResponseDto> results = userService.searchUsersByKeyword(keyword, user.getId());
         return ApiResponse.of(UserSuccessStatus._USER_FOUND, results);
     }
-
-    @Operation(
-            summary = "최근 공개 투두 2개 조회",
-            description = "특정 유저의 최근 공개 투두 2개를 반환합니다."
-    )
-    @GetMapping(value = "/{userId}/todos/public/recent", produces = "application/json")
-    public ApiResponse<List<PublicTodoResponseDto>> getRecentPublicTodos(
-            @Parameter(description = "공개 투두를 조회할 유저 ID", example = "1")
-            @PathVariable("userId") Long userId
-    ) {
-        return ApiResponse.onSuccess(null);
-    }
-
-    @Operation(
-            summary = "특정 날짜의 공개 투두 조회",
-            description = "특정 유저의 특정 날짜에 해당하는 모든 공개 투두를 반환합니다."
-    )
-    @GetMapping(value = "/{userId}/todos/public", produces = "application/json")
-    public ApiResponse<List<PublicTodoResponseDto>> getDailyPublicTodos(
-            @Parameter(description = "조회할 유저 ID", example = "1")
-            @PathVariable("userId") Long userId,
-
-            @Parameter(description = "조회할 날짜 (YYYY-MM-DD)", example = "2024-07-12")
-            @RequestParam("date") String date
-    ) {
-        return ApiResponse.onSuccess(null);
-    }
-
-    @Operation(
-            summary = "공개 투두가 있는 날짜(월별) 조회",
-            description = "특정 유저의 특정 월에 공개 투두가 존재하는 날짜 목록을 반환합니다."
-    )
-    @GetMapping(value = "/{userId}/todos/public/calendar", produces = "application/json")
-    public ApiResponse<List<String>> getTodoDatesOfMonth(
-            @Parameter(description = "조회할 유저 ID", required = true, example = "1")
-            @PathVariable("userId") Long userId,
-
-            @Parameter(description = "조회할 월 (YYYY-MM)", required = true, example = "2024-07")
-            @RequestParam("month") String month
-    ) {
-        return ApiResponse.onSuccess(null);
-    }
-
 
     @Operation(
         summary = "마이페이지 정보 조회",

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -1,7 +1,6 @@
 package umc.teumteum.server.domain.user.service;
 
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
-import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -11,12 +10,6 @@ import java.util.Optional;
 
 public interface UserService {
     List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId);
-
-    List<PublicTodoResponseDto> getRecentPublicTodos(Long userId);
-
-    List<PublicTodoResponseDto> getDailyPublicTodos(Long userId, String date);
-
-    List<String> getTodoDatesOfMonth(Long userId, String month);
 
     User findOrCreateUser(OAuthUserInfo userInfo);
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.converter.UserConverter;
-import umc.teumteum.server.domain.user.dto.PublicTodoResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -40,25 +39,6 @@ public class UserServiceImpl implements UserService {
                 .limit(5)
                 .map(entry -> userConverter.toSearchResponseDto(entry.getKey()))
                 .toList();
-    }
-
-
-    @Override
-    public List<PublicTodoResponseDto> getRecentPublicTodos(Long userId) {
-        // TODO : 최근 공개 투두 2개 조회 로직 구현
-        return List.of();
-    }
-
-    @Override
-    public List<PublicTodoResponseDto> getDailyPublicTodos(Long userId, String date) {
-        // TODO : 특정 날짜의 공개 투두 조회 로직 구현
-        return List.of();
-    }
-
-    @Override
-    public List<String> getTodoDatesOfMonth(Long userId, String month) {
-        // TODO : 공개 투두가 있는 날짜 조회 로직 구현
-        return List.of();
     }
 
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#123 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 기존 user 도메인에 있던 공개 투두 관련 API를 friend 도메인으로 이동
- 친구의 최근 공개 투두 2개 조회 API 구현
  - 조건: `isPublic = true`, `isDeleted = false`
    - `TODO`/`WISH`/`AI` → `ACTIVE`
    - `TEUM` → `ACTIVE`, `COMPLETED`
  - 최신 등록순 기준 2개 제한
- 본인 요청일 경우 예외 처리 (`FRIEND4002`)
- 응답 코드 및 메시지 추가 (`FRIEND2005`)

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 현재는 endTime이 다음날 자정인 경우 `00:00`으로 표기되는데, 이를 `24:00`로 변환하는 함수가 별도 브랜치에 존재해서 해당 포맷 변환은 추후에 반영 예정

### 📷 테스트

#### 공개 투두 조회
```json
{
  "isSuccess": true,
  "code": "FRIEND2005",
  "message": "친구의 공개 투두 조회에 성공하였습니다.",
  "result": [
    {
      "title": "WISH - ACTIVE",
      "startTime": "10:00",
      "endTime": "11:30"
    },
    {
      "title": "TODO - ACTIVE",
      "startTime": "23:00",
      "endTime": "00:30"
    }
  ]
}
```
#### WISH의 is_public을 false로 바꿨을 때 제외됨
```json
{
  "isSuccess": true,
  "code": "FRIEND2005",
  "message": "친구의 공개 투두 조회에 성공하였습니다.",
  "result": [
    {
      "title": "TODO - ACTIVE",
      "startTime": "23:00",
      "endTime": "00:30"
    },
    {
      "title": "TEUM - ACTIVE",
      "startTime": "19:40",
      "endTime": "20:30"
    }
  ]
}
```

#### TEUM의 경우 COMPLETED도 조회
```json
{
  "isSuccess": true,
  "code": "FRIEND2005",
  "message": "친구의 공개 투두 조회에 성공하였습니다.",
  "result": [
    {
      "title": "TODO - ACTIVE",
      "startTime": "23:00",
      "endTime": "00:30"
    },
    {
      "title": "TEUM - COMPLETED",
      "startTime": "19:40",
      "endTime": "20:30"
    }
  ]
}
```
#### 존재하지 않는 유저
```json
{
  "isSuccess": false,
  "code": "FRIEND4040",
  "message": "존재하지 않는 유저입니다."
}
```
#### 본인 조회
```json
{
  "isSuccess": false,
  "code": "FRIEND4002",
  "message": "자기 자신은 조회할 수 없습니다."
}
```