### PR TITLE
Fix: 약속된 틈을 취소한 사용자의 틈 응답 상태 변경

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -11,6 +11,7 @@ import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
 
@@ -40,5 +41,18 @@ public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long
             @Param("start") LocalDate start,
             @Param("end") LocalDate end
     );
+
+    @Query("""
+        SELECT r
+        FROM TeumResponse r
+        JOIN r.teumRequest tr
+        WHERE tr.id = :requestId
+          AND r.receiverUser.id = :receiverUserId
+""")
+    Optional<TeumResponse> findRequestAndReceiver(
+            @Param("requestId") Long requestId,
+            @Param("receiverUserId") Long receiverUserId
+    );
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -311,17 +311,22 @@ public class TeumServiceImpl implements TeumService {
             throw new GeneralException(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND);
         }
 
-        // 본인 스케줄을 CANCELLED 처리
+        // 본인 스케줄만 취소
         schedule.cancel();
+
+        // 본인 응답만 LEFT로 (상대는 그대로)
+        teumResponseRepository.findRequestAndReceiver(request.getId(), userId)
+                .ifPresent(r -> r.changeStatus(ResponseStatus.LEFT));
+
         List<Long> cancelledUserIds = new ArrayList<>();
         cancelledUserIds.add(userId);
 
-        // 해당 틈 요청과 연결된 다른 ACTIVE 스케줄이 있는지 조회
+        // 같은 요청에 다른 ACTIVE 스케줄 조회
         List<Schedule> activeSchedules = scheduleRepository.findByTeumRequestAndStatusIn(
                 request, List.of(ScheduleStatus.ACTIVE)
         );
 
-        // 한 명만 남아 있다면, 그 사람 스케줄도 같이 취소
+        // 한 명만 남아 있다면, 그 사람 스케줄도 같이 취소 (응답 상태는 변경 없음)
         if (activeSchedules.size() == 1) {
             Schedule lastOne = activeSchedules.getFirst();
             lastOne.cancel();
@@ -332,6 +337,7 @@ public class TeumServiceImpl implements TeumService {
                 .cancelledUserIds(cancelledUserIds)
                 .build();
     }
+
 
     // 공통 가능한 시간대 계산
     @Override


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#187 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 약속된 틈을 취소한 사용자의 `TeumResponse` 상태를 `LEFT`로 변경
- 기존에는 `Schedule` 상태만 `CANCELLED`로 변경됨
- 강제 취소된 사용자의 응답 상태는 변경하지 않음

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 약속된 틈 취소 시 `Schedule`
  - 참가자가 2명일 경우 → 양쪽 모두 `Schedule`은 `CANCELLED` 처리
  - 2명 이상일 경우 → 본인의 `Schedule`만 `CANCELLED` 처리
- 응답 상태(`TeumResponse.status`) 변경은 취소한 본인만 `LEFT`로 변경
- 이 로직은 특정 날짜의 틈 요청 조회 API에서  
  강제 취소된 사용자를 ‘승인(ACCEPTED)’ 상태로 표시하기 위함

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|약속된 틈 취소|<img width="1184" height="299" alt="image" src="https://github.com/user-attachments/assets/9e4a6813-ad48-4d08-b78e-50348b534a18" />|
|틈 요청 조회|<img width="1185" height="561" alt="image" src="https://github.com/user-attachments/assets/db2dd295-6a9d-4dec-9c4c-0928d24d7c60" />|
|틈 응답 상태|<img width="1247" height="74" alt="image" src="https://github.com/user-attachments/assets/81a92d10-f344-43c7-8d3e-320582ceca53" />|

#### 특정 날짜의 틈 요청 조회
```json
  "cancelled": [
    {
      "userId": 1,
      "nickname": "1",
      "profileImageUrl": "https://teumteum..."
    }
```
> 기존에는 accepted에 포함되었던 유저1이 cancelled에 포함되는 것 확인