### PR TITLE
Fix: 현재 시각 이전에 대한 틈 요청 예외 처리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
@@ -40,17 +40,17 @@ public class TeumRequestDto {
 
         @NotBlank
         @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식은 YYYY-MM-DD이어야 합니다.")
-        @Schema(description = "날짜 (YYYY-MM-DD)", example = "YYYY-MM-DD")
+        @Schema(description = "날짜 (YYYY-MM-DD)", example = "2025-08-20")
         private String date;
 
         @NotBlank
         @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
-        @Schema(description = "시작 시간 (HH:MM)", example = "00:00")
+        @Schema(description = "시작 시간 (HH:MM)", example = "13:00")
         private String startTime;
 
         @NotBlank
         @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
-        @Schema(description = "종료 시간 (HH:MM)", example = "00:00")
+        @Schema(description = "종료 시간 (HH:MM)", example = "14:00")
         private String endTime;
 
         @NotNull
@@ -70,10 +70,12 @@ public class TeumRequestDto {
 
         @NotBlank
         @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
+        @Schema(description = "시작 시간 (HH:MM)", example = "13:00")
         private String startTime;
 
         @NotBlank
         @Pattern(regexp = "^\\d{2}:\\d{2}$", message = "시간 형식은 HH:MM이어야 합니다.")
+        @Schema(description = "종료 시간 (HH:MM)", example = "14:00")
         private String endTime;
 
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -68,6 +68,9 @@ public class TeumServiceImpl implements TeumService {
         LocalTime startTime = LocalTime.parse(dto.getStartTime());
         LocalTime endTime = LocalTime.parse(dto.getEndTime());
 
+        // 시작 시간이 현재 시각보다 과거인지 검증
+        validateStartTimeNotPast(date, startTime);
+
         // 모든 사용자 조회 (요청자 + 수신자)
         List<User> receivers = dto.getReceiverUserIds().stream()
                 .map(this::getUserOrThrow)
@@ -124,6 +127,9 @@ public class TeumServiceImpl implements TeumService {
         LocalDate date = parent.getDate();
         LocalTime startTime = LocalTime.parse(dto.getStartTime());
         LocalTime endTime = LocalTime.parse(dto.getEndTime());
+
+        // 시작 시간이 현재 시각보다 과거인지 검증
+        validateStartTimeNotPast(date, startTime);
 
         User originalSender = parent.getUser();  // 부모 요청의 작성자 → 이번 재요청의 수신자
 
@@ -675,5 +681,16 @@ public class TeumServiceImpl implements TeumService {
             throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
         }
     }
+
+    // 시작 시간이 현재 시각보다 과거인지 검증
+    private void validateStartTimeNotPast(LocalDate date, LocalTime startTime) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime requestStartDateTime = LocalDateTime.of(date, startTime);
+
+        if (requestStartDateTime.isBefore(now)) {
+            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        }
+    }
+
 
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#211 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 틈 요청(createRequest)과 재요청(createResendRequest) 시 시작 시간이 현재 시각보다 과거인 경우 예외 처리 추가
- validateStartTimeNotPast 메서드로 공통화하여 재사용 가능하도록 개선
- 예외 발생 시 TeumErrorStatus.INVALID_TEUM_TIME 반환

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 기존의 validateTimeOrder와 함께 동작 → 시간 순서 검증 + 현재 시각 검증 두 가지 조건 모두 충족해야 요청 가능
- 클라이언트에서는 잘못된 시간 입력 시 TEUM4001 코드로 분기 처리 필요

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|틈 요청|<img width="1248" height="901" alt="image" src="https://github.com/user-attachments/assets/d15aa376-4002-4a87-a4e3-6de027371be4" />|
|틈 요청 예외 처리|<img width="1187" height="249" alt="image" src="https://github.com/user-attachments/assets/e8d457a5-84a6-4ca1-83e5-7c4587e6b5b6" />|
|틈 재요청|<img width="1229" height="984" alt="image" src="https://github.com/user-attachments/assets/f87be3a4-cd2e-4b1a-aff4-7cd0734c5f2b" />|
|틈 재요청 예외 처리|<img width="1187" height="249" alt="image" src="https://github.com/user-attachments/assets/1c803dca-9f69-4850-a7ae-82267ddc1fae" />|