### PR TITLE
Feat: 틈 요청 날짜 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -56,15 +56,15 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     WHERE s.user.id = :userId
       AND s.type = 'TEUM'
       AND s.status IN (:statuses)
-      AND FUNCTION('DATE_FORMAT', s.date, '%Y-%m') = :yearMonth
+      AND s.date BETWEEN :start AND :end
       AND s.isDeleted = false
 """)
-    List<LocalDate> findScheduledTeumsByMonth(
+    List<LocalDate> findScheduledTeumsByDates(
             @Param("userId") Long userId,
             @Param("statuses") List<ScheduleStatus> statuses,
-            @Param("yearMonth") String yearMonth
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
     );
-
 
     @Query("""
     SELECT s FROM Schedule s

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -113,9 +113,11 @@ public class TeumController {
     @GetMapping(value = "/requests/calendar", produces = "application/json")
     public ApiResponse<List<String>> getTeumRequestsOfMonth(
             @Parameter(description = "조회할 연월 (YYYY-MM)", example = "2025-05")
-            @RequestParam("month") String month
+            @RequestParam("month") String month,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-        return ApiResponse.onSuccess(null);
+        List<String> dates = teumService.getTeumRequestsOfMonth(user.getId(), month);
+        return ApiResponse.of(TeumSuccessStatus._TEUM_CALENDAR_LOADED, dates);
     }
 
     @Operation(

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
@@ -15,7 +15,7 @@ public enum TeumSuccessStatus implements BaseCode {
     _TEUM_RECEIVED_LIST_LOADED(HttpStatus.OK, "TEUM2002", "받은 틈 요청 목록이 조회되었습니다."),
     _TEUM_DETAIL_LOADED(HttpStatus.OK, "TEUM2003", "틈 요청 상세 정보가 조회되었습니다."),
     _TEUM_STATUS_UPDATED(HttpStatus.OK, "TEUM2004", "틈 응답 상태가 성공적으로 변경되었습니다."),
-    _TEUM_CALENDAR_LOADED(HttpStatus.OK, "TEUM2005", "요청 달력 정보가 조회되었습니다."),
+    _TEUM_CALENDAR_LOADED(HttpStatus.OK, "TEUM2005", "틈 요청 달력 정보가 조회되었습니다."),
     _TEUM_LIST_BY_DATE_LOADED(HttpStatus.OK, "TEUM2006", "지정한 날짜의 틈 요청 목록이 조회되었습니다."),
     _SCHEDULED_CALENDAR_LOADED(HttpStatus.OK, "TEUM2007", "약속된 틈 달력 정보가 조회되었습니다."),
     _SCHEDULED_LIST_LOADED(HttpStatus.OK, "TEUM2008", "지정한 날짜의 약속된 틈 목록이 조회되었습니다."),

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -36,5 +36,15 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
             @Param("date") LocalDate date
     );
 
+    @Query("""
+        SELECT DISTINCT tr.date FROM TeumRequest tr
+        WHERE tr.user.id = :userId
+          AND tr.date BETWEEN :start AND :end
+    """)
+    List<LocalDate> findMyRequestDates(
+            @Param("userId") Long userId,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -10,6 +10,7 @@ import umc.teumteum.server.domain.teum.entity.TeumResponse;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
 
@@ -26,6 +27,18 @@ public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long
             @Param("today") LocalDate today,
             @Param("now") LocalTime now,
             Pageable pageable
+    );
+
+    @Query("""
+        SELECT DISTINCT tr.date FROM TeumResponse r
+        JOIN r.teumRequest tr
+        WHERE r.receiverUser.id = :userId
+          AND tr.date BETWEEN :start AND :end
+    """)
+    List<LocalDate> findReceivedRequestDates(
+            @Param("userId") Long userId,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
     );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -25,6 +25,8 @@ public interface TeumService {
 
     TeumStatusUpdateResponseDto updateResponseStatus(Long responseId, Long userId, TeumStatusUpdateRequestDto requestDto);
 
+    List<String> getTeumRequestsOfMonth(Long userId, String month);
+
     List<String> getScheduledTeumsOfMonth(Long userId, String month);
 
     List<ScheduledTeumResponseDto> getScheduledTeums(Long userId, String date);

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -33,14 +33,12 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.global.validator.ConflictValidator;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
 
@@ -217,7 +215,25 @@ public class TeumServiceImpl implements TeumService {
         return TeumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
     }
 
+    @Override
+    public List<String> getTeumRequestsOfMonth(Long userId, String month) {
+        YearMonth yearMonth = YearMonth.parse(month);
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth();
 
+        List<LocalDate> myRequestDates =
+                teumRequestRepository.findMyRequestDates(userId, start, end);
+
+        List<LocalDate> receivedRequestDates =
+                teumResponseRepository.findReceivedRequestDates(userId, start, end);
+
+        List<LocalDate> allDates = Stream.concat(myRequestDates.stream(), receivedRequestDates.stream())
+                .distinct()
+                .sorted()
+                .toList();
+
+        return TeumConverter.toDateStringList(allDates);
+    }
 
     @Override
     public List<String> getScheduledTeumsOfMonth(Long userId, String month) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -1,7 +1,6 @@
 package umc.teumteum.server.domain.teum.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,22 +34,19 @@ import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.global.util.TimeUtil;
 import umc.teumteum.server.global.validator.ConflictValidator;
 
-import java.time.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.*;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
 
-import static umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus.INVALID_PARENT_REQUEST;
-import static umc.teumteum.server.domain.user.entity.enums.UserStatus.ACTIVE;
-
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TeumServiceImpl implements TeumService {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -238,9 +238,15 @@ public class TeumServiceImpl implements TeumService {
     @Override
     public List<String> getScheduledTeumsOfMonth(Long userId, String month) {
         List<ScheduleStatus> validStatuses = List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
-        List<LocalDate> dates = scheduleRepository.findScheduledTeumsByMonth(userId, validStatuses, month);
+
+        YearMonth ym = YearMonth.parse(month);
+        LocalDate start = ym.atDay(1);
+        LocalDate end = ym.atEndOfMonth();
+
+        List<LocalDate> dates = scheduleRepository.findScheduledTeumsByDates(userId, validStatuses, start, end);
         return TeumConverter.toDateStringList(dates);
     }
+
 
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#129 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 월별 틈 요청 날짜 조회 API (`GET /requests/calendar`) 구현
  - 로그인한 사용자가 **보낸 요청 (TeumRequest)** 또는 **받은 요청 (TeumResponse)** 중,
    지정한 월(`YYYY-MM`)에 포함된 요청이 있는 날짜 리스트를 조회
- Schedule 쪽도 쿼리 방식 통일 (`DATE_FORMAT` → `BETWEEN`) 리팩터링
  - 기존 TeumRequest 방식과 동일하게 `start/end` 범위를 기준으로 조회

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 8월의 틈 요청 조회 |<img width="1168" height="715" alt="image" src="https://github.com/user-attachments/assets/e1bd4616-9ec4-4ffc-acf2-f3bb7a9b818b" />|
| 9월의 틈 요청 조회 | <img width="1169" height="672" alt="image" src="https://github.com/user-attachments/assets/0b17f129-db25-4dc0-a891-b2c89b5a4d9a" /> |

- 틈 응답(받은 요청): 8월 1일, 8월 10일
- 본인의 틈 요청: 8월 17일, 9월 12일
- 받은 요청과 본인이 보낸 요청에 상관없이 한꺼번에 표시