### PR TITLE
Fix : 투두 등록 시작시간과 종료시간이 같은 경우

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -9,7 +9,7 @@ import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
 @Getter
 @AllArgsConstructor
 public enum HomeErrorStatus implements BaseErrorCode {
-    _INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "HOME4001", "endTime은 startTime을 앞설 수 없습니다."),
+    _INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "HOME4001", "종료시간은 시작시간 이후여야 합니다."),
     _INVALID_DURATION(HttpStatus.BAD_REQUEST,"HOME4002","잘못된 조회 기간입니다."),
     _CANNOT_UPDATE_ROUTINE(HttpStatus.BAD_REQUEST,"HOME4003","반복일정은 수정할 수 없습니다."),
     _INVALID_VIRTUAL_ID(HttpStatus.BAD_REQUEST,"HOME4004","잘못된 루틴 ID 형식입니다."),

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -66,7 +66,7 @@ public class HomeServiceImpl implements HomeService {
         // Todo 등록
 
         // 시간 유효성 검사
-        if(dto.getEndTime().isBefore(dto.getStartTime())){
+        if(dto.getEndTime().isBefore(dto.getStartTime()) || dto.getEndTime().isEqual(dto.getStartTime())){
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
@@ -174,7 +174,7 @@ public class HomeServiceImpl implements HomeService {
         }
 
         // 4. 시간 유효성 검사
-        if(dto.getEndTime().isBefore(dto.getStartTime())){
+        if(dto.getEndTime().isBefore(dto.getStartTime()) || dto.getEndTime().isEqual(dto.getStartTime())){
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
@@ -456,7 +456,7 @@ public class HomeServiceImpl implements HomeService {
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._WISH_NOT_FOUND));
 
         // 2. 시간 유효성 검사
-        if(dto.getEndTime().isBefore(dto.getStartTime())){
+        if(dto.getEndTime().isBefore(dto.getStartTime()) || dto.getEndTime().isEqual(dto.getStartTime())){
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
@@ -731,7 +731,7 @@ public class HomeServiceImpl implements HomeService {
 
         // 2. 스케줄 알림 테이블 조회
         List<ScheduleReminder> reminders = scheduleReminderRepository.findByScheduleId(scheduleId);
-        System.out.println("reminders = " + reminders);
+
         // 3. 필드 업데이트
         for(ScheduleReminder reminder : reminders){
             reminder.updateStatus(alarmStatus);


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#215

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
투두 등록 수정, 위시 투두 등록시 시작시간과 종료시간이 같은 경우도 등록할 수 없도록 유효성 검사 로직 수정했습니다.
또, 유효성 검사 에러 메시지를 다듬어 "종료시간은 시작시간 이후여야 합니다."로 수정했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
POST /api/home/todo
PUT /api/home/todo/{todoId}
POST /api/wishes/{wishId}/assign
### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X