### PR TITLE
Fix: 종료시간이 00:00인 TeumRequest 충돌 검사 보정

### DIFF
--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -92,6 +92,11 @@ public class ConflictValidator {
             LocalDateTime teumStart = LocalDateTime.of(request.getDate(), request.getStartTime());
             LocalDateTime teumEnd = LocalDateTime.of(request.getDate(), request.getEndTime());
 
+            // 종료시간이 00:00이면 익일 00:00으로 보정
+            if (request.getEndTime().equals(LocalTime.MIDNIGHT)) {
+                teumEnd = teumEnd.plusDays(1);
+            }
+
             if (isOverlapping(requestStart, requestEnd, teumStart, teumEnd)) {
                 throw new GeneralException(ConflictErrorStatus.TEUM_REQUEST_CONFLICT);
             }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#191 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `endTime`이 00:00인 경우 익일 00:00으로 처리하도록 수정
- 종료 시간이 자정인 요청(예:23:00→00:00)의 겹침이 정상적으로 감지되도록 함

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- `checkWithTeumRequests` 내부에서 자정 보정 로직 적용

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|틈 요청 충돌 처리|<img width="1169" height="244" alt="image" src="https://github.com/user-attachments/assets/068738af-a22e-4980-8120-e58b6dec6234" />|
- 09-10 23:00 ~ 00:00의 틈 요청이 존재하는 상태에서 아래의 틈 요청을 넣었을 때의 결과
```json
{
  "title": "운동하기",
  "description": "헬스장 가자",
  "date": "2025-09-10",
  "startTime": "23:00",
  "endTime": "23:30",
  "graphicId": 1,
  "receiverUserIds": [
    2
  ]
}
```
- 투두 등록도 동일한 결과 확인