### PR TITLE
Fix: 투두 등록 리마인드 알림 관련 기능 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
@@ -66,8 +66,11 @@ public class HomeController {
 
     @GetMapping(value = "/user-reminds", produces = "application/json")
     @Operation(summary = "리마인드 알림 정보 조회 API",description = "유저의 리마인드 알림 설정 정보를 조회하는 API입니다")
-    public ApiResponse<String> getUserRemind(){
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<HomeResponseDto.ReminderDto> getUserRemind(
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        HomeResponseDto.ReminderDto response = homeService.getUserRemind(user);
+        return ApiResponse.of(HomeSuccessStatus._REMINDER_LOADED,response);
     }
 
     @PostMapping(value = "/todo",consumes = "application/json", produces = "application/json")

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -11,6 +11,7 @@ import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -52,7 +53,7 @@ public class ScheduleConverter {
     }
 
     // Schedule -> TodoInfoResponseDTO
-    public TodoInfoResponseDto toTodoInfoResponse(Schedule schedule, List<ScheduleReminder> reminders, List<String> profileUrls) {
+    public TodoInfoResponseDto toTodoInfoResponse(Schedule schedule, List<RemindAlarm> onboardingReminders, List<ScheduleReminder> reminders, List<String> profileUrls) {
 
         return TodoInfoResponseDto.builder()
                 .type(schedule.getType())
@@ -62,6 +63,9 @@ public class ScheduleConverter {
                 .description(schedule.getDescription())
                 .isPublic(schedule.getIsPublic())
                 .includeTeum(schedule.getIncludeTeum())
+                .onboardingReminder(onboardingReminders.stream()
+                        .map(RemindAlarm::getMinutesBefore)
+                        .toList())
                 .remindAlarm(reminders.stream()
                         .map(ScheduleReminder::getReminderTime)
                         .toList())

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
@@ -9,6 +9,7 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public class HomeResponseDto {
 
@@ -68,4 +69,11 @@ public class HomeResponseDto {
     private Long routineId;
   }
 
+  @Builder
+  @Getter
+  @AllArgsConstructor
+  static public class ReminderDto {
+    @Schema(description = "온보딩 리마인드 알림 설정 정보", example = "[1,5]")
+    private List<Integer> reminders;
+  }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/TodoInfoResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/TodoInfoResponseDto.java
@@ -36,6 +36,9 @@ public class TodoInfoResponseDto {
     @Schema(description = "빈틈 시간 포함 여부", example = "false")
     private Boolean includeTeum;
 
+    @Schema(description = " 온보딩 리마인드 알림 목록", example = "[1, 30]")
+    private List<Integer> onboardingReminder;
+
     @Schema(description = "리마인드 알림 목록", example = "[1, 3, 5, 10, 30]")
     private List<Integer> remindAlarm;
 

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -26,7 +26,8 @@ public enum HomeSuccessStatus implements BaseCode {
     _TEUMTIME_LOADED(HttpStatus.OK, "HOME20013", "지금까지 채운 빈틈 시간이 성공적으로 조회되었습니다."),
     _CALENDAR_LOADED(HttpStatus.OK,"HOME20014","캘린더 정보가 성공적으로 조회되었습니다."),
     _TODOLIST_LOADED(HttpStatus.OK,"HOME20015","투두리스트가 성공적으로 조회되었습니다."),
-    _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다.")
+    _REMINDER_LOADED(HttpStatus.OK, "HOME20016", "리마인드 알림 정보가 성공적으로 조회되었습니다."),
+    _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -58,4 +58,7 @@ public interface HomeService {
 
     // 가상의 루틴 ID 파싱
     HomeResponseDto.VirtualRoutineDto getVirtualRoutine(Long virtualId);
+
+    // 리마인드 알림 정보 조회
+    HomeResponseDto.ReminderDto getUserRemind(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -116,7 +116,10 @@ public class HomeServiceImpl implements HomeService {
             profileUrls = profileImageName != null ? List.of(s3Util.toPresignedUrl("profile/" + profileImageName, Duration.ofMinutes(30))) : List.of();
         }
 
-        return scheduleConverter.toTodoInfoResponse(schedule,reminders, profileUrls);
+        // 온보딩 리마인드 알림 조회
+        List<RemindAlarm> onboardingReminders = remindAlarmRepository.findAllByUser(schedule.getUser());
+
+        return scheduleConverter.toTodoInfoResponse(schedule,onboardingReminders, reminders, profileUrls);
     }
 
     private List<String> getTeumProfileUrls(Schedule schedule){
@@ -608,6 +611,7 @@ public class HomeServiceImpl implements HomeService {
 
     @Override
     public HomeResponseDto.ReminderDto getUserRemind(User user) {
+        // 리마인드 알림 정보 조회
         List<Integer> response = remindAlarmRepository.findAllByUser(user).stream()
                 .map(RemindAlarm::getMinutesBefore)
                 .toList();

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -29,9 +29,11 @@ import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.exception.GeneralException;
@@ -56,6 +58,7 @@ public class HomeServiceImpl implements HomeService {
     private final CategoryRepository categoryRepository;
     private final S3Util s3Util;
     private final RoutineRepository routineRepository;
+    private final RemindAlarmRepository remindAlarmRepository;
 
     @Transactional
     @Override
@@ -601,5 +604,15 @@ public class HomeServiceImpl implements HomeService {
         } catch(Exception e){
             throw new HomeException(HomeErrorStatus._INVALID_VIRTUAL_ID);
         }
+    }
+
+    @Override
+    public HomeResponseDto.ReminderDto getUserRemind(User user) {
+        List<Integer> response = remindAlarmRepository.findAllByUser(user).stream()
+                .map(RemindAlarm::getMinutesBefore)
+                .toList();
+
+        return HomeResponseDto.ReminderDto.builder()
+                .reminders(response).build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
@@ -4,8 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RemindAlarmRepository extends JpaRepository<RemindAlarm, Long> {
     Optional<RemindAlarm> findByUser(User user);
+    List<RemindAlarm> findAllByUser(User user);
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#144 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 투두 등록시 바텀시트로 리마인드 알림 관련 정보를 반환하는 API 추가했습니다.
- 스케줄에 별도로 리마인드 알림은 설정하지 않아도 온보딩에서 설정한 알림은 기본 필드로 제공되어야해서 투두 조회 응답시 onboardingReminder 필드 추가했습니다.
### 🌀 PR Point

`/api/home/todo/user-reminds`
`/api/home/todo/{todoId}`

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF

X