### PR TITLE
Fix: 공통 가능시간대 조회에 틈 요청 반영

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
@@ -14,7 +14,7 @@ public class TeumRequestDto {
 
     @Getter
     @NoArgsConstructor
-    @Schema(title = "TeumAvailableTime : 공통 가능 시간 요청")
+    @Schema(name = "TeumAvailableTimeRequest", title = "공통 가능 시간 요청")
     public static class TeumAvailableTime {
 
         @Schema(description = "참여자 ID 목록 (요청자는 자동 포함됨)", example = "[1, 2, 3]")

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -21,7 +21,7 @@ public class TeumResponseDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    @Schema(title = "TeumAvailableTime : 공통 가능 시간 응답")
+    @Schema(name = "TeumAvailableTimeResponse", title = "공통 가능 시간 응답")
     public static class TeumAvailableTime {
 
         @Schema(description = "날짜", example = "2025-07-14")

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -366,6 +366,14 @@ public class TeumServiceImpl implements TeumService {
                     .filter(Objects::nonNull)
                     .forEach(scheduledSlots::add);
 
+            // 틈 요청
+            List<TeumRequest> teumRequests = teumRequestRepository.findTeumRequestsByUserAndDate(targetUser, date);
+            for (TeumRequest tr : teumRequests) {
+                String start = tr.getStartTime().toString();
+                String end = tr.getEndTime().equals(LocalTime.MIDNIGHT) ? "24:00" : tr.getEndTime().toString();
+                scheduledSlots.add(new TimeSlot(start, end));
+            }
+
             // 수면 시간
             LocalTime sleep = targetUser.getSleepTime();
             LocalTime wake = targetUser.getWakeTime();

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -31,6 +31,7 @@ import umc.teumteum.server.global.util.TimeUtil;
 import umc.teumteum.server.global.validator.ConflictValidator;
 
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -370,7 +371,7 @@ public class TeumServiceImpl implements TeumService {
             List<TeumRequest> teumRequests = teumRequestRepository.findTeumRequestsByUserAndDate(targetUser, date);
             for (TeumRequest tr : teumRequests) {
                 String start = tr.getStartTime().toString();
-                String end = tr.getEndTime().equals(LocalTime.MIDNIGHT) ? "24:00" : tr.getEndTime().toString();
+                String end   = timeUtil.formatEndTime(timeUtil.convertEndTime(tr.getEndTime()));
                 scheduledSlots.add(new TimeSlot(start, end));
             }
 
@@ -399,7 +400,7 @@ public class TeumServiceImpl implements TeumService {
                     if (!isRoutineDeleted) {
                         scheduledSlots.add(new TimeSlot(
                                 routine.getStartTime().toString(),
-                                routine.getEndTime().toString()
+                                timeUtil.formatEndTime(timeUtil.convertEndTime(routine.getEndTime()))
                         ));
                     }
                 }
@@ -415,6 +416,10 @@ public class TeumServiceImpl implements TeumService {
         sortedAvailable.sort(Comparator.comparing(slot -> timeUtil.parseTimeForSort(slot.getStart())));
 
         return new TeumResponseDto.TeumAvailableTime(date.toString(), sortedAvailable);
+    }
+
+    private String formatEnd(LocalTime t) {
+        return t.equals(LocalTime.MIDNIGHT) ? "24:00" : t.format(DateTimeFormatter.ofPattern("HH:mm"));
     }
 
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#193 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- `getAvailableTime` 로직에서 TeumRequest를 바쁜 시간대로 포함
- 대상 날짜의 ACTIVE 상태이며 관련 스케줄이 없는 틈 요청만 포함
- 충돌 처리에 사용 중인 `findTeumRequestsByUserAndDate` 쿼리 재사용

#### 자정 처리
- 틈 요청을 추가하면서 반복일정의 자정처리가 제대로 되지 않는다는 걸 깨달아서 같이 수정했습니다!

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

#### 틈 요청이 존재하는 경우 (12:00 ~ 13:30)
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-09-10",
    "availableTime": [
      {
        "start": "00:00",
        "end": "12:00"
      },
      {
        "start": "13:30",
        "end": "24:00"
      }
    ]
  }
}
```

#### 틈 요청을 수락했다가 취소한 경우
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-09-10",
    "availableTime": [
      {
        "start": "00:00",
        "end": "24:00"
      }
    ]
  }
}
```
> 틈은 ACTIVE여야 하고 틈 요청은 연결된 스케줄이 없어야 하기 때문에 바쁜 시간대로 처리 Xx

#### 반복 일정 자정 처리
```json
{
  "isSuccess": true,
  "code": "TEUM2011",
  "message": "공통 가능한 시간대가 조회되었습니다.",
  "result": {
    "date": "2025-08-13",
    "availableTime": [
      {
        "start": "00:00",
        "end": "23:00"
      }
    ]
  }
}
```
> 23:00 ~ 00:00 의 반복 일정이 있는 경우

+) 스웨거에 요청/응답도 제대로 뜨도록 수정함
<img width="574" alt="image" src="https://github.com/user-attachments/assets/e376b4db-470f-440b-9ed0-575d29830124"/>
