### PR TITLE
Feat: 함께한 틈 목록 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.domain.home.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -257,6 +259,39 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("friendId") Long friendId,
             @Param("type") ScheduleType type,
             @Param("status") ScheduleStatus status
+    );
+
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.date = :date
+      AND s.isPublic = true
+      AND s.isDeleted = false
+""")
+    List<Schedule> findPublicSchedulesByUserAndDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
+
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.teumRequest.id IN (
+          SELECT sr.teumRequest.id FROM Schedule sr
+          WHERE sr.user.id = :friendId
+            AND sr.type = :type
+            AND sr.status = :status
+      )
+      AND s.type = :type
+      AND s.status = :status
+""")
+    Slice<Schedule> findSharedTeumSchedulesPaged(
+            @Param("userId") Long userId,
+            @Param("friendId") Long friendId,
+            @Param("type") ScheduleType type,
+            @Param("status") ScheduleStatus status,
+            Pageable pageable
     );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -21,6 +21,7 @@ import umc.teumteum.server.domain.teum.service.TeumService;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
+import umc.teumteum.server.global.dto.PagingResponseDto;
 
 import java.util.List;
 
@@ -221,12 +222,17 @@ public class TeumController {
             summary = "함께한 틈 목록 조회",
             description = "로그인한 사용자와 지정된 친구가 함께 참여한 모든 틈 요청 목록을 반환합니다."
     )
-    @GetMapping(value = "/{userId}/shared", produces = "application/json")
-    public ApiResponse<List<SharedTeumListResponseDto>> getSharedTeums(
-            @Parameter(name = "userId", description = "함께한 틈을 조회할 친구 ID", example = "1")
-            @PathVariable("userId") Long userId
+    @GetMapping("/{userId}/shared")
+    public ApiResponse<PagingResponseDto<SharedTeumListResponseDto>> getSharedTeums(
+            @Parameter(hidden = true) @CurrentUser User loginUser,
+            @Parameter(name = "userId", description = "조회할 친구 ID", example = "2")
+            @PathVariable("userId") Long targetUserId,
+            @Parameter(description = "페이지 번호 (1부터 시작)") @RequestParam(name = "page", defaultValue = "1") int page,
+            @Parameter(description = "한 페이지에 포함될 항목 수") @RequestParam(name = "size", defaultValue = "10") int size
     ) {
-        return ApiResponse.onSuccess(null);
+        PagingResponseDto<SharedTeumListResponseDto> result = teumService.getSharedTeums(loginUser.getId(), targetUserId, page, size);
+        return ApiResponse.of(TeumSuccessStatus._SHARED_LIST_LOADED, result);
     }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -8,6 +8,7 @@ import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
 import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
+import umc.teumteum.server.domain.teum.dto.shared.SharedTeumListResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumTimeResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
@@ -348,6 +349,24 @@ public class TeumConverter {
                 .accepted(accepted)
                 .cancelled(cancelled)
                 .resend(resend)
+                .build();
+    }
+
+
+    public SharedTeumListResponseDto toSharedTeumListDto(Schedule schedule, Long loginUserId) {
+        TeumRequest request = schedule.getTeumRequest();
+        User sender = request.getUser();
+
+        return SharedTeumListResponseDto.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .date(request.getDate().toString())
+                .time(new TimeSlot(
+                        schedule.getStartTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                        timeUtil.parseAndFormatEndTime(schedule.getEndTime().toLocalTime())
+                ))
+                .sender(toParticipantDto(sender))
+                .isSender(sender.getId().equals(loginUserId))
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/shared/SharedTeumListResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/shared/SharedTeumListResponseDto.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.teum.dto.shared;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,14 +13,14 @@ import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(title = "SharedTeumListResponseDto : 공유된 틈 요청 리스트 응답 DTO")
+@Schema(title = "SharedTeumListResponseDto : 함께한 틈 요청 리스트 응답 DTO")
 public class SharedTeumListResponseDto {
-
-    @Schema(description = "틈 ID", example = "1")
-    private Long teumId;
 
     @Schema(description = "제목", example = "string")
     private String title;
+
+    @Schema(description = "설명", example = "string")
+    private String description;
 
     @Schema(description = "요청 날짜", example = "2025-07-15")
     private String date;
@@ -30,6 +31,7 @@ public class SharedTeumListResponseDto {
     @Schema(description = "요청자 정보")
     private ParticipantDto sender;
 
+    @JsonProperty("isSender")
     @Schema(description = "요청자가 나인지 여부", example = "true")
-    private boolean isRequester;
+    private boolean isSender;
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -7,9 +7,11 @@ import umc.teumteum.server.domain.teum.dto.availability.AvailableTimeResponseDto
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumCancelResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
+import umc.teumteum.server.domain.teum.dto.shared.SharedTeumListResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumTimeResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.dto.PagingResponseDto;
 
 import java.util.List;
 
@@ -38,6 +40,8 @@ public interface TeumService {
     AvailableTimeResponseDto getAvailableTime(User user, AvailableTimeRequestDto requestDto);
 
     SharedTeumTimeResponseDto getSharedTeumStats(Long userId, Long friendId);
+
+    PagingResponseDto<SharedTeumListResponseDto> getSharedTeums(Long loginUserId, Long targetUserId, int page, int size);
 
     List<TeumRequestResponseDto> getTeumRequestsByDate(Long userId, String date);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -15,6 +15,7 @@ import umc.teumteum.server.domain.teum.dto.common.TimeSlot;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumCancelResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumDetailResponseDto;
 import umc.teumteum.server.domain.teum.dto.schedule.ScheduledTeumResponseDto;
+import umc.teumteum.server.domain.teum.dto.shared.SharedTeumListResponseDto;
 import umc.teumteum.server.domain.teum.dto.shared.SharedTeumTimeResponseDto;
 import umc.teumteum.server.domain.teum.dto.teum.*;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
@@ -28,6 +29,7 @@ import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
@@ -405,6 +407,38 @@ public class TeumServiceImpl implements TeumService {
                 .sum();
 
         return TeumConverter.toSharedTeumTimeDto(totalMinutes);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PagingResponseDto<SharedTeumListResponseDto> getSharedTeums(Long loginUserId, Long targetUserId, int page, int size) {
+        validateNotSelf(loginUserId, targetUserId);
+        validateUserExists(targetUserId);
+
+        // 정렬: date desc, startTime desc
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0),
+                size,
+                Sort.by(
+                        Sort.Order.desc("date"),
+                        Sort.Order.desc("startTime")
+                )
+        );
+
+        // 스케줄 조회
+        Slice<Schedule> slice = scheduleRepository.findSharedTeumSchedulesPaged(
+                loginUserId,
+                targetUserId,
+                ScheduleType.TEUM,
+                ScheduleStatus.COMPLETED,
+                pageable
+        );
+
+        List<SharedTeumListResponseDto> content = slice.getContent().stream()
+                .map(s -> teumConverter.toSharedTeumListDto(s, loginUserId))
+                .toList();
+
+        return new PagingResponseDto<>(content, slice.hasNext());
     }
 
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#157 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `/api/teums/{userId}/shared` GET 엔드포인트 추가
- 로그인한 사용자와 특정 친구가 함께한 틈 목록 조회
- `Slice` 기반 페이징 적용 + `PagingResponseDto`로 감싸서 반환
- 응답 정렬 기준: `date DESC` → `startTime DESC`

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 화면설계서 상에서는 요청자 기준으로 틈 목록이 좌/우로 배치되도록 되어 있으나, 이는 다자 간 틈 상황을 고려하지 않음
- 실제 구현에서는 다음 기준으로 좌측 표시 여부를 결정
  → 로그인 유저 또는 상대 유저가 모두 수신자인 경우 → 좌측에 표시
- 요청자/수신자가 명확히 나뉘지 않는 다자 간 상황을 감안한 UI 동작 보완

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|함께한 틈 목록 조회|<img width="1692" height="1364" alt="image" src="https://github.com/user-attachments/assets/834ff164-04a4-4f4a-90ba-0f4b83aa896c" />|

#### 조회 성공
```json
{
  "isSuccess": true,
  "code": "TEUM2013",
  "message": "함께한 틈 목록이 조회되었습니다.",
  "result": {
    "content": [
      {
        "title": "틈 요청 3",
        "description": "함께한 틈 조회 API 테스트용",
        "date": "2025-08-03",
        "time": {
          "start": "12:00",
          "end": "12:30"
        },
        "sender": {
          "userId": 1,
          "nickname": null,
          "profileImageUrl": "https://teumteum..."
        },
        "isSender": true
      },
      {
        "title": "틈 요청 2",
        "description": "함께한 틈 조회 API 테스트용",
        "date": "2025-08-01",
        "time": {
          "start": "23:00",
          "end": "24:00"
        },
        "sender": {
          "userId": 3,
          "nickname": "유저3",
          "profileImageUrl": "https://teumteum..."
        },
        "isSender": false
      },
      {
        "title": "틈 요청 1",
        "description": "함께한 틈 조회 API 테스트용",
        "date": "2025-08-01",
        "time": {
          "start": "12:00",
          "end": "13:00"
        },
        "sender": {
          "userId": 2,
          "nickname": "유저2",
          "profileImageUrl": "https://teumteum..."
        },
        "isSender": false
      }
    ],
    "hasNext": false
  }
}
```