### PR TITLE
Feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -4,16 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 import umc.teumteum.server.domain.auth.exception.status.AuthSuccessStatus;
 import umc.teumteum.server.domain.auth.service.AuthService;
-import umc.teumteum.server.domain.user.entity.User;
-import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -49,7 +47,7 @@ public class AuthController {
             description = "리프레시 토큰을 사용하여 새로운 액세스 토큰&리프레시 토큰을 발급받습니다."
     )
     @PostMapping(value = "/reissue", produces = "application/json")
-    public ApiResponse<Object> reissueToken(
+    public ApiResponse<AuthResponseDTO.ReissueResponse> reissueToken(
             @Valid @RequestBody AuthRequestDTO.ReissueRequest request
     ) {
         AuthResponseDTO.ReissueResponse response = authService.reissueToken(request);
@@ -57,10 +55,15 @@ public class AuthController {
     }
 
 
-//    @GetMapping(value = "/test/jwt", produces = "application/json")
-//    public ApiResponse<Long> getUser(
-//            @CurrentUser @Parameter(hidden = true) User user
-//    ) {
-//        return ApiResponse.onSuccess(user.getId());
-//    }
+    @Operation(
+            summary = "로그아웃",
+            description = "AT는 블랙리스트 등록 / RT는 화이트리스트 삭제를 진행합니다."
+    )
+    @PostMapping(value = "/logout", produces = "application/json")
+    public ApiResponse<Object> logout(
+            HttpServletRequest httpServletRequest
+    ) {
+        authService.logout(httpServletRequest);
+        return ApiResponse.of(AuthSuccessStatus.LOGOUT_SUCCESS, null);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthSuccessStatus.java
@@ -13,6 +13,8 @@ public enum AuthSuccessStatus implements BaseCode {
     SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 완료되었습니다."),
     DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다."),
     TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2003", "토큰 재발급이 완료되었습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2004", "로그아웃이 완료되었습니다."),
+
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.domain.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import umc.teumteum.server.domain.auth.dto.AuthRequestDTO;
 import umc.teumteum.server.domain.auth.dto.AuthResponseDTO;
 
@@ -9,4 +10,6 @@ public interface AuthService {
     AuthResponseDTO.DevTokenResponse generateDevAccessToken();
 
     AuthResponseDTO.ReissueResponse reissueToken(AuthRequestDTO.ReissueRequest request);
+
+    void logout(HttpServletRequest httpServletRequest);
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,7 +62,7 @@ public class AuthServiceImpl implements AuthService {
     @Value("${jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
 
-
+    // 인증 - 소셜로그인
     @Override
     @Transactional
     public AuthResponseDTO.LoginResponse socialLogin(String socialType, AuthRequestDTO.SocialLoginRequest request) {
@@ -122,6 +123,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
 
+    // 인증 - 개발용 토큰 발급
     @Override
     @Transactional
     public AuthResponseDTO.DevTokenResponse generateDevAccessToken() {
@@ -143,6 +145,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
 
+    // 인증 - 토큰 재발급
     @Override
     public AuthResponseDTO.ReissueResponse reissueToken(AuthRequestDTO.ReissueRequest request) {
         String refreshKey = null;
@@ -168,7 +171,7 @@ public class AuthServiceImpl implements AuthService {
 
             // 5. 요청받은 RT와 Redis에 저장된 RT 비교 (불일치 -> 재로그인 필요)
             if (!refreshToken.equals(storedRefreshToken)) {
-                log.warn("토큰 탈취 의심 - userId: {}, sessionId: {}", userId, sessionId);
+                log.warn("[토큰 탈취 의심] : 요청 RT != Redis RT - userId: {}, sessionId: {}", userId, sessionId);
                 
                 // 동일한 sessionID를 갖는 AT 블랙리스트 등록
                 String blacklistKey = getBlacklistKey(userId, sessionId);
@@ -200,6 +203,26 @@ public class AuthServiceImpl implements AuthService {
     }
 
 
+    // 인증 - 로그아웃
+    @Override
+    public void logout(HttpServletRequest httpServletRequest) {
+        // 1. Authorization 헤더의 AT로 userId & sessionId 추출
+        String accessToken = jwtProvider.resolveToken(httpServletRequest);
+        String userId = jwtProvider.getUserIdFromToken(accessToken);
+        String sessionId = jwtProvider.getSessionIdFromToken(accessToken);
+
+        // 2. RT 화이트리스트 삭제
+        String refreshKey = getRefreshKey(userId, sessionId);
+        rtWhitelistRedisTemplate.delete(refreshKey);
+
+        // 3. AT 블랙리스트 등록 (남은 시간만큼)
+        String blacklistKey = getBlacklistKey(userId, sessionId);
+        long remainingTime = jwtProvider.getRemainingTime(accessToken);
+        if (remainingTime > 0) {
+            Duration blacklistDuration = Duration.ofMillis(remainingTime);
+            atBlacklistRedisTemplate.opsForValue().set(blacklistKey, "blacklisted", blacklistDuration);
+        }
+    }
 
 
     // SocialType 따라 로그인 분기 처리

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtAuthenticationFilter.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.exception.InvalidTokenTypeException;
@@ -44,7 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
             // 1. Authorization 헤더에서 JWT 토큰 추출
-            String token = resolveToken(request);
+            String token = jwtProvider.resolveToken(request);
 
             if (token != null) {
                 // 2. 액세스 토큰 유효성 검증
@@ -78,15 +77,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    // Authorization 헤더에서 JWT 토큰 추출
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 
 

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
@@ -9,9 +9,11 @@ package umc.teumteum.server.global.jwt;
     import io.jsonwebtoken.security.Keys;
     import io.jsonwebtoken.security.SecurityException;
     import jakarta.annotation.PostConstruct;
+    import jakarta.servlet.http.HttpServletRequest;
     import org.springframework.beans.factory.annotation.Value;
     import org.springframework.security.authentication.BadCredentialsException;
     import org.springframework.stereotype.Component;
+    import org.springframework.util.StringUtils;
     import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 
     import java.nio.charset.StandardCharsets;
@@ -35,6 +37,15 @@ public class JwtProvider {
     @PostConstruct
     public void init() {
         key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Authorization 헤더에서 JWT 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
     // 액세스 토큰 생성
@@ -123,5 +134,21 @@ public class JwtProvider {
                 ;
 
         return claims.get("sessionId", String.class);
+    }
+
+    // 토큰 남은 유효시간 계산
+    public long getRemainingTime(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                ;
+
+        Date expiration = claims.getExpiration();
+        Date now = new Date();
+
+        long remainingTime = expiration.getTime() - now.getTime();
+        return Math.max(0, remainingTime);
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#165

### ✨ 작업한 내용
이슈에서 고민한 내용과 다현님의 피드백 종합
- `Filter`와 `Resolver`에 의한 총 2번의 DB 조회는 유지
- 현재 기준 `sessionId`는 로그아웃 API에서만 필요하기 때문에, `CustomUserDetails`까지는 사용 X
대신 RT를 Requset Body로 받으려하였으나, Header에 유효한 AT가 존재하는 상황에서 이 또한 애매하다고 생각되어 X
<br>

구현 내용
- AT와 RT는 `userId`와 `sessionId`를 공유하기 때문에, AT만으로 RT 화이트리스트 삭제
- 해당 AT의 남은 만료시간만큼만 AT 블랙리스트 등록


### 🌀 PR Point
X

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
|  로그아웃 API  |  <img width="353" height="523" alt="스크린샷 2025-08-11 오후 2 50 22" src="https://github.com/user-attachments/assets/117d21cf-dc5f-41fd-9f83-f1c45a3d6100" />  |

