### PR TITLE
Refactor: S3Util 사용 로직을 컨버터에서 서비스 계층으로 이동

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -22,51 +22,34 @@ public class FriendConverter {
     private final S3Util s3Util;
     private final TimeUtil timeUtil;
 
-    public FollowingUserResponseDto toFollowingUserResponse(Friend friend) {
+    public FollowingUserResponseDto toFollowingUserResponse(Friend friend, String profileImageUrl) {
         User following = friend.getFollowing();
-        String imageUrl = s3Util.toPresignedUrl("profile/" + following.getProfileImageName(), Duration.ofMinutes(30));
-
         return new FollowingUserResponseDto(
                 following.getId(),
                 following.getNickname(),
                 following.getJob(),
-                imageUrl,
+                profileImageUrl,
                 friend.getIsFavorite()
         );
     }
 
-    public List<FollowingUserResponseDto> toFollowingUserResponseList(List<Friend> friendList) {
-        return friendList.stream()
-                .map(this::toFollowingUserResponse)
-                .collect(Collectors.toList());
-    }
-
-    public FollowerUserResponseDto toFollowerUserResponse(Friend friend) {
+    public FollowerUserResponseDto toFollowerUserResponse(Friend friend, String profileImageUrl) {
         User follower = friend.getFollower();
-        String imageUrl = s3Util.toPresignedUrl("profile/" + follower.getProfileImageName(), Duration.ofMinutes(30));
-
         return new FollowerUserResponseDto(
                 follower.getId(),
                 follower.getNickname(),
                 follower.getJob(),
-                imageUrl
+                profileImageUrl
         );
     }
 
-    public List<FollowerUserResponseDto> toFollowerUserResponseList(List<Friend> friendList) {
-        return friendList.stream()
-                .map(this::toFollowerUserResponse)
-                .collect(Collectors.toList());
-    }
 
-    public FriendProfileResponseDto toFriendProfileResponse(User targetUser, Friend followRelation) {
-        String imageUrl = s3Util.toPresignedUrl("profile/" + targetUser.getProfileImageName(), Duration.ofMinutes(30));
-
+    public FriendProfileResponseDto toFriendProfileResponse(User targetUser, Friend followRelation, String profileImageUrl) {
         return FriendProfileResponseDto.builder()
                 .userId(targetUser.getId())
                 .name(targetUser.getNickname())
-                .profileImageUrl(imageUrl)
-                .field(targetUser.getJob()) // 또는 getField() 등
+                .profileImageUrl(profileImageUrl)
+                .field(targetUser.getJob())
                 .isFollowing(followRelation != null)
                 .isFavorite(followRelation != null && followRelation.getIsFavorite())
                 .build();

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -51,6 +51,10 @@ public class FriendServiceImpl implements FriendService {
     private static final Set<ScheduleStatus> TEUM_VALID_STATUSES =
             EnumSet.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
 
+    private String toProfileUrl(User user) {
+        if (user == null || user.getProfileImageName() == null) return null;
+        return s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
+    }
 
     @Override
     @Transactional
@@ -160,7 +164,10 @@ public class FriendServiceImpl implements FriendService {
         Slice<Friend> slice = friendRepository.findByFollowerId(userId, pageable);
 
         List<FollowingUserResponseDto> dtoList = slice.getContent().stream()
-                .map(friendConverter::toFollowingUserResponse)
+                .map(friend -> {
+                    String url = toProfileUrl(friend.getFollowing());
+                    return friendConverter.toFollowingUserResponse(friend, url);
+                })
                 .collect(Collectors.toList());
 
         return new PagingResponseDto<>(dtoList, slice.hasNext());
@@ -180,7 +187,10 @@ public class FriendServiceImpl implements FriendService {
         Slice<Friend> slice = friendRepository.findByFollowingId(userId, pageable);
 
         List<FollowerUserResponseDto> dtoList = slice.getContent().stream()
-                .map(friendConverter::toFollowerUserResponse)
+                .map(friend -> {
+                    String url = toProfileUrl(friend.getFollower());
+                    return friendConverter.toFollowerUserResponse(friend, url);
+                })
                 .collect(Collectors.toList());
 
         return new PagingResponseDto<>(dtoList, slice.hasNext());
@@ -194,7 +204,8 @@ public class FriendServiceImpl implements FriendService {
         Optional<Friend> followRelationOpt =
                 friendRepository.findByFollowerIdAndFollowingId(loginUserId, targetUser.getId());
 
-        return friendConverter.toFriendProfileResponse(targetUser, followRelationOpt.orElse(null));
+        String url = toProfileUrl(targetUser);
+        return friendConverter.toFriendProfileResponse(targetUser, followRelationOpt.orElse(null), url);
     }
 
     @Override

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -302,19 +302,23 @@ public class TeumConverter {
             boolean isResend,
             Map<Long, String> profileUrlByUserId
     ) {
+        // 요청 시간 정보를 TimeSlot 객체로 변환
         TimeSlot timeSlot = new TimeSlot(
                 request.getStartTime().toString(),
                 timeUtil.parseAndFormatEndTime(request.getEndTime())
         );
 
+        // 요청자 정보를 ParticipantDto로 변환
         ParticipantDto requester = toParticipantDto(request.getUser(),
                 profileUrlByUserId.get(request.getUser().getId()));
 
+        // 응답 상태별 참가자 리스트 초기화
         List<ParticipantDto> pending = new ArrayList<>();
         List<ParticipantDto> accepted = new ArrayList<>();
         List<ParticipantDto> cancelled = new ArrayList<>();
         List<ParticipantDto> resend = new ArrayList<>();
 
+        // 각 응답 상태에 맞게 수신자 분류
         for (TeumResponse response : request.getTeumResponses()) {
             ParticipantDto participant = toParticipantDto(response.getReceiverUser(),
                     profileUrlByUserId.get(response.getReceiverUser().getId()));
@@ -362,6 +366,7 @@ public class TeumConverter {
     }
 
 
+    // User 객체와 프로필 이미지 URL을 이용해 ParticipantDto를 생성
     private ParticipantDto toParticipantDto(User user, String profileImageUrl) {
         return ParticipantDto.builder()
                 .userId(user.getId())

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -20,7 +20,6 @@ import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.global.util.TimeUtil;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -28,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -71,7 +71,7 @@ public class TeumConverter {
                 .toList();
     }
 
-    public TeumReceivedResponseDto toReceivedResponseDto(TeumResponse response, S3Util s3Util) {
+    public TeumReceivedResponseDto toReceivedResponseDto(TeumResponse response, String senderProfileImageUrl) {
         TeumRequest request = response.getTeumRequest();
         User sender = request.getUser();
 
@@ -86,8 +86,7 @@ public class TeumConverter {
                 .senderUser(ParticipantDto.builder()
                         .userId(sender.getId())
                         .nickname(sender.getNickname())
-                        .profileImageUrl(s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(),
-                            Duration.ofMinutes(30)))
+                        .profileImageUrl(senderProfileImageUrl)
                         .build())
                 .date(request.getDate().toString())
                 .timeSlot(TimeSlot.builder()
@@ -97,12 +96,6 @@ public class TeumConverter {
                 .build();
     }
 
-
-    public List<TeumReceivedResponseDto> toReceivedResponseDtoList(List<TeumResponse> responses, S3Util s3Util) {
-        return responses.stream()
-                .map(response -> toReceivedResponseDto(response, s3Util))
-                .toList();
-    }
 
     public TeumRequest toResendTeumRequest(TeumRequest parent, TeumResendRequestDto dto, User resender) {
         return TeumRequest.builder()
@@ -259,7 +252,7 @@ public class TeumConverter {
     public ScheduledTeumDetailResponseDto toScheduledTeumDetailDto(
             Schedule baseSchedule,
             List<Schedule> relatedSchedules,
-            S3Util s3Util
+            Map<Long, String> profileUrlByUserId
     ) {
         return ScheduledTeumDetailResponseDto.builder()
                 .teumId(baseSchedule.getTeumRequest().getId())
@@ -271,8 +264,7 @@ public class TeumConverter {
                 .participants(relatedSchedules.stream()
                         .map(s -> {
                             var u = s.getUser();
-                            String presignedUrl = s3Util.toPresignedUrl("profile/" + u.getProfileImageName(), Duration.ofMinutes(30));
-                            return new ParticipantDto(u.getId(), u.getNickname(), presignedUrl);
+                            return new ParticipantDto(u.getId(), u.getNickname(), profileUrlByUserId.get(u.getId()));
                         })
                         .collect(Collectors.toList()))
                 .build();
@@ -307,31 +299,30 @@ public class TeumConverter {
     public TeumRequestResponseDto toTeumRequestResponseDto(
             TeumRequest request,
             boolean isCancelled,
-            boolean isResend
+            boolean isResend,
+            Map<Long, String> profileUrlByUserId
     ) {
-        // 시간 정보 구성
         TimeSlot timeSlot = new TimeSlot(
                 request.getStartTime().toString(),
                 timeUtil.parseAndFormatEndTime(request.getEndTime())
         );
 
-        // 요청자 정보 생성
-        ParticipantDto requester = toParticipantDto(request.getUser());
+        ParticipantDto requester = toParticipantDto(request.getUser(),
+                profileUrlByUserId.get(request.getUser().getId()));
 
-        // 응답자 상태별 분류
         List<ParticipantDto> pending = new ArrayList<>();
         List<ParticipantDto> accepted = new ArrayList<>();
         List<ParticipantDto> cancelled = new ArrayList<>();
         List<ParticipantDto> resend = new ArrayList<>();
 
         for (TeumResponse response : request.getTeumResponses()) {
-            ParticipantDto participant = toParticipantDto(response.getReceiverUser());
+            ParticipantDto participant = toParticipantDto(response.getReceiverUser(),
+                    profileUrlByUserId.get(response.getReceiverUser().getId()));
 
-            // 응답 상태에 따라 분류
             switch (response.getStatus()) {
                 case PENDING -> pending.add(participant);
                 case ACCEPTED -> accepted.add(participant);
-                case REJECTED, LEFT -> cancelled.add(participant);  // 거절과 취소는 모두 취소 처리
+                case REJECTED, LEFT -> cancelled.add(participant);
                 case RESEND -> resend.add(participant);
             }
         }
@@ -353,7 +344,7 @@ public class TeumConverter {
     }
 
 
-    public SharedTeumListResponseDto toSharedTeumListDto(Schedule schedule, Long loginUserId) {
+    public SharedTeumListResponseDto toSharedTeumListDto(Schedule schedule, Long loginUserId, String senderProfileImageUrl) {
         TeumRequest request = schedule.getTeumRequest();
         User sender = request.getUser();
 
@@ -365,22 +356,17 @@ public class TeumConverter {
                         schedule.getStartTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
                         timeUtil.parseAndFormatEndTime(schedule.getEndTime().toLocalTime())
                 ))
-                .sender(toParticipantDto(sender))
+                .sender(toParticipantDto(sender, senderProfileImageUrl))
                 .isSender(sender.getId().equals(loginUserId))
                 .build();
     }
 
 
-    private ParticipantDto toParticipantDto(User user) {
-        String presignedUrl = s3Util.toPresignedUrl(
-                "profile/" + user.getProfileImageName(),
-                Duration.ofMinutes(30)
-        );
-
+    private ParticipantDto toParticipantDto(User user, String profileImageUrl) {
         return ParticipantDto.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
-                .profileImageUrl(presignedUrl)
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -54,6 +54,11 @@ public class TeumServiceImpl implements TeumService {
     private final TeumConverter teumConverter;
     private final TimeUtil timeUtil;
 
+    private String toProfileUrl(User user) {
+        if (user == null || user.getProfileImageName() == null) return null;
+        return s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
+    }
+
     @Override
     @Transactional
     public Long createRequest(TeumRequestDto dto, User user) {
@@ -147,9 +152,7 @@ public class TeumServiceImpl implements TeumService {
         List<TeumReceivedResponseDto> dtoList = pageData.getContent().stream()
                 .map(response -> {
                     User sender = response.getTeumRequest().getUser();
-                    String url = (sender == null || sender.getProfileImageName() == null)
-                            ? null
-                            : s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(), Duration.ofMinutes(30));
+                    String url = toProfileUrl(sender); // CHANGED: 헬퍼 사용
                     return teumConverter.toReceivedResponseDto(response, url);
                 })
                 .toList();
@@ -291,9 +294,7 @@ public class TeumServiceImpl implements TeumService {
                 .map(Schedule::getUser)
                 .collect(Collectors.toMap(
                         User::getId,
-                        u -> (u == null || u.getProfileImageName() == null)
-                                ? null
-                                : s3Util.toPresignedUrl("profile/" + u.getProfileImageName(), Duration.ofMinutes(30)),
+                        this::toProfileUrl,
                         (a, b) -> a
                 ));
 
@@ -454,9 +455,7 @@ public class TeumServiceImpl implements TeumService {
         List<SharedTeumListResponseDto> content = slice.getContent().stream()
                 .map(s -> {
                     User sender = s.getTeumRequest().getUser();
-                    String url = (sender == null || sender.getProfileImageName() == null)
-                            ? null
-                            : s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(), Duration.ofMinutes(30));
+                    String url = toProfileUrl(sender);
                     return teumConverter.toSharedTeumListDto(s, loginUserId, url);
                 })
                 .toList();
@@ -483,16 +482,11 @@ public class TeumServiceImpl implements TeumService {
                     // 요청자 + 응답자 전원의 URL 맵 구성
                     Map<Long, String> urlMap = new HashMap<>();
                     User requester = req.getUser();
-                    if (requester != null && requester.getProfileImageName() != null) {
-                        urlMap.put(requester.getId(),
-                                s3Util.toPresignedUrl("profile/" + requester.getProfileImageName(), Duration.ofMinutes(30)));
-                    }
+                    urlMap.put(requester.getId(), toProfileUrl(requester));
+
                     req.getTeumResponses().forEach(r -> {
                         User recv = r.getReceiverUser();
-                        if (recv != null && recv.getProfileImageName() != null) {
-                            urlMap.putIfAbsent(recv.getId(),
-                                    s3Util.toPresignedUrl("profile/" + recv.getProfileImageName(), Duration.ofMinutes(30)));
-                        }
+                        urlMap.putIfAbsent(recv.getId(), toProfileUrl(recv));
                     });
 
                     // DTO로 변환

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -152,7 +152,7 @@ public class TeumServiceImpl implements TeumService {
         List<TeumReceivedResponseDto> dtoList = pageData.getContent().stream()
                 .map(response -> {
                     User sender = response.getTeumRequest().getUser();
-                    String url = toProfileUrl(sender); // CHANGED: 헬퍼 사용
+                    String url = toProfileUrl(sender);
                     return teumConverter.toReceivedResponseDto(response, url);
                 })
                 .toList();

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -38,6 +38,7 @@ import umc.teumteum.server.global.validator.ConflictValidator;
 
 import java.time.*;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -144,7 +145,13 @@ public class TeumServiceImpl implements TeumService {
         );
 
         List<TeumReceivedResponseDto> dtoList = pageData.getContent().stream()
-                .map(response -> teumConverter.toReceivedResponseDto(response, s3Util))
+                .map(response -> {
+                    User sender = response.getTeumRequest().getUser();
+                    String url = (sender == null || sender.getProfileImageName() == null)
+                            ? null
+                            : s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(), Duration.ofMinutes(30));
+                    return teumConverter.toReceivedResponseDto(response, url);
+                })
                 .toList();
 
         return new PageImpl<>(dtoList, pageable, pageData.getTotalElements());
@@ -280,7 +287,17 @@ public class TeumServiceImpl implements TeumService {
                 List.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
         );
 
-        return teumConverter.toScheduledTeumDetailDto(schedule, relatedSchedules, s3Util);
+        Map<Long, String> profileUrlByUserId = relatedSchedules.stream()
+                .map(Schedule::getUser)
+                .collect(Collectors.toMap(
+                        User::getId,
+                        u -> (u == null || u.getProfileImageName() == null)
+                                ? null
+                                : s3Util.toPresignedUrl("profile/" + u.getProfileImageName(), Duration.ofMinutes(30)),
+                        (a, b) -> a
+                ));
+
+        return teumConverter.toScheduledTeumDetailDto(schedule, relatedSchedules, profileUrlByUserId);
     }
 
     @Override
@@ -435,7 +452,13 @@ public class TeumServiceImpl implements TeumService {
         );
 
         List<SharedTeumListResponseDto> content = slice.getContent().stream()
-                .map(s -> teumConverter.toSharedTeumListDto(s, loginUserId))
+                .map(s -> {
+                    User sender = s.getTeumRequest().getUser();
+                    String url = (sender == null || sender.getProfileImageName() == null)
+                            ? null
+                            : s3Util.toPresignedUrl("profile/" + sender.getProfileImageName(), Duration.ofMinutes(30));
+                    return teumConverter.toSharedTeumListDto(s, loginUserId, url);
+                })
                 .toList();
 
         return new PagingResponseDto<>(content, slice.hasNext());
@@ -457,11 +480,27 @@ public class TeumServiceImpl implements TeumService {
                     // 약속 취소 여부 판단
                     boolean isCancelled = isTeumCancelled(req);
 
+                    // 요청자 + 응답자 전원의 URL 맵 구성
+                    Map<Long, String> urlMap = new HashMap<>();
+                    User requester = req.getUser();
+                    if (requester != null && requester.getProfileImageName() != null) {
+                        urlMap.put(requester.getId(),
+                                s3Util.toPresignedUrl("profile/" + requester.getProfileImageName(), Duration.ofMinutes(30)));
+                    }
+                    req.getTeumResponses().forEach(r -> {
+                        User recv = r.getReceiverUser();
+                        if (recv != null && recv.getProfileImageName() != null) {
+                            urlMap.putIfAbsent(recv.getId(),
+                                    s3Util.toPresignedUrl("profile/" + recv.getProfileImageName(), Duration.ofMinutes(30)));
+                        }
+                    });
+
                     // DTO로 변환
-                    return teumConverter.toTeumRequestResponseDto(req, isCancelled, isResend);
+                    return teumConverter.toTeumRequestResponseDto(req, isCancelled, isResend, urlMap);
                 })
                 .toList();
     }
+
 
     // 사용자가 해당 요청의 요청자 또는 응답자인지 여부
     private boolean isParticipant(TeumRequest req, Long userId) {


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#166 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 컨버터에서 S3Util 사용 로직 제거
  - TeumConverter, FriendConverter에서 S3Util 필드 및 presigned URL 생성 로직 삭제
  - URL 생성 파라미터를 서비스에서 전달받도록 메서드 시그니처 변경
- 서비스 계층에서 S3Util 호출하도록 변경
  - TeumServiceImpl, FriendServiceImpl에서 presigned URL 생성 처리 후 컨버터에 전달

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- NotificationServiceImpl 구조를 참고하여 구현

### 📷 스크린샷 또는 GIF

- 서비스 계층에서 URL 생성 후 컨버터에 넘기는 구조로 변경된 부분이 정상적으로 동작하는지 확인함