### PR TITLE
Feat: openai API를 활용한 AI 추천 컨텐츠 불러오기 API 구현 

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -86,6 +86,7 @@ jobs:
                 -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
                 -e S3_BUCKET=${{ secrets.S3_BUCKET }} \
                 -e S3_PREFIX=${{ secrets.S3_PREFIX }} \
+                -e OPEN_API_KEY=${{ secrets.OPEN_API_KEY }} \
                 ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest
             
               docker system df

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 	// Firebase Admin SDK
 	implementation 'com.google.firebase:firebase-admin:9.5.0'
 
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 

--- a/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
+++ b/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
@@ -88,10 +88,8 @@ public class AiWishGenerator {
 
   private String buildPrompt(AiWishOptionRequest request, String categoryName) {
     // 기본 값들
-    String location = Optional.ofNullable(request.getLocation()).orElse("실내");
-    String duration = Optional.ofNullable(request.getEstimatedDuration())
-        .map(EstimatedDuration::getDisplayName)
-        .orElse("30m");
+    String location = request.getLocation();
+    String duration = request.getEstimatedDuration().getDisplayName();
 
     return String.format(
         "지금 사용자는 %s에서 %s 정도 활동하고 싶어 해. 카테고리는 %s야."

--- a/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
+++ b/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
@@ -6,11 +6,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.AiWishDto;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.global.config.GptConfig;
@@ -22,9 +24,8 @@ public class AiWishGenerator {
 
   private final WebClient gptWebClient;
   private final GptConfig gptConfig;
-  private final ObjectMapper objectMapper = new ObjectMapper();
 
-  public List<WishDto> generate(AiWishOptionRequest request, String categoryName) {
+  public List<AiWishDto> generate(AiWishOptionRequest request, String categoryName) {
     // 1. 프롬프트 생성
     String prompt = buildPrompt(request, categoryName);
 
@@ -32,7 +33,7 @@ public class AiWishGenerator {
     Map<String, Object> requestBody = Map.of(
         "model", gptConfig.getModel(),
         "messages", List.of(
-            Map.of("role", "system", "content", prompt),
+            Map.of("role", "system", "content", "너는 간단한 활동 추천을 해주는 역할을 수행해야해."),
             Map.of("role", "user", "content", prompt)
         ),
         "temperature", gptConfig.getTemperature()
@@ -52,31 +53,31 @@ public class AiWishGenerator {
       return parseWishList(content, request.getEstimatedDuration());
 
     } catch (Exception e) {
+      log.warn("AI 콘텐츠 생성 실패. fallback 실행: {}", e.getMessage());
       return fallbackWish(request.getEstimatedDuration());
     }
   }
 
-  private List<WishDto> fallbackWish(EstimatedDuration estimatedDuration) {
+  private List<AiWishDto> fallbackWish(EstimatedDuration estimatedDuration) {
     return List.of(
-        WishDto.builder()
-            .id(1L)
-            .content("")
+        AiWishDto.builder()
+            .id(UUID.randomUUID().toString())
+            .title("AI 추천을 불러올 수 없어요.")
             .estimatedDuration(estimatedDuration)
             .build()
     );
 
   }
 
-  private List<WishDto> parseWishList(String content, EstimatedDuration estimatedDuration) {
-    List<WishDto> result = new ArrayList<>();
-    Long id = 1L;
+  private List<AiWishDto> parseWishList(String content, EstimatedDuration estimatedDuration) {
+    List<AiWishDto> result = new ArrayList<>();
 
     for (String line : content.split("\n")) {
       line = line.replaceFirst("[-\\d. ]+", "").trim();
       if(!line.isEmpty()){
-        result.add(WishDto.builder()
-                .id(id++)
-                .content(line)
+        result.add(AiWishDto.builder()
+                .id(UUID.randomUUID().toString())
+                .title(line)
                 .estimatedDuration(estimatedDuration)
             .build());
       }

--- a/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
+++ b/src/main/java/umc/teumteum/server/domain/home/ai/generator/AiWishGenerator.java
@@ -1,0 +1,105 @@
+package umc.teumteum.server.domain.home.ai.generator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
+import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
+import umc.teumteum.server.global.config.GptConfig;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiWishGenerator {
+
+  private final WebClient gptWebClient;
+  private final GptConfig gptConfig;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public List<WishDto> generate(AiWishOptionRequest request, String categoryName) {
+    // 1. 프롬프트 생성
+    String prompt = buildPrompt(request, categoryName);
+
+    // 2. 요청 생성
+    Map<String, Object> requestBody = Map.of(
+        "model", gptConfig.getModel(),
+        "messages", List.of(
+            Map.of("role", "system", "content", prompt),
+            Map.of("role", "user", "content", prompt)
+        ),
+        "temperature", gptConfig.getTemperature()
+
+    );
+    // 3. 요청 보냄
+    try {
+      String content = gptWebClient.post()
+          .bodyValue(requestBody)
+          .retrieve()
+          .bodyToMono(JsonNode.class)
+          .map(json -> json.get("choices").get(0).get("message").get("content").asText())
+          .block();
+
+      log.info("GPT 응답: {}", content);
+
+      return parseWishList(content, request.getEstimatedDuration());
+
+    } catch (Exception e) {
+      return fallbackWish(request.getEstimatedDuration());
+    }
+  }
+
+  private List<WishDto> fallbackWish(EstimatedDuration estimatedDuration) {
+    return List.of(
+        WishDto.builder()
+            .id(1L)
+            .content("")
+            .estimatedDuration(estimatedDuration)
+            .build()
+    );
+
+  }
+
+  private List<WishDto> parseWishList(String content, EstimatedDuration estimatedDuration) {
+    List<WishDto> result = new ArrayList<>();
+    Long id = 1L;
+
+    for (String line : content.split("\n")) {
+      line = line.replaceFirst("[-\\d. ]+", "").trim();
+      if(!line.isEmpty()){
+        result.add(WishDto.builder()
+                .id(id++)
+                .content(line)
+                .estimatedDuration(estimatedDuration)
+            .build());
+      }
+
+    }
+    return result;
+  }
+
+  private String buildPrompt(AiWishOptionRequest request, String categoryName) {
+    // 기본 값들
+    String location = Optional.ofNullable(request.getLocation()).orElse("실내");
+    String duration = Optional.ofNullable(request.getEstimatedDuration())
+        .map(EstimatedDuration::getDisplayName)
+        .orElse("30m");
+
+    return String.format(
+        "지금 사용자는 %s에서 %s 정도 활동하고 싶어 해. 카테고리는 %s야."
+            + "이 조건을 바탕으로 간단한 활동 3가지를 추천해줘."
+            + "각 활동은 한 문장으로 짧게 제시하고 리스트 형식(-)으로 줘.",
+        location,
+        duration,
+        categoryName
+    );
+  }
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/ai/util/AiWishContentSerializer.java
+++ b/src/main/java/umc/teumteum/server/domain/home/ai/util/AiWishContentSerializer.java
@@ -6,13 +6,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.stereotype.Component;
-import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.AiWishDto;
 
 @Component
 public class AiWishContentSerializer {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  public String serialize(List<WishDto> content) {
+  public String serialize(List<AiWishDto> content) {
     try {
       return objectMapper.writeValueAsString(content);
     } catch (JsonProcessingException e) {
@@ -20,9 +20,10 @@ public class AiWishContentSerializer {
     }
   }
 
-  public List<WishDto> deserialize(String json) {
+  // AI 위시 -> 투두 등록할때 사용할 예정
+  public List<AiWishDto> deserialize(String json) {
     try {
-      return objectMapper.readValue(json, new TypeReference<List<WishDto>>() {});
+      return objectMapper.readValue(json, new TypeReference<List<AiWishDto>>() {});
     } catch (IOException e) {
       throw new RuntimeException("역직렬화 실패", e);
     }

--- a/src/main/java/umc/teumteum/server/domain/home/ai/util/AiWishContentSerializer.java
+++ b/src/main/java/umc/teumteum/server/domain/home/ai/util/AiWishContentSerializer.java
@@ -1,0 +1,32 @@
+package umc.teumteum.server.domain.home.ai.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
+
+@Component
+public class AiWishContentSerializer {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public String serialize(List<WishDto> content) {
+    try {
+      return objectMapper.writeValueAsString(content);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("직렬화 실패", e);
+    }
+  }
+
+  public List<WishDto> deserialize(String json) {
+    try {
+      return objectMapper.readValue(json, new TypeReference<List<WishDto>>() {});
+    } catch (IOException e) {
+      throw new RuntimeException("역직렬화 실패", e);
+    }
+  }
+
+
+}

--- a/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
@@ -16,7 +16,6 @@ import umc.teumteum.server.domain.home.service.ActivityService;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
-import umc.teumteum.server.global.apiPayload.code.status.SuccessStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,7 +31,7 @@ public class ActivityController {
   )
   @PostMapping(value = "/user-wishes", produces = "application/json")
   public ApiResponse<ActivityResponseDto.WishResponse> getMyWish(
-      @Valid @RequestBody ActivityRequestDto.OptionRequest request,
+      @Valid @RequestBody ActivityRequestDto.WishOptionRequest request,
       @CurrentUser @Parameter(hidden = true) User user
   ) {
     // TODO: 채움활동에서 사용자의 조건을 만족하는 "내가 등록한 위시" 조회 로직 구현
@@ -43,18 +42,17 @@ public class ActivityController {
 
 
   @Operation(
-      summary = "채움활동 AI 추천 컨텐츠 조회(자동 새로고침 포함)",
+      summary = "채움활동 AI 추천 컨텐츠 조회(새로고침 포함)",
       description = "채움활동에서 AI가 추천한 콘텐츠 목록들을 조회합니다. 새로고침 시에도 해당 api를 사용해 주세요."
   )
   @PostMapping(value = "/ai", produces = "application/json")
   public ApiResponse<Object> getAiWish(
+      @Valid @RequestBody ActivityRequestDto.AiWishOptionRequest request,
+      @CurrentUser @Parameter(hidden = true) User user
   ) {
     // TODO: Redis에서 기존 컨텐츠 확인 후, 채움활동 "AI 추천 컨텐츠" 생성 및 Redis 저장 후 반환 로직 구현
-    // 1. Redis 캐시 삭제 (기존 추천 초기화)
-    // 2. AI 추천 로직 실행 -> 콘텐츠 목록 생성
-    // 3. 콘텐츠 목록을 응답으로 반환
-    return null;
-
+    ActivityResponseDto.WishResponse response = activityServiceImpl.getAiWish(user, request);
+    return ApiResponse.of(HomeSuccessStatus._ACTIVITY_LOADED, response);
   }
 
 

--- a/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/ActivityController.java
@@ -46,12 +46,12 @@ public class ActivityController {
       description = "채움활동에서 AI가 추천한 콘텐츠 목록들을 조회합니다. 새로고침 시에도 해당 api를 사용해 주세요."
   )
   @PostMapping(value = "/ai", produces = "application/json")
-  public ApiResponse<Object> getAiWish(
+  public ApiResponse<ActivityResponseDto.AiWishResponse> getAiWish(
       @Valid @RequestBody ActivityRequestDto.AiWishOptionRequest request,
       @CurrentUser @Parameter(hidden = true) User user
   ) {
     // TODO: Redis에서 기존 컨텐츠 확인 후, 채움활동 "AI 추천 컨텐츠" 생성 및 Redis 저장 후 반환 로직 구현
-    ActivityResponseDto.WishResponse response = activityServiceImpl.getAiWish(user, request);
+    ActivityResponseDto.AiWishResponse response = activityServiceImpl.getAiWish(user, request);
     return ApiResponse.of(HomeSuccessStatus._ACTIVITY_LOADED, response);
   }
 

--- a/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/WishConverter.java
@@ -89,7 +89,7 @@ public class WishConverter {
     public ActivityResponseDto.WishDto toActivityWishDto(Wish wish) {
         return ActivityResponseDto.WishDto.builder()
             .id(wish.getId())
-            .content(wish.getContent())
+            .title(wish.getTitle())
             .estimatedDuration(wish.getEstimatedDuration())
             .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
@@ -1,10 +1,7 @@
 package umc.teumteum.server.domain.home.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +13,31 @@ public class ActivityRequestDto {
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
-  public static class OptionRequest {
+  public static class WishOptionRequest {
 
     @NotNull
     @Schema(description = "예상 소요 시간", example = "10m")
     private EstimatedDuration estimatedDuration;
+
+    @Schema(description = "활동 카테고리", example = "1")
+    private Long categoryId;
+
+    @Schema(description = "사용자가 직접 입력한 카테고리", example = "명상")
+    private String customCategory;
+
+  }
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class AiWishOptionRequest {
+
+    @NotNull
+    @Schema(description = "예상 소요 시간", example = "10m")
+    private EstimatedDuration estimatedDuration;
+
+    @Schema(description = "현재 위치", example = "회사")
+    private String location;
 
     @Schema(description = "활동 카테고리", example = "1")
     private Long categoryId;

--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,6 +37,7 @@ public class ActivityRequestDto {
     @Schema(description = "예상 소요 시간", example = "10m")
     private EstimatedDuration estimatedDuration;
 
+    @NotBlank
     @Schema(description = "현재 위치", example = "회사")
     private String location;
 

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/ActivityResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/ActivityResponseDto.java
@@ -26,14 +26,43 @@ public class ActivityResponseDto {
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = " ai 위시 추천 응답")
+  public static class AiWishResponse {
+
+    @Schema(description = "추천된 위시 목록")
+    private List<AiWishDto> wishes;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   @Schema(description = "추천된 위시 정보")
   public static class WishDto {
 
     @Schema(description = "Wish ID", example = "1")
     private Long id;
 
-    @Schema(description = "위시 상세 설명", example = "성북천 산책하기")
-    private String content;
+    @Schema(description = "위시 제목", example = "성북천 산책하기")
+    private String title;
+
+    @Schema(description = "예상 소요 시간", example = "TEN_MINUTES")
+    private EstimatedDuration estimatedDuration;
+
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "추천된 Ai 위시 정보")
+  public static class AiWishDto {
+
+    @Schema(description = "Wish ID", example = "3b4b2df3-8ef0-43e7-9474-762a76e53e49")
+    private String id;
+
+    @Schema(description = "위시 제목", example = "성북천 산책하기")
+    private String title;
 
     @Schema(description = "예상 소요 시간", example = "TEN_MINUTES")
     private EstimatedDuration estimatedDuration;

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
@@ -1,10 +1,13 @@
 package umc.teumteum.server.domain.home.service;
 
-import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface ActivityService {
 
-  WishResponse getMyWish(User user, OptionRequest request);
+  WishResponse getMyWish(User user, WishOptionRequest request);
+
+  WishResponse getAiWish(User user, AiWishOptionRequest request);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityService.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.domain.home.service;
 
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.AiWishResponse;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -9,5 +10,5 @@ public interface ActivityService {
 
   WishResponse getMyWish(User user, WishOptionRequest request);
 
-  WishResponse getAiWish(User user, AiWishOptionRequest request);
+  AiWishResponse getAiWish(User user, AiWishOptionRequest request);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -17,9 +17,9 @@ import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
-import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.AiWishDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.AiWishResponse;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
-import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.home.exception.HomeException;
@@ -79,7 +79,7 @@ public class ActivityServiceImpl implements ActivityService{
   }
 
   @Override
-    public WishResponse getAiWish(User user, AiWishOptionRequest request) {
+    public AiWishResponse getAiWish(User user, AiWishOptionRequest request) {
       // 유저 아이디 추출, 카테고리 이름 검증
       Long userId = user.getId();
       String categoryName = extractCategoryName(request.getCategoryId(), request.getCustomCategory());
@@ -94,7 +94,7 @@ public class ActivityServiceImpl implements ActivityService{
       }
 
       // 2. AI 콘텐츠 생성 (새로운 추천 생성)
-      List<WishDto> generated = aiWishGenerator.generate(request, categoryName);
+      List<AiWishDto> generated = aiWishGenerator.generate(request, categoryName);
 
       // 3. Redis 캐시에 저장 (TTL 1시간)
       aiContentsRedisTemplate.opsForValue().set(
@@ -104,7 +104,7 @@ public class ActivityServiceImpl implements ActivityService{
       );;
 
       // 4. 변환 후 반환
-      return ActivityResponseDto.WishResponse.builder()
+      return ActivityResponseDto.AiWishResponse.builder()
         .wishes(generated)
         .build();
 

--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.domain.home.service;
 
+import jakarta.annotation.Resource;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -7,19 +9,22 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.home.ai.generator.AiWishGenerator;
+import umc.teumteum.server.domain.home.ai.util.AiWishContentSerializer;
 import umc.teumteum.server.domain.home.converter.WishConverter;
-import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.AiWishOptionRequest;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto;
+import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishDto;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
 import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
-import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 import umc.teumteum.server.domain.home.exception.HomeException;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.repository.CategoryRepository;
-import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -28,14 +33,18 @@ import umc.teumteum.server.domain.user.entity.User;
 public class ActivityServiceImpl implements ActivityService{
 
   private final WishRepository wishRepository;
-  private final WishCategoryRepository wishCategoryRepository;
   private final WishConverter wishConverter;
   private final CategoryRepository categoryRepository;
+  private final AiWishGenerator aiWishGenerator;
+  private final AiWishContentSerializer contentSerializer;
+
+  @Resource(name = "aiContentsRedisTemplate")
+  private RedisTemplate<String, String> aiContentsRedisTemplate;
 
   @Override
-  public WishResponse getMyWish(User user, OptionRequest request) {
+  public WishResponse getMyWish(User user, WishOptionRequest request) {
     EstimatedDuration duration = request.getEstimatedDuration();
-    String categoryName = extractCategoryName(request);
+    String categoryName = extractCategoryName(request.getCategoryId(), request.getCustomCategory());
 
     // 1. 시간과 카테고리가 모두 일치하는 경우 (우선순위1)
     List<Wish> priority1 = wishRepository.findByUserAndDurationAndWishCategoriesLike(user, duration, categoryName);
@@ -68,9 +77,52 @@ public class ActivityServiceImpl implements ActivityService{
         .build();
 
   }
-  private String extractCategoryName(OptionRequest request) {
-    boolean hasCustomCategory = request.getCustomCategory() != null && !request.getCustomCategory().isBlank();
-    boolean hasCategoryId = request.getCategoryId() != null;
+
+  @Override
+    public WishResponse getAiWish(User user, AiWishOptionRequest request) {
+      // 유저 아이디 추출, 카테고리 이름 검증
+      Long userId = user.getId();
+      String categoryName = extractCategoryName(request.getCategoryId(), request.getCustomCategory());
+
+      // 1. Redis 키 생성, 캐시 확인 및 Redis 캐시 삭제 (기존 추천 초기화)
+      // - Redis 키 생성
+      String redisKey = generateRedisKey(userId, request, categoryName);
+
+      // - 기존 캐시가 있으면 무조건 삭제
+      if (aiContentsRedisTemplate.hasKey(redisKey)) {
+        aiContentsRedisTemplate.delete(redisKey);
+      }
+
+      // 2. AI 콘텐츠 생성 (새로운 추천 생성)
+      List<WishDto> generated = aiWishGenerator.generate(request, categoryName);
+
+      // 3. Redis 캐시에 저장 (TTL 1시간)
+      aiContentsRedisTemplate.opsForValue().set(
+          redisKey,
+          contentSerializer.serialize(generated),
+          Duration.ofHours(1)
+      );;
+
+      // 4. 변환 후 반환
+      return ActivityResponseDto.WishResponse.builder()
+        .wishes(generated)
+        .build();
+
+  }
+
+  private String generateRedisKey(Long userId, AiWishOptionRequest request, String categoryName) {
+    return String.format("AI_WISH:%d:%s:%s:%s",
+        userId,
+        request.getEstimatedDuration(),
+        request.getLocation(),
+        categoryName
+    );
+  }
+
+
+  private String extractCategoryName(Long categoryId, String customCategory) {
+    boolean hasCustomCategory = customCategory != null && !customCategory.isBlank();
+    boolean hasCategoryId = categoryId != null;
 
     // 1. 카테고리를 두개 입력한 경우 예외
     if (hasCustomCategory && hasCategoryId) {
@@ -78,13 +130,13 @@ public class ActivityServiceImpl implements ActivityService{
     }
     // 2. CustomCategory를 입력한 경우 반환
     if (hasCustomCategory) {
-      return request.getCustomCategory();
+      return customCategory;
     }
     // 3. 선택한 카테고리 Id가 존재하면 DB에서 name 조회 후 반환
     if (hasCategoryId) {
-      Category category = categoryRepository.findById(request.getCategoryId())
-          .orElseThrow(() -> new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND));
-      return category.getName();
+      return categoryRepository.findById(categoryId)
+          .orElseThrow(() -> new HomeException(HomeErrorStatus._CATEGORY_NOT_FOUND))
+          .getName();
     }
     // 4. 카테고리가 아예 없으면 예외
     throw new HomeException(HomeErrorStatus._CATEGORY_REQUIRED);

--- a/src/main/java/umc/teumteum/server/global/config/GptConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/GptConfig.java
@@ -1,0 +1,27 @@
+package umc.teumteum.server.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+@Getter
+@Configuration
+public class GptConfig {
+  @Value("${open.api-url}")
+  private String apiUrl;
+  @Value("${open.api-key}")
+  private String apiKey;
+  @Value("${openai.model}")
+  private String model;
+  @Value("${openai.temperature}")
+  private double temperature;
+
+  public HttpHeaders buildAuthHeader() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(apiKey);
+    return headers;
+  }
+}

--- a/src/main/java/umc/teumteum/server/global/config/GptWebClientConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/GptWebClientConfig.java
@@ -1,0 +1,22 @@
+package umc.teumteum.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class GptWebClientConfig {
+
+  @Bean
+  public WebClient getWebClient(GptConfig gptConfig) {
+    return WebClient.builder()
+        .baseUrl(gptConfig.getApiUrl())
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + gptConfig.getApiKey())
+        .build();
+
+  }
+
+}

--- a/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.home.ai.generator.AiWishGenerator;
+import umc.teumteum.server.domain.home.ai.util.AiWishContentSerializer;
 import umc.teumteum.server.domain.home.converter.WishConverter;
 import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
@@ -39,6 +41,9 @@ class ActivityServiceTest {
   private WishRepository wishRepository;
   @Mock private CategoryRepository categoryRepository;
   @Mock private WishConverter wishConverter;
+  @Mock private AiWishGenerator aiWishGenerator;
+  @Mock private AiWishContentSerializer aiWishContentSerializer;
+
 
   @InjectMocks
   private ActivityServiceImpl activityService;

--- a/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
@@ -20,7 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.teumteum.server.domain.home.converter.WishConverter;
-import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.OptionRequest;
+import umc.teumteum.server.domain.home.dto.request.ActivityRequestDto.WishOptionRequest;
 import umc.teumteum.server.domain.home.dto.response.ActivityResponseDto.WishResponse;
 import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Wish;
@@ -28,7 +28,6 @@ import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.home.exception.HomeException;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.repository.CategoryRepository;
-import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.home.service.ActivityServiceImpl;
 import umc.teumteum.server.domain.user.entity.User;
@@ -38,7 +37,6 @@ class ActivityServiceTest {
 
   @Mock
   private WishRepository wishRepository;
-  @Mock private WishCategoryRepository wishCategoryRepository;
   @Mock private CategoryRepository categoryRepository;
   @Mock private WishConverter wishConverter;
 
@@ -66,7 +64,7 @@ class ActivityServiceTest {
   @DisplayName("[ActivityServiceImpl] - TC1 시간과 카테고리가 모두 일치하는 경우 priority1에서 최대 3개 반환")
   void getMyWish_priority1_max3() {
     // given
-    OptionRequest request = OptionRequest.builder()
+    WishOptionRequest request = WishOptionRequest.builder()
         .estimatedDuration(EstimatedDuration.MINUTES_10)
         .categoryId(1L)
         .build();
@@ -94,7 +92,7 @@ class ActivityServiceTest {
   @DisplayName("[ActivityServiceImpl] - TC2 우선순위1은 없고, 우선순위2(카테고리, 시간 일치)에서 추천되는 경우")
   void getMyWish_priority2_used() {
     // given
-    OptionRequest request = OptionRequest.builder()
+    WishOptionRequest request = WishOptionRequest.builder()
         .estimatedDuration(EstimatedDuration.MINUTES_10)
         .customCategory("휴식")
         .build();
@@ -120,7 +118,7 @@ class ActivityServiceTest {
   @DisplayName("[ActivityServiceImpl] - TC3 customCategory와 categoryId가 동시에 존재하면 예외 발생")
   void getMyWish_bothCategoryFields_throwsException() {
     // given
-    OptionRequest request = OptionRequest.builder()
+    WishOptionRequest request = WishOptionRequest.builder()
         .estimatedDuration(EstimatedDuration.MINUTES_10)
         .categoryId(1L)
         .customCategory("운동")
@@ -140,7 +138,7 @@ class ActivityServiceTest {
   @DisplayName("[ActivityServiceImpl] - TC4 categoryId로 조회했지만 존재하지 않으면 예외 발생")
   void getMyWish_categoryId_notFound() {
     // given
-    OptionRequest request = OptionRequest.builder()
+    WishOptionRequest request = WishOptionRequest.builder()
         .estimatedDuration(EstimatedDuration.MINUTES_10)
         .categoryId(99L)
         .build();
@@ -162,7 +160,7 @@ class ActivityServiceTest {
   @DisplayName("[ActivityServiceImpl] - TC5 category, duration 둘 다 비어있을 경우 예외 발생")
   void getMyWish_noCategory_throwsException() {
     // given
-    OptionRequest request = OptionRequest.builder()
+    WishOptionRequest request = WishOptionRequest.builder()
         .estimatedDuration(EstimatedDuration.MINUTES_10)
         .build(); // categoryId도 없고 custom도 없음
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#133 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
<img width="200" height="300" alt="스크린샷 2025-08-03 오후 3 14 06" src="https://github.com/user-attachments/assets/97bc93da-89ec-46b2-a4c3-737c820f0ecc" />
<img width="259" height="188" alt="스크린샷 2025-08-03 오후 3 12 47" src="https://github.com/user-attachments/assets/43d733da-d17e-4ac7-8f40-9230fc9ec858" />

1. 해당 화면에서 사용자에게 전달받은 시간, 위치, 카테고리를 바탕으로 open ai api 를 이용하여 추천 컨텐츠 3개 생성하고 반환합니다. 
전에 작업했던 #125 부분애서 categoryId,  customCategoryName을 검증하는 함수가 있는데, 해당 함수를 재사용할 수 있도록 매개변수를 변경하였습니다.

2. 해당 api의 비즈니스 로직은 아래와 같습니다. 
(1) 유저아이디와 카테고리 이름 검증
(2) 유저아이디와 요청값을 바탕으로 Redis Key를 생성
  <img width="254" height="46" alt="스크린샷 2025-08-04 오후 4 14 44" src="https://github.com/user-attachments/assets/e9ffd95d-10bd-4eef-87cf-68951c384a05" />
  
  
  이건 키 형식입니다
  AI_WISH{userId}~..
  
  (3) Redis Key를 바탕으로 기존의 데이터가 있는지 확인 -> 있다면 삭제
  (4) openai api를 활용하여 추천 컨텐츠 생성 (이때 Redis에서 데이터를 식별할 수 있도록 데이터의 id에 UUID를 부여 -> 나중에 해당 아이디를 가지고 데이터를 식별하고 투두에 등록해야 하기 때문입니다.)
  (5) Redis 캐시에 저장
  (6) 응답값 변환 후 반환


> 현재 로직은 사용자가 해당 화면을 나갔다가 다시 접속했을때, 다른 조건으로 검색한다면 기존 데이터를 삭제할 수 없습니다. 그렇기 때문에 Redis에 데이터를 저장할때 TTL을 1시간으로 설정하였습니다. 해당 로직을 선택하게 된 이유는 다음과 같습니다.
원래는 이 문제를 해결하기 위해 Redis Key에 UUID를 붙여서 구분하는 방법을 생각했었습니다.
-> 이 방법을 사용했을때 사용자의 다중 세션 문제도 해결할 수 있다는 장점이 있습니다. 그런데 이 방식을 사용하면 프론트에서 UUID를 인식하고 있어야 한다는 부담이 생깁니다.


3. Dto 응답값 수정
화면설계서를 다시 보니, 위시 조회시 content가 아닌 title을 반환해야 한다는걸 확인하고
필드 값을 content -> title로 변경하였습니다.





### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
openai api를 처음 사용해봐서 제가 구현한 방법이 일반적인 방법인지 잘 모르겠습니다..
그리고 현재 openai api는 홈 도메인쪽에서만 사용되는 것 같아서 홈쪽 패키지에 배치하였는데, 글로벌로 옮겨야 될지도 고민중입니다.
테스트 코드는 시간 관계상 기능 구현이 마무리 된 후, 추가하겠습니다.

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
Redis도 인텔리제이에서 연결해서 확인할 수 있다는걸 이제야 깨달은 바보.....

### 📷 스크린샷 또는 GIF
실내, 1(베이킹), 10m을 입력값으로 주었을때의 결과는 아래와 같습니다.

<img width="1188" height="174" alt="스크린샷 2025-08-04 오후 4 02 45" src="https://github.com/user-attachments/assets/9e09f447-98a1-4ffc-8c4a-6721a34de70a" />
<img width="896" height="406" alt="스크린샷 2025-08-04 오후 4 02 51" src="https://github.com/user-attachments/assets/70d8cc6a-59fb-4711-ba6a-be99f36dc94e" />

그리고 같은 조건으로 다시 입력했을떄 Redis 데이터가 갱신됨을 체크하였고,
AI 컨텐츠의 경우 Redis 2번에 잘 저장됨을 확인했습니다.
그리고 카테고리 검증도 확인했습니다!
<img width="881" height="94" alt="스크린샷 2025-08-04 오후 4 03 10" src="https://github.com/user-attachments/assets/5c970653-b5a3-4222-b8a6-68081cb550ba" />
<img width="884" height="91" alt="스크린샷 2025-08-04 오후 4 03 23" src="https://github.com/user-attachments/assets/ab25b6fe-eaef-4bba-b1b2-e39aad7f8eea" />
<img width="887" height="117" alt="스크린샷 2025-08-04 오후 4 03 39" src="https://github.com/user-attachments/assets/451f3fba-1f73-41aa-8a40-96ab06502dc3" />

