### PR TITLE
Feat: 친구의 공개 투두 날짜 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -124,7 +124,7 @@ public class FriendController {
             @Parameter(name = "userId", description = "조회할 친구 ID") @PathVariable("userId") Long targetUserId
     ) {
         FriendTeumTimeResponseDto result = friendService.getFriendTeumTime(loginUser.getId(), targetUserId);
-        return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_TEUM_TIME_SUCCESS, result);
+        return ApiResponse.of(FriendSuccessStatus._GET_FRIEND_TEUM_TIME_SUCCESS, result);
     }
 
     @Operation(
@@ -138,7 +138,7 @@ public class FriendController {
             @PathVariable("userId") Long targetUserId
     ) {
         List<FriendPublicTodoResponseDto> result = friendService.getRecentPublicTodos(loginUser.getId(), targetUserId);
-        return ApiResponse.of(FriendSuccessStatus.GET_FRIEND_PUBLIC_TODO_SUCCESS, result);
+        return ApiResponse.of(FriendSuccessStatus._GET_FRIEND_PUBLIC_TODO_SUCCESS, result);
     }
 
     @Operation(
@@ -157,19 +157,19 @@ public class FriendController {
     }
 
     @Operation(
-            summary = "공개 투두가 있는 날짜(월별) 조회",
+            summary = "친구의 공개 투두가 있는 날짜(월별) 조회",
             description = "특정 유저의 특정 월에 공개 투두가 존재하는 날짜 목록을 반환합니다."
     )
     @GetMapping(value = "/{userId}/todos/public/calendar", produces = "application/json")
     public ApiResponse<List<String>> getTodoDatesOfMonth(
-            @Parameter(description = "조회할 유저 ID", required = true, example = "1")
-            @PathVariable("userId") Long userId,
-
-            @Parameter(description = "조회할 월 (YYYY-MM)", required = true, example = "2024-07")
+            @Parameter(hidden = true) @CurrentUser User loginUser,
+            @Parameter(name = "userId", description = "조회할 친구 ID", example = "2")
+            @PathVariable("userId") Long targetUserId,
+            @Parameter(description = "조회할 연월 (YYYY-MM)", example = "2025-05")
             @RequestParam("month") String month
     ) {
-        return ApiResponse.onSuccess(null);
-    }
+        List<String> result = friendService.getTodoDatesOfMonth(loginUser.getId(), targetUserId, month);
+        return ApiResponse.of(FriendSuccessStatus._GET_FRIEND_PUBLIC_TODO_SUCCESS, result);    }
 
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -9,6 +9,7 @@ import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -92,5 +93,10 @@ public class FriendConverter {
                 .collect(Collectors.toList());
     }
 
+    public List<String> toDateStringList(List<LocalDate> dates) {
+        return dates.stream()
+                .map(LocalDate::toString)
+                .toList();
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -8,6 +8,7 @@ import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
+import umc.teumteum.server.global.util.TimeUtil;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class FriendConverter {
 
     private final S3Util s3Util;
+    private final TimeUtil timeUtil;
 
     public FollowingUserResponseDto toFollowingUserResponse(Friend friend) {
         User following = friend.getFollowing();
@@ -88,7 +90,7 @@ public class FriendConverter {
                 .map(s -> new FriendPublicTodoResponseDto(
                         s.getTitle(),
                         s.getStartTime().format(formatter),
-                        s.getEndTime().format(formatter)
+                        timeUtil.parseAndFormatEndTime(s.getEndTime().toLocalTime())
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendSuccessStatus.java
@@ -13,8 +13,8 @@ public enum FriendSuccessStatus implements BaseCode {
     _UNFOLLOW_SUCCESS(HttpStatus.OK, "FRIEND2001", "언팔로우가 성공적으로 완료되었습니다."),
     _GET_FRIENDS_SUCCESS(HttpStatus.OK, "FRIEND2002", "친구 목록 조회에 성공하였습니다."),
     _FAVORITE_UPDATE_SUCCESS(HttpStatus.OK, "FRIEND2003", "즐겨찾기 설정이 완료되었습니다."),
-    GET_FRIEND_TEUM_TIME_SUCCESS(HttpStatus.OK, "FRIEND2004", "친구 빈틈 시간 조회에 성공하였습니다."),
-    GET_FRIEND_PUBLIC_TODO_SUCCESS(HttpStatus.OK, "FRIEND2005", "친구의 공개 투두 조회에 성공하였습니다.");
+    _GET_FRIEND_TEUM_TIME_SUCCESS(HttpStatus.OK, "FRIEND2004", "친구 빈틈 시간 조회에 성공하였습니다."),
+    _GET_FRIEND_PUBLIC_TODO_SUCCESS(HttpStatus.OK, "FRIEND2005", "친구의 공개 투두 조회에 성공하였습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendService.java
@@ -26,6 +26,6 @@ public interface FriendService {
 
     List<FriendPublicTodoResponseDto> getDailyPublicTodos(Long userId, String date);
 
-    List<String> getTodoDatesOfMonth(Long userId, String month);
+    List<String> getTodoDatesOfMonth(Long loginUserId, Long targetUserId, String month);
 
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -19,10 +19,15 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +37,13 @@ public class FriendServiceImpl implements FriendService {
     private final FriendRepository friendRepository;
     private final ScheduleRepository scheduleRepository;
     private final FriendConverter friendConverter;
+
+    private static final Set<ScheduleType> GENERAL_SCHEDULE_TYPES =
+            EnumSet.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI);
+
+    private static final Set<ScheduleStatus> TEUM_VALID_STATUSES =
+            EnumSet.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
+
 
     @Override
     @Transactional
@@ -154,7 +166,7 @@ public class FriendServiceImpl implements FriendService {
                         return s.getStatus() == ScheduleStatus.ACTIVE || s.getStatus() == ScheduleStatus.COMPLETED;
                     } else {
                         return s.getStatus() == ScheduleStatus.ACTIVE &&
-                                List.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI).contains(s.getType());
+                                GENERAL_SCHEDULE_TYPES.contains(s.getType());
                     }
                 })
                 .limit(2)
@@ -170,9 +182,26 @@ public class FriendServiceImpl implements FriendService {
     }
 
     @Override
-    public List<String> getTodoDatesOfMonth(Long userId, String month) {
-        // TODO : 공개 투두가 있는 날짜 조회 로직 구현
-        return List.of();
+    public List<String> getTodoDatesOfMonth(Long loginUserId, Long targetUserId, String month) {
+        validateNotSelf(loginUserId, targetUserId);
+        validateUserExists(targetUserId);
+
+        YearMonth ym = YearMonth.parse(month);
+        LocalDate start = ym.atDay(1);
+        LocalDate end = ym.atEndOfMonth();
+
+        // TODO/WISH/AI 일정 (status: ACTIVE)
+        List<LocalDate> generalDates = scheduleRepository.findPublicActiveTodos(targetUserId, GENERAL_SCHEDULE_TYPES, start, end);
+
+        // TEUM 일정 (status: ACTIVE, COMPLETED)
+        List<LocalDate> teumDates = scheduleRepository.findPublicTeumDates(targetUserId, TEUM_VALID_STATUSES, start, end);
+
+        List<LocalDate> allDates = Stream.concat(generalDates.stream(), teumDates.stream())
+                .distinct()
+                .sorted()
+                .toList();
+
+        return friendConverter.toDateStringList(allDates);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -13,6 +13,7 @@ import umc.teumteum.server.domain.user.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -185,6 +186,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("delete from Schedule s where s.user = :user")
     void deleteByUser(@Param("user") User user);
 
+
     @Query("""
     SELECT s FROM Schedule s
     WHERE s.user.id = :userId
@@ -195,7 +197,41 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findAllPublicByUserId(@Param("userId") Long userId);
 
 
-
     @Query("SELECT s FROM Schedule s WHERE s.user = :user AND s.date BETWEEN :startDate AND :endDate")
     List<Schedule> findByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
+
+
+    @Query("""
+    SELECT DISTINCT s.date FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.type IN :types
+      AND s.status = 'ACTIVE'
+      AND s.isPublic = true
+      AND s.isDeleted = false
+      AND s.date BETWEEN :start AND :end
+""")
+    List<LocalDate> findPublicActiveTodos(
+            @Param("userId") Long userId,
+            @Param("types") Collection<ScheduleType> types,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+
+    @Query("""
+    SELECT DISTINCT s.date FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.type = 'TEUM'
+      AND s.status IN :statuses
+      AND s.isPublic = true
+      AND s.isDeleted = false
+      AND s.date BETWEEN :start AND :end
+""")
+    List<LocalDate> findPublicTeumDates(
+            @Param("userId") Long userId,
+            @Param("statuses") Collection<ScheduleStatus> statuses,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+
+
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#134 
#124 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 친구의 공개 투두가 존재하는 날짜(월별)를 조회하는 API 구현
  - `/friend/{userId}/todos/public/calendar`
  - TEUM: status가 ACTIVE 또는 COMPLETED인 경우만 포함
  - TODO/WISH/AI: status가 ACTIVE인 경우만 포함
  - 본인 조회는 차단 (`loginUserId == targetUserId`)
- 응답 DTO에서 `endTime = 00:00`인 경우 `"24:00"`으로 포맷 처리
  - `TimeUtil.parseAndFormatEndTime()` 유틸 활용


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 반복되는 일정 타입/상태 필터는 `EnumSet` 상수로 분리하여 재사용성과 성능 향상 (현재는 친구 서비스 구현체에만 적용돼서 틈 서비스 구현체에서도 나중에 리팩토링 필요...)

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|친구의 공개 투두 날짜 리스트 조회|<img width="1173" height="740" alt="image" src="https://github.com/user-attachments/assets/a2120767-0c81-44d4-9023-97a1b53a3909" />|
|공개 투두 조회 자정 처리|<img width="1165" height="542" alt="image" src="https://github.com/user-attachments/assets/483d9ec1-d7c4-46ce-ae95-47887197a9e6" />|