### PR TITLE
Feat: 토큰 재발급 API 구현 및 인증 흐름 개선

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -50,9 +50,10 @@ public class AuthController {
     )
     @PostMapping(value = "/reissue", produces = "application/json")
     public ApiResponse<Object> reissueToken(
+            @Valid @RequestBody AuthRequestDTO.ReissueRequest request
     ) {
-        // TODO: 토큰 재발급 로직 구현
-        return null;
+        AuthResponseDTO.ReissueResponse response = authService.reissueToken(request);
+        return ApiResponse.of(AuthSuccessStatus.TOKEN_REISSUE_SUCCESS, response);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/converter/AuthConverter.java
@@ -25,9 +25,18 @@ public class AuthConverter {
                 ;
     }
 
-    public static AuthResponseDTO.DevTokenResponse toDevTokenResponse(String accessToken) {
+    public static AuthResponseDTO.DevTokenResponse toDevTokenResponse(String accessToken, String refreshToken) {
         return AuthResponseDTO.DevTokenResponse.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build()
+                ;
+    }
+
+    public static AuthResponseDTO.ReissueResponse toReissueResponse(String newAccessToken, String newRefreshToken) {
+        return AuthResponseDTO.ReissueResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build()
                 ;
     }

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDTO.java
@@ -16,8 +16,20 @@ public class AuthRequestDTO {
     @AllArgsConstructor
     public static class SocialLoginRequest {
 
-        @NotBlank(message = "액세스 토큰은 필수입니다")
-        @Schema(description = "소셜 로그인 액세스 토큰")
+        @NotBlank(message = "액세스 토큰은 필수입니다.")
+        @Schema(description = "소셜 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
         private String accessToken;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReissueRequest {
+
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        @Schema(description = "틈틈 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String refreshToken;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,16 +14,39 @@ public class AuthResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginResponse {
-        private String accessToken;     // 액세스토큰
-        private String refreshToken;    // 리프레시토큰
-        private UserStep nextStep;        // 다음 화면 단계
+        @Schema(description = "틈틈 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String accessToken;
+
+        @Schema(description = "틈틈 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String refreshToken;
+
+        @Schema(description = "다음 전환 화면", example = "ONBOARDING")
+        private UserStep nextStep;
     }
+
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DevTokenResponse {
-        private String accessToken;     // 액세스토큰
+        @Schema(description = "개발용 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String accessToken;
+
+        @Schema(description = "개발용 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String refreshToken;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReissueResponse {
+        @Schema(description = "새로운 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String accessToken;
+
+        @Schema(description = "새로운 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String refreshToken;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
@@ -14,6 +14,11 @@ public enum AuthErrorStatus implements BaseErrorCode {
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "AUTH4001", "지원하지 않는 소셜 로그인 타입입니다."),
     KAKAO_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "카카오 사용자 정보 조회에 실패했습니다."),
     NAVER_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4003", "네이버 사용자 정보 조회에 실패했습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4004", "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4011", "리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH40112", "리프레시 토큰이 일치하지 않습니다."),
+
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
@@ -11,7 +11,9 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 public enum AuthSuccessStatus implements BaseCode {
 
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 완료되었습니다."),
-    DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다.")
+    DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다."),
+    TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2003", "토큰 재발급이 완료되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
@@ -7,4 +7,6 @@ public interface AuthService {
     AuthResponseDTO.LoginResponse socialLogin(String socialType, AuthRequestDTO.SocialLoginRequest request);
 
     AuthResponseDTO.DevTokenResponse generateDevAccessToken();
+
+    AuthResponseDTO.ReissueResponse reissueToken(AuthRequestDTO.ReissueRequest request);
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -1,10 +1,15 @@
 package umc.teumteum.server.domain.auth.service;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.converter.AuthConverter;
@@ -21,14 +26,16 @@ import umc.teumteum.server.domain.user.entity.enums.UserStep;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
+import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AuthServiceImpl implements AuthService {
 
     private final KakaoOAuthService kakaoOAuthService;
@@ -41,8 +48,15 @@ public class AuthServiceImpl implements AuthService {
     private final RoutineRepository routineRepository;
     private final ScheduleRepository scheduleRepository;
 
-    @Resource(name = "rtRedisTemplate")
-    private RedisTemplate<String, String> rtRedisTemplate;
+    @Resource(name = "rtWhitelistRedisTemplate")
+    private RedisTemplate<String, String> rtWhitelistRedisTemplate;
+
+    @Resource(name = "atBlacklistRedisTemplate")
+    private RedisTemplate<String, String> atBlacklistRedisTemplate;
+
+
+    @Value("${jwt.access-expiration-ms}")
+    private long accessExpirationMs;
 
     @Value("${jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
@@ -63,14 +77,14 @@ public class AuthServiceImpl implements AuthService {
         }
 
         // 4. 토큰 생성
-        String accessToken = jwtProvider.generateAccessToken(user.getId());
-        String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+        String sessionId = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), sessionId);
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), sessionId);
 
-        // TODO 기기별 분리 저장 필요
-        // 5. 리프레시 토큰 저장
-        String key = user.getId().toString();
+        // 5. RT 저장
+        String refreshKey = getRefreshKey(user.getId().toString(), sessionId);
         Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
-        rtRedisTemplate.opsForValue().set(key, refreshToken, refreshDuration);
+        rtWhitelistRedisTemplate.opsForValue().set(refreshKey, refreshToken, refreshDuration);
 
         // 6. 다음 전환할 화면
         UserStep nextStep = user.getStep();
@@ -107,6 +121,87 @@ public class AuthServiceImpl implements AuthService {
         return AuthConverter.toLoginResponse(accessToken, refreshToken, nextStep);
     }
 
+
+    @Override
+    @Transactional
+    public AuthResponseDTO.DevTokenResponse generateDevAccessToken() {
+        // 1. 더미 사용자 조회 (없으면 생성)
+        User masterUser = userService.createDevUser();
+
+        // 2. 토큰 발급
+        String sessionId = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.generateAccessToken(masterUser.getId(), sessionId);
+        String refreshToken = jwtProvider.generateRefreshToken(masterUser.getId(), sessionId);
+
+        // 3. RT 저장
+        String refreshKey = getRefreshKey(masterUser.getId().toString(), sessionId);
+        Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
+        rtWhitelistRedisTemplate.opsForValue().set(refreshKey, refreshToken, refreshDuration);
+
+        // 4. converter 작업
+        return AuthConverter.toDevTokenResponse(accessToken, refreshToken);
+    }
+
+
+    @Override
+    public AuthResponseDTO.ReissueResponse reissueToken(AuthRequestDTO.ReissueRequest request) {
+        String refreshKey = null;
+
+        try {
+            // 1. 전달받은 RT 유효성 검증 (검증 실패 -> 재로그인 필요)
+            String refreshToken = request.getRefreshToken();
+            validateRefreshTokenForService(refreshToken);
+
+            // 2. 토큰에서 userId와 sessionId 추출
+            String userId = jwtProvider.getUserIdFromToken(refreshToken);
+            String sessionId = jwtProvider.getSessionIdFromToken(refreshToken);
+
+            // 3. Redis에 저장된 RT 조회 (null -> 재로그인 필요)
+            refreshKey = getRefreshKey(userId, sessionId);
+            String storedRefreshToken = rtWhitelistRedisTemplate.opsForValue().get(refreshKey);
+            if (storedRefreshToken == null) {
+                throw new AuthHandler(AuthErrorStatus.REFRESH_TOKEN_NOT_FOUND);
+            }
+
+            // 4. Redis에 저장된 RT 유효성 검증 (검증 실패 -> 재로그인 필요)
+            validateRefreshTokenForService(storedRefreshToken);
+
+            // 5. 요청받은 RT와 Redis에 저장된 RT 비교 (불일치 -> 재로그인 필요)
+            if (!refreshToken.equals(storedRefreshToken)) {
+                log.warn("토큰 탈취 의심 - userId: {}, sessionId: {}", userId, sessionId);
+                
+                // 동일한 sessionID를 갖는 AT 블랙리스트 등록
+                String blacklistKey = getBlacklistKey(userId, sessionId);
+                Duration blacklistDuration = Duration.ofMillis(accessExpirationMs);
+                atBlacklistRedisTemplate.opsForValue().set(blacklistKey, "blacklisted", blacklistDuration);
+
+                throw new AuthHandler(AuthErrorStatus.REFRESH_TOKEN_MISMATCH);
+            }
+
+            // 6. 기존 sessionId로 토큰 재발급
+            String newAccessToken = jwtProvider.generateAccessToken(Long.valueOf(userId), sessionId);
+            String newRefreshToken = jwtProvider.generateRefreshToken(Long.valueOf(userId), sessionId);
+
+            // 7. Redis RT 업데이트
+            Duration refreshDuration = Duration.ofMillis(refreshExpirationMs);
+            rtWhitelistRedisTemplate.opsForValue().set(refreshKey, newRefreshToken, refreshDuration);
+
+            // 8. converter 작업
+            return AuthConverter.toReissueResponse(newAccessToken, newRefreshToken);
+
+        } catch (AuthHandler e) {
+            // 예외 발생 시, RT Redis 초기화하여 동일한 sessionID로 토큰 재발급 불가
+            if (refreshKey != null) {
+                rtWhitelistRedisTemplate.delete(refreshKey);
+            }
+
+            throw e;
+        }
+    }
+
+
+
+
     // SocialType 따라 로그인 분기 처리
     private OAuthUserInfo getUserInfo(SocialType socialType, String accessToken) {
         switch (socialType) {
@@ -120,16 +215,40 @@ public class AuthServiceImpl implements AuthService {
     }
 
 
-    @Override
-    @Transactional
-    public AuthResponseDTO.DevTokenResponse generateDevAccessToken() {
-        // 1. 더미 사용자 조회 (없으면 생성)
-        User masterUser = userService.createDevUser();
+    // 서비스용 RT 유효성 검증
+    private void validateRefreshTokenForService(String token) {
+        try {
+            jwtProvider.validateRefreshToken(token);
+        } catch (BadCredentialsException e) {
+            Throwable cause = e.getCause();
 
-        // 2. 액세스 토큰 발급
-        String accessToken = jwtProvider.generateAccessToken(masterUser.getId());
+            if (cause instanceof SecurityException) {
+                throw new AuthHandler(ErrorStatus.INVALID_JWT_SIGNATURE);
+            } else if (cause instanceof MalformedJwtException) {
+                throw new AuthHandler(ErrorStatus.MALFORMED_JWT_TOKEN);
+            } else if (cause instanceof ExpiredJwtException) {
+                throw new AuthHandler(ErrorStatus.EXPIRED_JWT_TOKEN);
+            } else if (cause instanceof UnsupportedJwtException) {
+                throw new AuthHandler(ErrorStatus.UNSUPPORTED_JWT_TOKEN);
+            } else if (cause instanceof IllegalArgumentException) {
+                throw new AuthHandler(ErrorStatus.EMPTY_JWT_CLAIMS);
+            }
+        } catch (InvalidTokenTypeException e) {
+            throw new AuthHandler(ErrorStatus.INVALID_TOKEN_TYPE);
+        } catch (Exception e) {
+            throw new AuthHandler(AuthErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+    }
 
-        // 3. converter 작업
-        return AuthConverter.toDevTokenResponse(accessToken);
+
+    // RT 화이트리스트 키 get
+    private String getRefreshKey(String userId, String sessionId) {
+        return String.format("RT_WHITELIST:%s:%s", userId, sessionId);
+    }
+
+
+    // AT 블랙리스트 키 get
+    private String getBlacklistKey(String userId, String sessionId) {
+        return String.format("AT_BLACKLIST:%s:%s", userId, sessionId);
     }
 }

--- a/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
@@ -19,13 +19,11 @@ public enum ErrorStatus implements BaseErrorCode {
   MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4101", "잘못 구성된 JWT 형식입니다."),
   UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4102", "지원하지 않는 JWT 형식입니다."),
   EMPTY_JWT_CLAIMS(HttpStatus.BAD_REQUEST, "AUTH4103", "JWT 클레임이 비어 있습니다."),
-  INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4111", "유효하지 않은 JWT 서명입니다."),
-  EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4112", "JWT 토큰이 만료되었습니다."),
-  INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH4114", "유효하지 않은 토큰 타입입니다."),
-  MISSING_JWT(HttpStatus.UNAUTHORIZED, "AUTH4115", "JWT 토큰이 없습니다."),
-
-  // 사용자 관련
   USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4111", "존재하지 않는 사용자입니다."),
+  INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4112", "유효하지 않은 JWT 서명입니다."),
+  EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4113", "JWT 토큰이 만료되었습니다."),
+  INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH4114", "유효하지 않은 토큰 타입입니다."),
+  ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "AUTH4115", "블랙리스트된 액세스 토큰입니다."),
   INACTIVE_USER(HttpStatus.FORBIDDEN, "AUTH4131", "비활성화된 사용자입니다."),
 
 
@@ -40,20 +38,20 @@ public enum ErrorStatus implements BaseErrorCode {
   @Override
   public ErrorReasonDto getReason() {
     return ErrorReasonDto.builder()
-        .isSuccess(true)
-        .message(message)
-        .code(code)
-        .build();
+            .isSuccess(true)
+            .message(message)
+            .code(code)
+            .build();
   }
 
   @Override
   public ErrorReasonDto getReasonHttpStatus() {
     return ErrorReasonDto.builder()
-        .httpStatus(httpStatus)
-        .isSuccess(true)
-        .code(code)
-        .message(message)
-        .build();
+            .httpStatus(httpStatus)
+            .isSuccess(true)
+            .code(code)
+            .message(message)
+            .build();
   }
 
 }

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -41,9 +41,9 @@ public class RedisConfig {
     return template;
   }
 
-  // RT용 Redis(index 0)
+  // RT 화이트리스트용 Redis(index 0)
   @Bean
-  public RedisTemplate<String, String> rtRedisTemplate() {
+  public RedisTemplate<String, String> rtWhitelistRedisTemplate() {
     return createRedisTemplate(createConnectionFactory(0));
   }
 
@@ -59,4 +59,9 @@ public class RedisConfig {
     return createRedisTemplate(createConnectionFactory(2));
   }
 
+  // AT 블랙리스트용 Redis(index 3)
+  @Bean
+  public RedisTemplate<String, String> atBlacklistRedisTemplate() {
+    return createRedisTemplate(createConnectionFactory(3));
+  }
 }

--- a/src/main/java/umc/teumteum/server/global/config/SecurityConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/SecurityConfig.java
@@ -20,12 +20,14 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // URL 접근 권한
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()  // 인증 관련 API 허용
+                        // 소셜 로그인, 토큰 재발급, 개발용 BE 토큰 발급 API 허용
+                        .requestMatchers("/api/auth/social-login/**", "/api/auth/reissue", "/api/auth/dev-token").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()   // Swagger 관련 경로 허용
                         .anyRequest().authenticated()   // 나머지는 인증 필요
                 )

--- a/src/main/java/umc/teumteum/server/global/exception/TokenBlacklistException.java
+++ b/src/main/java/umc/teumteum/server/global/exception/TokenBlacklistException.java
@@ -1,0 +1,9 @@
+package umc.teumteum.server.global.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class TokenBlacklistException extends AuthenticationException {
+    public TokenBlacklistException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,19 +1,13 @@
 package umc.teumteum.server.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
-import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 
 import java.io.IOException;
 
@@ -22,13 +16,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    // 인증 실패 시 호출되는 메서드
+    // 인증 실패 시, 호출되는 메서드
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-
         // 1. 예외 타입에 따른 ErrorStatus 결정
-        ErrorStatus errorStatus = determineErrorStatus(authException);
+        ErrorStatus errorStatus = (ErrorStatus) request.getAttribute("errorStatus");
+
+        // 인증이 필요하지만, AT가 없는 경우
+        if (errorStatus == null)
+            errorStatus = ErrorStatus._UNAUTHORIZED;
 
         // 2. HTTP 응답 설정
         response.setStatus(errorStatus.getHttpStatus().value());
@@ -40,42 +37,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                 errorStatus.getMessage(),
                 null
         );
-
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
-    }
-
-    // 적절한 ErrorStatus 반환
-    private ErrorStatus determineErrorStatus(AuthenticationException ex) {
-
-        // 1. JWT 토큰 검증 관련 예외
-        // cause : 실제 원인이 되는 예외
-        Throwable cause = ex.getCause();
-
-        if (cause instanceof SecurityException) {
-            return ErrorStatus.INVALID_JWT_SIGNATURE;
-        } else if (cause instanceof MalformedJwtException) {
-            return ErrorStatus.MALFORMED_JWT_TOKEN;
-        } else if (cause instanceof ExpiredJwtException) {
-            return ErrorStatus.EXPIRED_JWT_TOKEN;
-        } else if (cause instanceof UnsupportedJwtException) {
-            return ErrorStatus.UNSUPPORTED_JWT_TOKEN;
-        } else if (cause instanceof IllegalArgumentException) {
-            return ErrorStatus.EMPTY_JWT_CLAIMS;
-        }
-
-        // 유효하지 않은(=refresh) 토큰 타입에 대한 예외 (커스텀)
-        if (ex instanceof InvalidTokenTypeException) {
-            return ErrorStatus.INVALID_TOKEN_TYPE;
-        }
-
-        // 2. 사용자 인증 과정 예외
-        if (ex instanceof DisabledException) {
-            return ErrorStatus.INACTIVE_USER;
-        }
-        if (ex instanceof UsernameNotFoundException) {
-            return ErrorStatus.USER_NOT_FOUND;
-        }
-
-        return ErrorStatus._UNAUTHORIZED;
     }
 }

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
@@ -1,28 +1,42 @@
 package umc.teumteum.server.global.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.Resource;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.exception.InvalidTokenTypeException;
+import umc.teumteum.server.global.exception.TokenBlacklistException;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService userDetailsService;
-    private final JwtAuthenticationEntryPoint authenticationEntryPoint;
+
+    @Resource(name = "atBlacklistRedisTemplate")
+    private RedisTemplate<String, String> atBlacklistRedisTemplate;
 
     // JWT 토큰 검증 및 인증 처리
     @Override
@@ -33,32 +47,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = resolveToken(request);
 
             if (token != null) {
-                // 2. 유효성 검증
-                jwtProvider.validateToken(token);
+                // 2. 액세스 토큰 유효성 검증
+                    jwtProvider.validateAccessToken(token);
 
-                // 3. 토큰에서 사용자 ID 추출
+                // 3. 토큰에서 사용자ID & 세션ID 추출
                 String userId = jwtProvider.getUserIdFromToken(token);
+                String sessionId = jwtProvider.getSessionIdFromToken(token);
 
-                // 4. UserDetails 로드
+                // 4. Redis 블랙리스트 확인 (있으면 -> 재로그인 필요)
+                String blacklistKey = String.format("AT_BLACKLIST:%s:%s", userId, sessionId);
+                if (atBlacklistRedisTemplate.hasKey(blacklistKey)) {
+                    log.error("블랙리스트된 토큰 접근 시도 - userId: {}, sessionId: {}", userId, sessionId);
+                    throw new TokenBlacklistException("블랙리스트된 토큰입니다.");
+                }
+
+                // 5. UserDetails 로드
                 UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
 
-                // 5. Authentication 객체 생성
+                // 6. Authentication 객체 생성
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
-                // 6. SecurityContext에 인증 정보 설정
+                // 7. SecurityContext에 인증 정보 설정
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-
-            filterChain.doFilter(request, response);
-
-        }
-        // AuthenticationEntryPoint에서 처리
-        catch (AuthenticationException e) {
-            authenticationEntryPoint.commence(request, response, e);
         } catch (Exception e) {
-            authenticationEntryPoint.commence(request, response, new BadCredentialsException("JWT 처리 중 오류가 발생했습니다.", e));
+            // 발생한 예외에 따라서 적절한 ErrorStatus 지정 (AuthenticationEntryPoint에서 처리)
+            ErrorStatus errorStatus = determineErrorStatus(e);
+            request.setAttribute("errorStatus", errorStatus);
         }
+
+        filterChain.doFilter(request, response);
     }
 
     // Authorization 헤더에서 JWT 토큰 추출
@@ -68,5 +87,37 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+
+    // 적절한 ErrorStatus 결정
+    private ErrorStatus determineErrorStatus(Exception ex) {
+        return switch (ex) {
+            // 유효하지 않은 토큰 타입(=refresh)에 대한 예외 (커스텀)
+            case InvalidTokenTypeException invalidType -> ErrorStatus.INVALID_TOKEN_TYPE;
+
+            // 유효하지 않은 AT 예외 (커스텀)
+            case TokenBlacklistException blacklist -> ErrorStatus.ACCESS_TOKEN_BLACKLISTED;
+
+            // 사용자 인증 과정 예외
+            case DisabledException disabled -> ErrorStatus.INACTIVE_USER;
+            case UsernameNotFoundException notFound -> ErrorStatus.USER_NOT_FOUND;
+
+            // JWT 토큰 검증 관련 예외
+            case BadCredentialsException badCreds -> {
+                // cause : 실제 원인이 되는 예외
+                Throwable cause = badCreds.getCause();
+                yield switch (cause) {
+                    case SecurityException sec -> ErrorStatus.INVALID_JWT_SIGNATURE;
+                    case MalformedJwtException mal -> ErrorStatus.MALFORMED_JWT_TOKEN;
+                    case ExpiredJwtException exp -> ErrorStatus.EXPIRED_JWT_TOKEN;
+                    case UnsupportedJwtException unsup -> ErrorStatus.UNSUPPORTED_JWT_TOKEN;
+                    case IllegalArgumentException illegal -> ErrorStatus.EMPTY_JWT_CLAIMS;
+                    default -> ErrorStatus._UNAUTHORIZED;
+                };
+            }
+
+            default -> ErrorStatus._UNAUTHORIZED;
+        };
     }
 }

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
@@ -1,16 +1,22 @@
 package umc.teumteum.server.global.jwt;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.stereotype.Component;
-import umc.teumteum.server.global.exception.InvalidTokenTypeException;
+    import io.jsonwebtoken.Claims;
+    import io.jsonwebtoken.ExpiredJwtException;
+    import io.jsonwebtoken.Jwts;
+    import io.jsonwebtoken.MalformedJwtException;
+    import io.jsonwebtoken.SignatureAlgorithm;
+    import io.jsonwebtoken.UnsupportedJwtException;
+    import io.jsonwebtoken.security.Keys;
+    import io.jsonwebtoken.security.SecurityException;
+    import jakarta.annotation.PostConstruct;
+    import org.springframework.beans.factory.annotation.Value;
+    import org.springframework.security.authentication.BadCredentialsException;
+    import org.springframework.stereotype.Component;
+    import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 
-import java.nio.charset.StandardCharsets;
-import java.security.Key;
-import java.util.Date;
+    import java.nio.charset.StandardCharsets;
+    import java.security.Key;
+    import java.util.Date;
 
 @Component
 public class JwtProvider {
@@ -32,21 +38,22 @@ public class JwtProvider {
     }
 
     // 액세스 토큰 생성
-    public String generateAccessToken(Long userId) {
-        return generateToken(userId, accessExpirationMs, "ACCESS");
+    public String generateAccessToken(Long userId, String sessionId) {
+        return generateToken(userId, sessionId, accessExpirationMs, "ACCESS");
     }
 
     // 리프레시 토큰 생성
-    public String generateRefreshToken(Long userId) {
-        return generateToken(userId, refreshExpirationMs, "REFRESH");
+    public String generateRefreshToken(Long userId, String sessionId) {
+        return generateToken(userId, sessionId, refreshExpirationMs, "REFRESH");
     }
 
     // 토큰 생성 (타입 구분)
-    private String generateToken(Long userId, long expiration, String tokenType) {
+    private String generateToken(Long userId, String sessionId, long expiration, String tokenType) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expiration);
         return Jwts.builder()
                 .setSubject(userId.toString())
+                .claim("sessionId", sessionId)
                 .claim("type", tokenType)   // ACCESS or REFRESH
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
@@ -55,8 +62,18 @@ public class JwtProvider {
                 ;
     }
 
+    // 액세스 토큰 유효성 검사
+    public void validateAccessToken(String token) {
+        validateToken(token, "ACCESS");
+    }
+
+    // 리프레시 토큰 유효성 검사
+    public void validateRefreshToken(String token) {
+        validateToken(token, "REFRESH");
+    }
+
     // 토큰 유효성 검사
-    public void validateToken(String token) {
+    public void validateToken(String token, String expectedType) {
         try {
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(key)
@@ -66,22 +83,22 @@ public class JwtProvider {
                     ;
 
             // 토큰 타입 확인
-            String tokenType = claims.get("type", String.class);
-            if (!("ACCESS".equals(tokenType))) {
-                throw new InvalidTokenTypeException("유효하지 않은 토큰 타입입니다.");
-            }
+                String tokenType = claims.get("type", String.class);
+                if (!(expectedType.equals(tokenType))) {
+                    throw new InvalidTokenTypeException("유효하지 않은 토큰 타입입니다.");
+                }
 
-        } catch (SecurityException e) {
-            throw new BadCredentialsException("유효하지 않은 JWT 서명입니다.", e);
-        } catch (MalformedJwtException e) {
-            throw new BadCredentialsException("손상된 JWT 토큰입니다.", e);
-        } catch (ExpiredJwtException e) {
-            throw new BadCredentialsException("만료된 JWT 토큰입니다.", e);
-        } catch (UnsupportedJwtException e) {
-            throw new BadCredentialsException("지원되지 않는 JWT 토큰입니다.", e);
-        } catch (IllegalArgumentException e) {
-            throw new BadCredentialsException("JWT 클레임이 비어있습니다.", e);
-        }
+            } catch (SecurityException e) {
+                throw new BadCredentialsException("유효하지 않은 JWT 서명입니다.", e);
+            } catch (MalformedJwtException e) {
+                throw new BadCredentialsException("손상된 JWT 토큰입니다.", e);
+            } catch (ExpiredJwtException e) {
+                throw new BadCredentialsException("만료된 JWT 토큰입니다.", e);
+            } catch (UnsupportedJwtException e) {
+                throw new BadCredentialsException("지원되지 않는 JWT 토큰입니다.", e);
+            } catch (IllegalArgumentException e) {
+                throw new BadCredentialsException("JWT 클레임이 비어있습니다.", e);
+            }
     }
 
     // 토큰에서 사용자 ID 추출
@@ -94,5 +111,17 @@ public class JwtProvider {
                 ;
 
         return claims.getSubject();
+    }
+
+    // 토큰에서 sessionId 추출
+    public String getSessionIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                ;
+
+        return claims.get("sessionId", String.class);
     }
 }

--- a/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/monitoring/service/InfraRedisServiceImpl.java
@@ -19,10 +19,10 @@ public class InfraRedisServiceImpl implements InfraRedisService {
   public InfraRedisServiceImpl(
       @Qualifier("notificationRedisTemplate") RedisTemplate<String, String> notifiactionRedisTemplate,
       @Qualifier("aiContentsRedisTemplate") RedisTemplate<String, String> aiContentsRedisTemplate,
-      @Qualifier("rtRedisTemplate") RedisTemplate<String, String> rtRedisTemplate) {
+      @Qualifier("rtWhitelistRedisTemplate") RedisTemplate<String, String> rtWhitelistRedisTemplate) {
     this.notifiactionRedisTemplate = notifiactionRedisTemplate;
     this.aiContentsRedisTemplate = aiContentsRedisTemplate;
-    this.rtRedisTemplate = rtRedisTemplate;
+    this.rtRedisTemplate = rtWhitelistRedisTemplate;
   }
 
 


### PR DESCRIPTION
### 👀 관련 이슈
#152

### ✨ 작업한 내용
- 토큰 재발급 API
- 기기별 RT 관리를 위해 JWT 클레임에 `sessionId` 추가
- AT 블랙리스트 추가
- Filter & EntryPoint 로직 수정

등을 진행하여 작업량이 많습니다. 😅
<br><br>

#### 1. 토큰 재발급 API 구현
- RTR 방식으로 토큰을 재발급

- `RequestBody로 받은 RT`와 `Redis에 저장된 RT`를 각각 유효성 검증
기존 유효성 검증 메소드가 Filter용이기 때문에, 던지는 예외 타입이 달라서 wrapper메소드를 두어 `AuthHandler`로 변환하여 던지도록 하였습니다.

- RT가 동일한지 확인 후, AT & RT 재발급
<br>

#### 2. JWT 클레임에 `sessionId` 추가
- 기기별 구분이 필요하여, JWT에 `sessionId`라 네이밍한 UUID를 저장

- 로그인 시, UUID를 발급 -> 토큰 재발급 시 동일한 UUID로 새로운 AT&RT 발급

- 다른 기기로 로그인한다면, 다른 UUID를 가지는 JWT 발급

따라서, 토큰 재발급 / 로그아웃을 진행하더라도 각 기기별로 RT가 관리되기 때문에 꼬이지 X
<br>

#### 3. AT 블랙리스트 추가
관련해서 구글링하던 중, 토큰 화이트리스트 / 블랙리스트 개념을 알게 되었는데요.
간단하게 다음과 같이 이해하였습니다.

> `화이트리스트` - 유효한 토큰을 저장해두고 비교 검증하는 방식 (현재 Redis RT 같은 방식)
`블랙리스트` - 반대로 허용하면 안되는 토큰을 저장해두고 비교 검증하는 방식

즉각적인 처리는 불가하지만, RT는 탈취상황이 발생하더라도 로그아웃 등으로 Redis의 데이터를 지운다면 이후 추가적인 토큰 재발급은 불가한 상황입니다. 하지만, 현재 AT의 경우 탈취상황이 발생한다면 만료하기 전까지 막을 방법이 없다고 생각하였고 `AT 블랙리스트`를 추가하게 되었습니다.

현재 `토큰 재발급 API`에서 `요청 RT != Redis RT`의 경우
> 1. RT 탈취 의심 로그를 출력
> 2. RT와 동일한 `sessionId`를 갖는 AT에 대해 Redis를 통해 블랙리스트에 추가
> 3. 해당 `sessionId`를 갖는 AT는 Filter 검증 시, 로그를 출력 & 예외 발생

과 같이 AT 블랙리스트가 쓰이도록 하였습니다.
로그아웃 API에서는 AT의 남은 만료시간만큼만 동일한`sessionId`를 갖는 AT를 Redis에 저장되도록 하려고 합니다.
<br>

#### 4. Filter & EntryPoint 로직 수정
기존에는 Filter에서 예외가 발생하면 catch하여 EntryPoint의 `commence()`를 직접 호출하는 방식이었습니다.
하지만, 해당 방식은 FilterChain 흐름을 벗어나서 예외를 처리하는 방식이라 생각했고,
`SecurityConfig`에서 다음과 같이 설정한 의미도 없어지는 방식이었습니다.
```
// 예외 처리
.exceptionHandling(exception ->
        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint)
)
```
<br>

관련해서 알게 된 바를 간단하게 정리하자면
> - JWT 커스텀 필터는 `인증` 필터이기 때문에 보통 다음처럼 순서를 설정
>   ```
>   .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
>   ```
> - `ExceptionTranslationFilter`라는 필터는 예외를 감지하여 EntryPoint의 `commence()`를 자동 호출하는 역할
> - But, `ExceptionTranslationFilter`는 자신보다 뒤에 위치한 필터에 대한 예외만 처리함
(JWT 커스텀 필터는 `ExceptionTranslationFilter`보다 앞에 위치)
<br>

즉, JWT 커스텀 필터에서 예외에 대해 처리하지 않으면 (catch X or 직접 `commence()` 호출 X)
필터가 중단되고 해당 예외는 `FilterChainProxy` -> `DelegatingFilterProxy` -> 서블릿 컨테이너에 의한 예외 처리
로 진행되는 거 같습니다.
<img width="800" height="600" alt="스크린샷 2025-08-09 오전 12 45 29" src="https://github.com/user-attachments/assets/d42c7e58-1f03-4be6-9b7d-df78371ba415" />

그래서 기존 EntryPoint의 `determineErrorStatus()`의 위치를 Filter로 옮기고
Filter에서 예외를 catch 한 다음 request에 `ErrorStatus`를 담도록 하였습니다.

이러면,
JWT 커스텀 필터에서 예외 발생으로 인해 인증 정보가 X (그렇다고 예외를 던지지는 않음)
-> But, 인증이 필요한 API이기 때문에 추후에 다른 필터에 의해 `ExceptionTranslationFilter`가 EntryPoint를 호출
-> request에 담겨있는 `ErrorStatus`를 통해서 예외를 구분하여 응답
같이 동작하게 됩니다.


### 🌀 PR Point
X

### 🍰 참고사항
- 기존에는 `commece()`를 직접 호출하기 때문에 Filter에서 발생하는 예외를 `BadCredentialsException`라는 `AuthenticationException`타입의 예외로 감싸주었는데, 로직이 변경되면서 불필요하다고 생각되어 추후 리팩토링하려 합니다!

- 보안 관련해서도 나름 생각해봤는데, 사용자가 로그아웃을 하면 나름 해결이 되겠지만
강제 종료 등 경우가 다양하기 때문에 해당 분야에 대해 모르는 입장에서는 추가적인 방법은 잘 모르겠습니다..

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
|  토큰 재발급 API  |  <img width="300" height="500" alt="스크린샷 2025-08-09 오전 12 37 10" src="https://github.com/user-attachments/assets/6b19ea89-b5da-46af-bcfc-fd64234369a2" />  |
|  REFRESH_TOKEN_MISMATCH  |  <img width="300" height="500" alt="스크린샷 2025-08-09 오전 12 38 14" src="https://github.com/user-attachments/assets/55ece36c-706f-45f1-a959-5df78d0d7848" />  |
|  ACCESS_TOKEN_BLACKLISTED  |  <img width="300" height="500" alt="스크린샷 2025-08-09 오전 12 39 50" src="https://github.com/user-attachments/assets/56b614c6-ed1e-4287-8f53-f47ab959ce3b" />  |
|  로그  |  <img width="500" height="100" alt="스크린샷 2025-08-09 오전 12 40 46" src="https://github.com/user-attachments/assets/0fc3ba13-7e9f-48ff-b6ac-d9e7e67b47c1" /> |



