### PR TITLE
Feat: 채움활동 위시리스트 불러오기 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
@@ -1,12 +1,22 @@
 package umc.teumteum.server.domain.home.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
+import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
+import umc.teumteum.server.domain.home.service.ActivityService;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
+import umc.teumteum.server.global.apiPayload.code.status.SuccessStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,15 +24,20 @@ import umc.teumteum.server.global.apiPayload.ApiResponse;
 @Tag(name="Activity", description = "채움 활동 관련 API")
 public class ActivityController {
 
+  private final ActivityService activityServiceImpl;
+
   @Operation(
       summary = "채움활동 위시리스트 조회",
       description = "채움활동에서 사용자가 입력한 조건들을 만족하는 '내가 등록한 위시'들을 조회합니다."
   )
   @PostMapping(value = "/user-wishes", produces = "application/json")
-  public ApiResponse<Object> getMyWish(
+  public ApiResponse<ActivityResponseDto.WishResponse> getMyWish(
+      @Valid @RequestBody ActivityRequestDto.OptionRequest request,
+      @CurrentUser @Parameter(hidden = true) User user
   ) {
     // TODO: 채움활동에서 사용자의 조건을 만족하는 "내가 등록한 위시" 조회 로직 구현
-    return null;
+    ActivityResponseDto.WishResponse response = activityServiceImpl.getMyWish(user, request);
+    return ApiResponse.of(HomeSuccessStatus._ACTIVITY_LOADED, response);
 
   }
 

--- a/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.converter;
 
 import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
 import umc.teumteum.server.domain.home.dto.response.CategoryResponseDto;
 import umc.teumteum.server.domain.home.dto.response.WishInfoResponseDto;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDto;
@@ -83,5 +84,19 @@ public class WishConverter {
                         .categoryName(category.getName())
                         .build())
                 .toList();
+    }
+
+    public ActivityResponseDto.WishDto toActivityWishDto(Wish wish) {
+        return ActivityResponseDto.WishDto.builder()
+            .id(wish.getId())
+            .content(wish.getContent())
+            .estimatedDuration(wish.getEstimatedDuration())
+            .build();
+    }
+
+    public List<ActivityResponseDto.WishDto> toActivityWishDtoList(List<Wish> wishes) {
+        return wishes.stream()
+            .map(this::toActivityWishDto)
+            .toList();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
@@ -1,0 +1,33 @@
+package umc.teumteum.server.domain.home.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+
+public class ActivityRequestDto {
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class OptionRequest {
+
+    @NotNull
+    @Schema(description = "예상 소요 시간", example = "10m")
+    private EstimatedDuration estimatedDuration;
+
+    @Schema(description = "활동 카테고리", example = "1")
+    private Long categoryId;
+
+    @Schema(description = "사용자가 직접 입력한 카테고리", example = "명상")
+    private String customCategory;
+
+  }
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/ActivityResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/ActivityResponseDto.java
@@ -1,0 +1,43 @@
+package umc.teumteum.server.domain.home.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+
+public class ActivityResponseDto {
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "위시 추천 응답")
+  public static class WishResponse {
+
+    @Schema(description = "추천된 위시 목록")
+    private List<WishDto> wishes;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "추천된 위시 정보")
+  public static class WishDto {
+
+    @Schema(description = "Wish ID", example = "1")
+    private Long id;
+
+    @Schema(description = "위시 상세 설명", example = "성북천 산책하기")
+    private String content;
+
+    @Schema(description = "예상 소요 시간", example = "TEN_MINUTES")
+    private EstimatedDuration estimatedDuration;
+
+  }
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -13,6 +13,8 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _INVALID_DURATION(HttpStatus.BAD_REQUEST,"HOME4002","잘못된 조회 기간입니다."),
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
+    _CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "HOME4003", "카테고리는 필수 항목입니다."),
+    _CATEGORY_INPUT_CONFLICT(HttpStatus.BAD_REQUEST, "HOME4004", "카테고리와 직접 입력은 둘 중 하나만 선택해야 합니다."),
     _WISH_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4043","해당 위시 정보를 찾을 수 없습니다."),
     _SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "HOME4092","해당 시간에 스케줄이 존재합니다.")
     ;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -23,7 +23,10 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODAY_SCHEDULE(HttpStatus.OK, "HOME20010", "오늘의 스케줄이 성공적으로 조회되었습니다."),
     _WISH_ASSIGNED(HttpStatus.OK, "HOME20011","선택된 위시가 투두로 등록되었습니다."),
     _CATEGORY_LOADED(HttpStatus.OK, "HOME20012","카테고리 정보가 조회되었습니다."),
-    _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다.")
+    _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다."),
+
+
+    _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -24,7 +24,7 @@ public enum HomeSuccessStatus implements BaseCode {
     _WISH_ASSIGNED(HttpStatus.OK, "HOME20011","선택된 위시가 투두로 등록되었습니다."),
     _CATEGORY_LOADED(HttpStatus.OK, "HOME20012","카테고리 정보가 조회되었습니다."),
     _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다."),
-    _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다.")
+    _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다."),
     _CALENDAR_LOADED(HttpStatus.OK,"HOME20014","캘린더 정보가 성공적으로 조회되었습니다.")
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishCategoryRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishCategoryRepository.java
@@ -1,4 +1,7 @@
 package umc.teumteum.server.domain.home.repository;
 
-public interface WishCategoryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
+
+public interface WishCategoryRepository extends JpaRepository<WishCategory, Long> {
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.home.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.user.entity.User;
@@ -19,4 +20,22 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 
     Slice<Wish> findAllByUser(User user, Pageable pageable);
     Slice<Wish> findAllByUserAndEstimatedDuration(User user, EstimatedDuration estimatedDuration, Pageable pageable);
+
+    // 시간 + 카테고리 이름 일치
+    @Query("SELECT w FROM Wish w " +
+        "JOIN w.wishCategories wc " +
+        "JOIN wc.category c " +
+        "WHERE w.user = :user AND w.estimatedDuration = :duration AND LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
+    List<Wish> findByUserAndDurationAndWishCategoriesLike(User user, EstimatedDuration duration, String categoryName);
+
+    // 시간만 일치
+    List<Wish> findByUserAndEstimatedDuration(User user, EstimatedDuration duration);
+
+    // 카테고리 이름만 일치
+    @Query("SELECT w FROM Wish w " +
+        "JOIN w.wishCategories wc " +
+        "JOIN wc.category c " +
+        "WHERE w.user = :user AND LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
+    List<Wish> findByUserAndCategoryLike(User user, String categoryName);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
@@ -1,0 +1,10 @@
+package umc.teumteum.server.domain.home.service;
+
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
+import umc.teumteum.server.domain.user.entity.User;
+
+public interface ActivityService {
+
+  WishResponse getMyWish(User user, OptionRequest request);
+}

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -1,0 +1,95 @@
+package umc.teumteum.server.domain.home.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.home.converter.WishConverter;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
+import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
+import umc.teumteum.server.domain.home.exception.HomeException;
+import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
+import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
+import umc.teumteum.server.domain.home.repository.WishRepository;
+import umc.teumteum.server.domain.user.entity.User;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityServiceImpl implements ActivityService{
+
+  private final WishRepository wishRepository;
+  private final WishCategoryRepository wishCategoryRepository;
+  private final WishConverter wishConverter;
+
+  @Override
+  public WishResponse getMyWish(User user, OptionRequest request) {
+    EstimatedDuration duration = request.getEstimatedDuration();
+    String categoryName = extractCategoryName(request);
+
+    // 1. 시간과 카테고리가 모두 일치하는 경우 (우선순위1)
+    List<Wish> priority1 = wishRepository.findByUserAndDurationAndWishCategoriesLike(user, duration, categoryName);
+
+    // 2. 시간만 OR 카테고리만 일치하는 경우 (우선순위2)
+    Set<Wish> priority2Set = new HashSet<>();
+
+    List<Wish> durationOnlyList = wishRepository.findByUserAndEstimatedDuration(user, duration);
+    priority2Set.addAll(durationOnlyList);
+
+    List<Wish> categoryOnlyList = wishRepository.findByUserAndCategoryLike(user, categoryName);
+    priority2Set.addAll(categoryOnlyList);
+
+    // 시간 + 카테고리 둘다 만족한 것 제외 (1번에서 구했으니까)
+    priority2Set.removeAll(priority1);
+
+    // 3. 위시 최종 선택
+    List<Wish> result = new ArrayList<>();
+    // 먼저 우선순위 1인 리스트 중에서 랜덤으로 추출
+    result.addAll(randomPick(priority1, Math.min(3, priority1.size())));
+
+    // 우선순위 1인 리스트에 있는 위시가 3개 이하라면, 2순위 리스트에 있는 위시틑 랜덤 추출
+    int remaining = 3 - result.size();
+    if (remaining > 0) {
+      result.addAll(randomPick(new ArrayList<>(priority2Set), remaining));
+    }
+
+    return ActivityResponseDto.WishResponse.builder()
+        .wishes(wishConverter.toActivityWishDtoList(result))
+        .build();
+
+  }
+  private String extractCategoryName(OptionRequest request) {
+    boolean hasCustomCategory = request.getCustomCategory() != null && !request.getCustomCategory().isBlank();
+    boolean hasCategoryId = request.getCategoryId() != null;
+
+    // 1. 카테고리를 두개 입력한 경우 예외
+    if (hasCustomCategory && hasCategoryId) {
+      throw new HomeException(HomeErrorStatus._CATEGORY_INPUT_CONFLICT);
+    }
+    // 2. CustomCategory를 입력한 경우 반환
+    if (hasCustomCategory) {
+      return request.getCustomCategory();
+    }
+    // 3. 선택한 카테고리 Id가 존재하면 DB에서 name 조회 후 반환
+    if (hasCategoryId) {
+      WishCategory category = wishCategoryRepository.findById(request.getCategoryId())
+          .orElseThrow(() -> new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND));
+      return category.getCategory().getName();
+    }
+    // 4. 카테고리가 아예 없으면 예외
+    throw new HomeException(HomeErrorStatus._CATEGORY_REQUIRED);
+  }
+
+  private List<Wish> randomPick(List<Wish> list, int count) {
+    if (list == null || list.isEmpty()) return Collections.emptyList();
+    Collections.shuffle(list);
+    return list.stream().limit(count).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -12,11 +12,13 @@ import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
+import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 import umc.teumteum.server.domain.home.exception.HomeException;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
+import umc.teumteum.server.domain.home.repository.CategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.user.entity.User;
@@ -28,6 +30,7 @@ public class ActivityServiceImpl implements ActivityService{
   private final WishRepository wishRepository;
   private final WishCategoryRepository wishCategoryRepository;
   private final WishConverter wishConverter;
+  private final CategoryRepository categoryRepository;
 
   @Override
   public WishResponse getMyWish(User user, OptionRequest request) {
@@ -36,15 +39,21 @@ public class ActivityServiceImpl implements ActivityService{
 
     // 1. 시간과 카테고리가 모두 일치하는 경우 (우선순위1)
     List<Wish> priority1 = wishRepository.findByUserAndDurationAndWishCategoriesLike(user, duration, categoryName);
+    System.out.println("🔍 priority1:");
+    priority1.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     // 2. 시간만 OR 카테고리만 일치하는 경우 (우선순위2)
     Set<Wish> priority2Set = new HashSet<>();
 
     List<Wish> durationOnlyList = wishRepository.findByUserAndEstimatedDuration(user, duration);
     priority2Set.addAll(durationOnlyList);
+    System.out.println("🔍 durationOnlyList:");
+    durationOnlyList.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     List<Wish> categoryOnlyList = wishRepository.findByUserAndCategoryLike(user, categoryName);
     priority2Set.addAll(categoryOnlyList);
+    System.out.println("🔍 categoryOnlyList:");
+    categoryOnlyList.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     // 시간 + 카테고리 둘다 만족한 것 제외 (1번에서 구했으니까)
     priority2Set.removeAll(priority1);
@@ -79,9 +88,9 @@ public class ActivityServiceImpl implements ActivityService{
     }
     // 3. 선택한 카테고리 Id가 존재하면 DB에서 name 조회 후 반환
     if (hasCategoryId) {
-      WishCategory category = wishCategoryRepository.findById(request.getCategoryId())
+      Category category = categoryRepository.findById(request.getCategoryId())
           .orElseThrow(() -> new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND));
-      return category.getCategory().getName();
+      return category.getName();
     }
     // 4. 카테고리가 아예 없으면 예외
     throw new HomeException(HomeErrorStatus._CATEGORY_REQUIRED);

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -39,21 +39,15 @@ public class ActivityServiceImpl implements ActivityService{
 
     // 1. 시간과 카테고리가 모두 일치하는 경우 (우선순위1)
     List<Wish> priority1 = wishRepository.findByUserAndDurationAndWishCategoriesLike(user, duration, categoryName);
-    System.out.println("🔍 priority1:");
-    priority1.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     // 2. 시간만 OR 카테고리만 일치하는 경우 (우선순위2)
     Set<Wish> priority2Set = new HashSet<>();
 
     List<Wish> durationOnlyList = wishRepository.findByUserAndEstimatedDuration(user, duration);
     priority2Set.addAll(durationOnlyList);
-    System.out.println("🔍 durationOnlyList:");
-    durationOnlyList.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     List<Wish> categoryOnlyList = wishRepository.findByUserAndCategoryLike(user, categoryName);
     priority2Set.addAll(categoryOnlyList);
-    System.out.println("🔍 categoryOnlyList:");
-    categoryOnlyList.forEach(w -> System.out.println(" - " + w.getId() + ": " + w.getEstimatedDuration()));
 
     // 시간 + 카테고리 둘다 만족한 것 제외 (1번에서 구했으니까)
     priority2Set.removeAll(priority1);

--- a/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/OnboardingRequestDto.java
@@ -135,7 +135,7 @@ public class OnboardingRequestDto {
 
         @NotNull(message = "요일은 필수 입력입니다")
         @Schema(description = "반복 요일", example = "WEDNESDAY",
-                allowableValues = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"})
+            allowableValues = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"})
         private Weekday weekday;
 
         @NotNull(message = "시작 시간은 필수 입력입니다")

--- a/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
@@ -1,0 +1,181 @@
+package umc.teumteum.server.unit.home.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.home.converter.WishConverter;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
+import umc.teumteum.server.domain.home.entity.Category;
+import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+import umc.teumteum.server.domain.home.exception.HomeException;
+import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
+import umc.teumteum.server.domain.home.repository.CategoryRepository;
+import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
+import umc.teumteum.server.domain.home.repository.WishRepository;
+import umc.teumteum.server.domain.home.service.ActivityServiceImpl;
+import umc.teumteum.server.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityServiceTest {
+
+  @Mock
+  private WishRepository wishRepository;
+  @Mock private WishCategoryRepository wishCategoryRepository;
+  @Mock private CategoryRepository categoryRepository;
+  @Mock private WishConverter wishConverter;
+
+  @InjectMocks
+  private ActivityServiceImpl activityService;
+
+  @Mock private User mockUser;
+
+  private List<Wish> dummyWishes;
+
+  @BeforeEach
+  void setup() {
+    dummyWishes = new ArrayList<>();
+    for (long i = 1; i <= 5; i++) {
+      Wish wish = Wish.builder()
+          .id(i)
+          .content("Wish " + i)
+          .estimatedDuration(EstimatedDuration.MINUTES_10)
+          .build();
+      dummyWishes.add(wish);
+    }
+  }
+
+  @Test
+  @DisplayName("[ActivityServiceImpl] - TC1 시간과 카테고리가 모두 일치하는 경우 priority1에서 최대 3개 반환")
+  void getMyWish_priority1_max3() {
+    // given
+    OptionRequest request = OptionRequest.builder()
+        .estimatedDuration(EstimatedDuration.MINUTES_10)
+        .categoryId(1L)
+        .build();
+
+    Category category = Category.builder()
+        .id(1L)
+        .name("운동")
+        .build();
+
+    when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+    when(wishRepository.findByUserAndDurationAndWishCategoriesLike(mockUser, EstimatedDuration.MINUTES_10, "운동"))
+        .thenReturn(dummyWishes); // 5개
+
+    when(wishConverter.toActivityWishDtoList(any())).thenReturn(Collections.emptyList());
+
+    // when
+    WishResponse response = activityService.getMyWish(mockUser, request);
+
+    // then
+    assertThat(response).isNotNull();
+    verify(wishRepository, times(1)).findByUserAndDurationAndWishCategoriesLike(eq(mockUser), any(), eq("운동"));
+  }
+
+  @Test
+  @DisplayName("[ActivityServiceImpl] - TC2 우선순위1은 없고, 우선순위2(카테고리, 시간 일치)에서 추천되는 경우")
+  void getMyWish_priority2_used() {
+    // given
+    OptionRequest request = OptionRequest.builder()
+        .estimatedDuration(EstimatedDuration.MINUTES_10)
+        .customCategory("휴식")
+        .build();
+
+    when(wishRepository.findByUserAndDurationAndWishCategoriesLike(mockUser, EstimatedDuration.MINUTES_10, "휴식"))
+        .thenReturn(List.of()); // priority1 비어있음
+    when(wishRepository.findByUserAndEstimatedDuration(mockUser, EstimatedDuration.MINUTES_10))
+        .thenReturn(List.of(dummyWishes.get(0), dummyWishes.get(1))); // 시간만 일치
+    when(wishRepository.findByUserAndCategoryLike(mockUser, "휴식"))
+        .thenReturn(List.of(dummyWishes.get(2))); // 카테고리만 일치
+    when(wishConverter.toActivityWishDtoList(any())).thenReturn(Collections.emptyList());
+
+    // when
+    WishResponse response = activityService.getMyWish(mockUser, request);
+
+    // then
+    assertThat(response).isNotNull();
+    verify(wishRepository).findByUserAndEstimatedDuration(eq(mockUser), any());
+    verify(wishRepository).findByUserAndCategoryLike(eq(mockUser), eq("휴식"));
+  }
+
+  @Test
+  @DisplayName("[ActivityServiceImpl] - TC3 customCategory와 categoryId가 동시에 존재하면 예외 발생")
+  void getMyWish_bothCategoryFields_throwsException() {
+    // given
+    OptionRequest request = OptionRequest.builder()
+        .estimatedDuration(EstimatedDuration.MINUTES_10)
+        .categoryId(1L)
+        .customCategory("운동")
+        .build();
+
+    // when
+    HomeException ex = (HomeException) catchThrowable(() -> activityService.getMyWish(mockUser, request));
+
+    // then
+    assertThat(ex).isInstanceOf(HomeException.class);
+    assertThat(ex.getErrorReason().getCode()).isEqualTo(HomeErrorStatus._CATEGORY_INPUT_CONFLICT.getCode());
+    assertThat(ex.getErrorReason().getMessage()).isEqualTo(HomeErrorStatus._CATEGORY_INPUT_CONFLICT.getMessage());
+  }
+
+
+  @Test
+  @DisplayName("[ActivityServiceImpl] - TC4 categoryId로 조회했지만 존재하지 않으면 예외 발생")
+  void getMyWish_categoryId_notFound() {
+    // given
+    OptionRequest request = OptionRequest.builder()
+        .estimatedDuration(EstimatedDuration.MINUTES_10)
+        .categoryId(99L)
+        .build();
+
+    when(categoryRepository.findById(99L)).thenReturn(Optional.empty());
+
+    // when
+    HomeException ex = (HomeException) catchThrowable(() -> activityService.getMyWish(mockUser, request));
+
+
+    // then
+    assertThat(ex).isInstanceOf(HomeException.class);
+    assertThat(ex.getErrorReason().getCode()).isEqualTo(HomeErrorStatus._CATEGORY_NOT_FOUND.getCode());
+    assertThat(ex.getErrorReason().getMessage()).isEqualTo(HomeErrorStatus._CATEGORY_NOT_FOUND.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("[ActivityServiceImpl] - TC5 category, duration 둘 다 비어있을 경우 예외 발생")
+  void getMyWish_noCategory_throwsException() {
+    // given
+    OptionRequest request = OptionRequest.builder()
+        .estimatedDuration(EstimatedDuration.MINUTES_10)
+        .build(); // categoryId도 없고 custom도 없음
+
+    // when
+    HomeException ex = (HomeException) catchThrowable(() -> activityService.getMyWish(mockUser, request));
+
+
+    // then
+    assertThat(ex).isInstanceOf(HomeException.class);
+    assertThat(ex.getErrorReason().getCode()).isEqualTo(HomeErrorStatus._CATEGORY_REQUIRED.getCode());
+    assertThat(ex.getErrorReason().getMessage()).isEqualTo(HomeErrorStatus._CATEGORY_REQUIRED.getMessage());
+
+
+  }
+}
+


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#102 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
1. 채움활동 위시리스트 불러오기 API 를 구현하였습니다. (ActivityServiceImpl 작성)
<img width="313" height="625" alt="스크린샷 2025-07-31 오후 1 56 24" src="https://github.com/user-attachments/assets/d074f6d5-6319-455d-add5-7a684bd5b211" />
<img width="321" height="364" alt="스크린샷 2025-07-31 오후 1 55 09" src="https://github.com/user-attachments/assets/e9d1cf97-dfb1-4990-afb0-ba10082ecf4f" />

2. 현재 위시 조회 시, 사용자는 기존 카테고리 중 하나를 선택하거나 “기타” 항목에 자유롭게 입력할 수 있습니다.
이를 고려하여 RequestDto에서는 두 가지 입력 방식을 다음과 같이 분리해 처리합니다:


```
    @NotNull
    @Schema(description = "예상 소요 시간", example = "10m")
    private EstimatedDuration estimatedDuration;

    @Schema(description = "활동 카테고리", example = "1")
    private Long categoryId;

    @Schema(description = "사용자가 직접 입력한 카테고리", example = "명상")
    private String customCategory;
```

- categoryId: 기존 카테고리를 선택한 경우 사용
- customCategory: "기타" 항목에 사용자가 직접 입력한 경우 사용

3. 위시를 조회할때는 위치는 조건 대상이 아닙니다. 시간과 카테고리를 기준으로 검색됩니다!
우선순위 1 -> 시간과 카테고리를 모두 만족하는 경우
우선순위 2 -> 시간 또는 카테고리 하나만 만족하는 경우 
를 기준으로 3개의 랜덤 위시를 조회하도록 로직을 설계하였습니다.


### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
빠진 예외처리가 있는지 확인 부탁드립니다!
현재 코드에서 의도한 예외 처리 흐름은 아래와 같습니다.

**예상 소요 시간 미입력 시**
→ @Validated를 통한 Controller 단의 입력값 검증으로 처리

**categoryId와 customCategory를 동시에 입력한 경우**
→ CATEGORY_INPUT_CONFLICT 예외 발생
(카테고리는 하나만 입력 가능해야 함)

**잘못된 categoryId 입력 시**
→ CATEGORY_NOT_FOUND 예외 발생
(DB에 존재하지 않는 카테고리 ID)

**categoryId와 customCategory 모두 비워둔 경우**
→ CATEGORY_REQUIRED 예외 발생
(카테고리는 필수 항목)



### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
참고로 위시리스트 조회 API인데 조건이 많아서 POST로 설계습니다.
REST 원칙상 GET이 맞을것 같은데 body로 조건을 받으려다 보니 POST로 했어요....
이 경우에 어떻게 하면 좋을지 의견 부탁드립니다!

### 📷 스크린샷 또는 GIF
테스트 코드를 간단하게 작성하여 로직이 제가 의도한대로 흘러가는지 검증하였습니다.
그것 외에도 스웨거 테스트를 이용해 응답 데이터 값을 확인하였습니다.
성공 응답의 경우 노션에 업뎃 해두었습니다!

| 입력값 | 스크린샷 |
| :--: | :------: |
|  <img width="429" height="126" alt="스크린샷 2025-07-31 오후 1 25 39" src="https://github.com/user-attachments/assets/aa63e007-35f3-4854-b9f0-4bc932a1e475" /> 존재하지 않는 카테고리 Id | <img width="506" height="104" alt="스크린샷 2025-07-31 오후 1 25 35" src="https://github.com/user-attachments/assets/e2da13ad-6b29-4962-a607-3f8f85c54ca8" /> |
|  <img width="554" height="115" alt="스크린샷 2025-07-31 오후 1 25 04" src="https://github.com/user-attachments/assets/6771f545-5111-4425-80b2-ea5f05c4d662" />카테고리를 2개 입력했을 경우 | <img width="636" height="102" alt="스크린샷 2025-07-31 오후 1 25 00" src="https://github.com/user-attachments/assets/ef07e979-f1bf-4398-82a9-5305c42d94c0" /> |
|  <img width="513" height="143" alt="스크린샷 2025-07-31 오후 1 24 38" src="https://github.com/user-attachments/assets/15c34abd-dbf7-4f65-979a-80c8e9f87776" />카테고리를 둘다 입력하지 않았을 경우 | <img width="451" height="107" alt="스크린샷 2025-07-31 오후 1 24 43" src="https://github.com/user-attachments/assets/a1048938-36b2-4356-8573-d6b4a4645456" />|
|  <img width="547" height="111" alt="스크린샷 2025-07-31 오후 1 26 07" src="https://github.com/user-attachments/assets/efd95308-fcab-40a3-9dc2-0e63e2f0e40c" /> 시간을 입력하지 않았을 경우 | <img width="471" height="163" alt="스크린샷 2025-07-31 오후 1 26 12" src="https://github.com/user-attachments/assets/40026213-c381-490d-9dbb-d74e9f18ec18" /> |






