### PR TITLE
Feat: 틈 시작 시간 경과 시 자동 완료 처리하는 스케줄러 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -98,8 +98,13 @@ public class Schedule extends BaseEntity {
         this.status = ScheduleStatus.CANCELLED;
     }
 
+    public void complete() {
+        this.status = ScheduleStatus.COMPLETED;
+    }
+
     // 루틴 삭제 처리
     public void setIsDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -12,6 +12,8 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -293,6 +295,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("type") ScheduleType type,
             @Param("status") ScheduleStatus status,
             Pageable pageable
+    );
+
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.type = :type
+      AND s.status = :status
+      AND s.isDeleted = false
+      AND s.startTime <= :now
+""")
+    List<Schedule> findAllExpiredActiveTeums(
+            @Param("now") LocalDateTime now,
+            @Param("type") ScheduleType type,
+            @Param("status") ScheduleStatus status
     );
 
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/TeumStatusScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/TeumStatusScheduler.java
@@ -1,0 +1,41 @@
+package umc.teumteum.server.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
+import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TeumStatusScheduler {
+
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    @Scheduled(fixedRate = 300000)
+    public void completeExpiredTeumSchedules() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Schedule> targets = scheduleRepository.findAllExpiredActiveTeums(
+                now,
+                ScheduleType.TEUM,
+                ScheduleStatus.ACTIVE
+        );
+        if (targets.isEmpty()) return;
+
+        targets.forEach(s -> {
+            s.complete();
+            log.info("Schedule {} marked as COMPLETED", s.getId());
+        });
+
+        scheduleRepository.saveAll(targets);
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#179 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 5분마다 TEUM 스케줄 상태를 확인하는 스케줄러 실행
- 시작 시간이 현재 시각보다 지난 ACTIVE 상태의 스케줄을 COMPLETED로 변경

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- Redis를 쓰는 걸 고려하고 있었는데, 프론트에서 지금 연동한 API에서 완료된 스케줄을 확인할 필요가 있다고 하여 우선 빠르게 스케줄러 구현했습니다.
- 틈의 시간 단위가 10분 단위기 때문에 스케줄러를 5분마다 돌리는 것으로 충분하다고 생각하여 5분 단위로 구현하였습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|스케줄러 실행 결과|<img width="1065" height="88" alt="image" src="https://github.com/user-attachments/assets/0ce067d4-a25e-4d45-a8b2-3fc05dc8c119" />|
> 가장 마지막이 updated_at 으로 서버 실행 후 5분이 지난 뒤 틈 상태가 COMPLETED로 변경되는 것을 확인했습니다.