### PR TITLE
Fix: 재요청 원본 시간 반환

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -70,6 +70,24 @@ public class TeumConverter {
         TeumRequest request = response.getTeumRequest();
         User sender = request.getUser();
 
+        // 현재 요청의 시간
+        TimeSlot currentSlot = TimeSlot.builder()
+                .start(request.getStartTime().toString())
+                .end(timeUtil.parseAndFormatEndTime(request.getEndTime()))
+                .build();
+
+        // 부모 요청의 시간 (재요청일 때만)
+        TeumRequest parent = request.getParentRequest();
+        String originalDate = null;
+        TimeSlot originalSlot = null;
+        if (parent != null) {
+            originalDate = parent.getDate().toString();
+            originalSlot = TimeSlot.builder()
+                    .start(parent.getStartTime().toString())
+                    .end(timeUtil.parseAndFormatEndTime(parent.getEndTime()))
+                    .build();
+        }
+
         return TeumResponseDto.TeumReceived.builder()
                 .responseId(response.getId())
                 .requestId(request.getId())
@@ -84,11 +102,10 @@ public class TeumConverter {
                         .profileImageUrl(senderProfileImageUrl)
                         .build())
                 .date(request.getDate().toString())
-                .timeSlot(TimeSlot.builder()
-                        .start(request.getStartTime().toString())
-                        .end(timeUtil.parseAndFormatEndTime(request.getEndTime()))
-                        .build())
-                .isResend(request.getParentRequest() != null)
+                .timeSlot(currentSlot)
+                .isResend(parent != null)
+                .originalDate(originalDate)
+                .originalTimeSlot(originalSlot)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -184,7 +184,13 @@ public class TeumResponseDto {
         @Schema(description = "재요청 여부", example = "false")
         private boolean isResend;
 
+        @Schema(description = "원본 요청 날짜(재요청일 때만 값 존재)", example = "2025-07-10")
+        private String originalDate;
+
+        @Schema(description = "원본 요청 시간 구간(재요청일 때만 값 존재)")
+        private TimeSlot originalTimeSlot;
     }
+
 
     @Getter
     @Builder

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.teum.entity.TeumResponse;
+import umc.teumteum.server.domain.teum.entity.enums.RequestStatus;
+import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -15,20 +17,27 @@ import java.util.Optional;
 
 public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long> {
 
-    @EntityGraph(attributePaths = {"teumRequest", "teumRequest.user"})
+    @EntityGraph(attributePaths = {
+            "teumRequest",
+            "teumRequest.user",
+            "teumRequest.parentRequest"
+    })
     @Query("""
-    SELECT r FROM TeumResponse r
-    WHERE r.receiverUser.id = :userId
-      AND r.status = umc.teumteum.server.domain.teum.entity.enums.ResponseStatus.PENDING
-      AND r.teumRequest.status = umc.teumteum.server.domain.teum.entity.enums.RequestStatus.ACTIVE
-      AND (r.teumRequest.date > :today OR (r.teumRequest.date = :today AND r.teumRequest.startTime > :now))
-""")
+        SELECT r FROM TeumResponse r
+        WHERE r.receiverUser.id = :userId
+          AND r.status = :respStatus
+          AND r.teumRequest.status = :reqStatus
+          AND (r.teumRequest.date > :today OR (r.teumRequest.date = :today AND r.teumRequest.startTime > :now))
+    """)
     Page<TeumResponse> findValidPendingResponses(
             @Param("userId") Long userId,
             @Param("today") LocalDate today,
             @Param("now") LocalTime now,
+            @Param("respStatus") ResponseStatus respStatus,
+            @Param("reqStatus") RequestStatus reqStatus,
             Pageable pageable
     );
+
 
     @Query("""
         SELECT DISTINCT tr.date FROM TeumResponse r

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -168,7 +168,12 @@ public class TeumServiceImpl implements TeumService {
         Pageable pageable = PageRequest.of(pageIndex, size, sort);
 
         Page<TeumResponse> pageData = teumResponseRepository.findValidPendingResponses(
-                userId, LocalDate.now(), LocalTime.now(), pageable
+                userId,
+                LocalDate.now(),
+                LocalTime.now(),
+                ResponseStatus.PENDING,
+                RequestStatus.ACTIVE,
+                pageable
         );
 
         List<TeumResponseDto.TeumReceived> dtoList = pageData.getContent().stream()


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#213 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- TeumReceived DTO에 originalDate, originalTimeSlot 필드 추가
- Converter 수정: parentRequest가 존재할 경우 원본 요청 시간 내려주도록 처리
- EntityGraph에 teumRequest.parentRequest 추가
- Repository JPQL enum 비교를 파라미터 바인딩 방식으로 변경
- Service 호출부에서 ResponseStatus.PENDING, RequestStatus.ACTIVE 전달하도록 수정
- 기존 date, timeSlot은 그대로 유지, 신규 original*은 nullable

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 재요청 시 기존 요청 시간 반환 |<img width="1169" height="764" alt="image" src="https://github.com/user-attachments/assets/1ffe0b07-429c-42ed-bd25-1b5b1e7aac39" />|

```
  "originalDate": "2025-08-30",
  "originalTimeSlot": {
    "start": "12:00",
    "end": "13:00"
  },
```