### PR TITLE
Fix : 투두리스트 조회 약속된 틈 조회

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -351,6 +351,12 @@ public class HomeServiceImpl implements HomeService {
         List<Schedule> schedules = scheduleRepository.findSchedulesOnDate(user, today, tomorrow);
 
         for (Schedule schedule : schedules) {
+            // 삭제된 루틴 ->  표시 X
+            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+
+            // 취소된 틈 -> 표시 X
+            if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;
+
             // 시작날짜가 어제인 경우
             LocalTime start = schedule.getStartTime().isBefore(today)?
                     LocalTime.MIDNIGHT : schedule.getStartTime().toLocalTime();
@@ -502,7 +508,11 @@ public class HomeServiceImpl implements HomeService {
             LocalDate date = schedule.getDate();
             // 3-1. 삭제된 루틴 ->  표시 X
             if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
-            // 3-2. 일정 등록
+
+            // 3-2. 취소된 틈 -> 표시 X
+            if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;
+
+            // 3-3. 일정 등록
             calendarMap.put(date, true);
         }
 
@@ -558,9 +568,10 @@ public class HomeServiceImpl implements HomeService {
         // 1. 해당 날짜의 모든 스케줄 조회
         List<Schedule> allSchedules = scheduleRepository.findByUserAndDate(user,date);
 
-        // 2. 삭제되지 않은 스케줄 필터링
+        // 2. 삭제되지 않은 스케줄 필터링 & 삭제된 틈 필터링
         List<Schedule> validSchedules = allSchedules.stream()
                 .filter(s -> !s.getIsDeleted())
+                .filter(s -> !s.getStatus().equals(ScheduleStatus.CANCELLED))
                 .toList();
 
         // 3. 알림 상태 판단을 위해,, ScheduleReminder 조회


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#206

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
캘린더, 투두리스트, 시간표 조회 시 취소된 틈까지 조회되는 문제가 발생해 취소된 경우 필터링하는 로직을 추가했습니다.
1. 투두리스트 조회 시 취소된 틈 필터링
2. 캘린더 조회 시 취소된 틈 필터링
3. 시간표 조회 시 취소된 팀 필터링
### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
1. GET /api/home/todolist?date={YYYY-MM-DD}
2. GET /api/home/calendar?startDate={YYYY-MM-DD}&endDate={YYYY-MM-DD}
3. GET /api/home/teum?date={YYYY-MM-DD}

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X