### PR TITLE
Feat: 캘린더 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
@@ -47,10 +47,12 @@ public class HomeController {
 
     @GetMapping(value = "/calendar", produces = "application/json")
     @Operation(summary = "캘린더 조회 API",description = "오늘의 빈틈 시간을 조회하는 API입니다. query string으로 시작날짜와 종료날찌를 입력주세요.")
-    public ApiResponse<String> getCalendar(
+    public ApiResponse<List<HomeResponseDto.CalendarDto>> getCalendar(
             @Parameter(name= "startDate", description = "시작날짜", example = "2025-07-01") @RequestParam("startDate") LocalDate startDate,
-            @Parameter(name= "endDate", description = "종료날짜", example = "2025-07-31") @RequestParam("endDate") LocalDate endDate){
-        return ApiResponse.onSuccess(null);
+            @Parameter(name= "endDate", description = "종료날짜", example = "2025-07-31") @RequestParam("endDate") LocalDate endDate,
+            @CurrentUser @Parameter(hidden = true) User user){
+        List<HomeResponseDto.CalendarDto> response = homeService.getCalendar(startDate,endDate,user);
+        return ApiResponse.of(HomeSuccessStatus._CALENDAR_LOADED,response);
     }
 
     @GetMapping(value = "/todolist", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -12,7 +12,10 @@ import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.user.entity.User;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
@@ -99,4 +102,19 @@ public class ScheduleConverter {
 
 
     }
+
+    // Schedule -> HomeResponseDto.CalendarDto
+    public List<HomeResponseDto.CalendarDto> toCalendarDto(Map<LocalDate, Boolean> calendarMap, LocalDate startDate, LocalDate endDate) {
+        List<HomeResponseDto.CalendarDto> result = new ArrayList<>();
+
+        for(LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)){
+            result.add(HomeResponseDto.CalendarDto.builder()
+                    .date(date)
+                    .hasSchedule(calendarMap.getOrDefault(date,false))
+                    .build());
+        }
+
+        return result;
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 public class HomeResponseDto {
 
   @Getter
@@ -20,6 +22,18 @@ public class HomeResponseDto {
     private Integer hours;
     @Schema(description = "분(minutes) 단위", example = "30")
     private Integer minutes;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class CalendarDto{
+
+    @Schema(description = "날짜", example = "2025-07-31")
+    private LocalDate date;
+
+    @Schema(description = "스케줄 여부", example = "true")
+    private Boolean hasSchedule;
   }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -23,7 +23,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODAY_SCHEDULE(HttpStatus.OK, "HOME20010", "오늘의 스케줄이 성공적으로 조회되었습니다."),
     _WISH_ASSIGNED(HttpStatus.OK, "HOME20011","선택된 위시가 투두로 등록되었습니다."),
     _CATEGORY_LOADED(HttpStatus.OK, "HOME20012","카테고리 정보가 조회되었습니다."),
-    _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다.")
+    _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다."),
+    _CALENDAR_LOADED(HttpStatus.OK,"HOME20014","캘린더 정보가 성공적으로 조회되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -167,4 +167,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s JOIN FETCH s.user WHERE s.date = :date")
     List<Schedule> findAllByDateWithUser(@Param("date") LocalDate today);
+
+    @Query("SELECT s FROM Schedule s WHERE s.user = :user AND s.date BETWEEN :startDate AND :endDate")
+    List<Schedule> findByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -1,6 +1,5 @@
 package umc.teumteum.server.domain.home.service;
 
-import java.time.Duration;
 import umc.teumteum.server.domain.home.dto.request.TodoRequestDto;
 import umc.teumteum.server.domain.home.dto.request.WishAssignRequestDto;
 import umc.teumteum.server.domain.home.dto.request.WishDeleteRequestDto;
@@ -50,4 +49,7 @@ public interface HomeService {
 
     // 빈틈 시간 조회
     HomeResponseDto.TeumTimeDto getTeaumTime(User user);
+
+    // 캘린더 스케줄 여부 조회
+    List<HomeResponseDto.CalendarDto> getCalendar(LocalDate startDate, LocalDate endDate,User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -458,12 +458,16 @@ public class HomeServiceImpl implements HomeService {
             // 4-2. 반복 일정 조회
             List<Routine> routines = routineRepository.findByUser(user);
 
-            // 4-3. 내일부터 endDate까지 날짜 순회
-            for(LocalDate date = today.plusDays(1); !date.isAfter(endDate); date = date.plusDays(1)) {
+            // 4-3. startDate부터 endDate까지 날짜 순회
+            for(LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                // 과거일 경우는 스킵
+                if(date.isBefore(today)) continue;
+
+                // 검증 날짜의 요일
                 Weekday weekday = Weekday.from(date.getDayOfWeek());
 
                 for(Routine routine : routines) {
-                    // 루틴의 요일과 해당 날짜의 요일이 일치하는 경우만 처리
+                    // 루틴의 요일과 검증 날짜의 요일이 일치하는 경우만 처리
                     if(!routine.getWeekday().equals(weekday)) {
                         continue;
                     }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -29,7 +29,10 @@ import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
@@ -39,6 +42,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +57,7 @@ public class HomeServiceImpl implements HomeService {
     private final WishRepository wishRepository;
     private final CategoryRepository categoryRepository;
     private final S3Util s3Util;
+    private final RoutineRepository routineRepository;
 
     @Transactional
     @Override
@@ -415,5 +420,64 @@ public class HomeServiceImpl implements HomeService {
 
     }
 
+    @Override
+    public List<HomeResponseDto.CalendarDto> getCalendar(LocalDate startDate, LocalDate endDate, User user) {
+        // 캘린더 조회
 
+        // 1. 오늘 날짜 조회 & 날짜별 일정 여부 담을 맵 초기화
+        LocalDate today = LocalDate.now();
+        Map<LocalDate, Boolean> calendarMap = new HashMap<>();
+
+        // 2. Schedule 테이블 조회
+        List<Schedule> schedules = scheduleRepository.findByUserAndDateBetween(user,startDate,endDate);
+
+        // 3. Schedule 기준 true 표시
+        for (Schedule schedule : schedules) {
+            LocalDate date = schedule.getDate();
+            // 3-1. 삭제된 루틴 ->  표시 X
+            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+            // 3-2. 일정 등록
+            calendarMap.put(date, true);
+        }
+
+
+        // 4. 미래의 경우 반복일정 검증
+        if(endDate.isAfter(today)){
+
+            // 4-1. 스케줄에서 삭제된 날짜의 루틴ID만 모아둠
+            Map<LocalDate, Set<Long>> deletedRoutine = schedules.stream()
+                    .filter(s -> s.getRoutine() != null && s.getIsDeleted())
+                    .collect(Collectors.groupingBy(
+                            Schedule::getDate,
+                            Collectors.mapping(
+                                    s -> s.getRoutine().getId(),
+                                    Collectors.toSet()
+                            )
+                    ));
+
+            // 4-2. 반복 일정 조회
+            List<Routine> routines = routineRepository.findByUser(user);
+
+            // 4-3. 내일부터 endDate까지 날짜 순회
+            for(LocalDate date = today.plusDays(1); !date.isAfter(endDate); date = date.plusDays(1)) {
+                Weekday weekday = Weekday.from(date.getDayOfWeek());
+
+                for(Routine routine : routines) {
+                    // 루틴의 요일과 해당 날짜의 요일이 일치하는 경우만 처리
+                    if(!routine.getWeekday().equals(weekday)) {
+                        continue;
+                    }
+
+                    // 삭제되지 않은 루틴만 true로
+                    Long routineId = routine.getId();
+                    boolean isDeleted = deletedRoutine.getOrDefault(date,Set.of()).contains(routineId);
+                    if(!isDeleted){
+                        calendarMap.put(date, true);
+                    }
+                }
+            }
+
+        }
+        return scheduleConverter.toCalendarDto(calendarMap,startDate,endDate);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -16,4 +16,7 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     @Modifying
     @Query("delete from Routine r where r.user = :user")
     void deleteByUser(@Param("user") User user);
+
+    @Query("SELECT r FROM Routine r WHERE r.user = :user")
+    List<Routine> findByUser(@Param("user") User user);
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#104 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
사용자가 요청한 기간(startDate ~ endDate)에 대해 해당 날짜에 스케줄이 존재하는지 여부를 반환하는 캘린더 API 구현했습니다.

기본적으로 스케줄 테이블에서 조죄하고 일정이 존재하며 삭제된 루틴이 아닐경우 해당 날짜를 `hasSchedule : true`로 표시합니다. 추가로 endDate가 오늘 날짜 이후인 경우, 사용자의 반복일정을 조회하고 각 날짜를 순회하며 반복요일이며 스케줄 테이블에 삭제된 일정이 아니라면 해당 날짜도 `hasSchedule : true`로 간주합니다.

true로 표시되는 경우
1. 스케줄 테이블에 해당 날짜의 일정이 존재하는 경우
2. 루틴 테이블에서 해당 날짜가 반복 요일에 해당하고, 스케줄 테이블에 삭제된 이력이 없는 경우

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
`/api/home/calendar`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
```json
{
  "isSuccess": true,
  "code": "HOME20014",
  "message": "캘린더 정보가 성공적으로 조회되었습니다.",
  "result": [
    {
      "date": "2025-07-27",
      "hasSchedule": false
    },
    {
      "date": "2025-07-28",
      "hasSchedule": true
    },
    {
      "date": "2025-07-29",
      "hasSchedule": true
    },
    {
      "date": "2025-07-30",
      "hasSchedule": false
    },
    {
      "date": "2025-07-31",
      "hasSchedule": true
    },
    {
      "date": "2025-08-01",
      "hasSchedule": false
    },
    {
      "date": "2025-08-02",
      "hasSchedule": false
    }
  ]
}
```