### PR TITLE
Fix : 시간표 조회 중복 로직 타입 분리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -429,7 +429,8 @@ public class HomeServiceImpl implements HomeService {
         for(int i = 1; i < list.size(); i++){
             HomeResponseDto.TodayScheduleDto current = list.get(i);
 
-            if(!current.getStartTime().isAfter(last.getEndTime())){
+            if(last.getType().equals(current.getType()) &&
+                    !current.getStartTime().isAfter(last.getEndTime())){
                 // current 투두의 시작시간이 last 투두의 종료시간과 같거나 이른 경우
                 HomeResponseDto.TodayScheduleDto merged = HomeResponseDto.TodayScheduleDto.builder()
                         .startTime(last.getStartTime()) // 이전 시작


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#221

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
시간표를 조회할 때 같은 시간에 투두가 겹칠 경우 하나의 투두로 합치는 로직을 구현했었습니다. 해당 로직 중 타입을 검증하지 않아 수면패턴과 투두가 맞닿아 있을 경우 하나의 투두로 합쳐지는 로직 오류가 있었습니다. 투두를 합칠 때, 뒤 투두의 startTime이 앞 투두의 endTime과 같거나 이른 경우와 두 타입이 같은 경우만 병합하도록 로직을 수정했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
GET /api/home/teum

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF

```
{
  "isSuccess": true,
  "code": "HOME20010",
  "message": "오늘의 스케줄이 성공적으로 조회되었습니다.",
  "result": [
    {
      "startTime": "00:00",
      "endTime": "08:00",
      "type": "EMPTY"
    },
    {
      "startTime": "08:00",
      "endTime": "11:00",
      "type": "TODO"
    },
    {
      "startTime": "11:00",
      "endTime": "12:00",
      "type": "SLEEP"
    },
    {
      "startTime": "12:00",
      "endTime": "24:00",
      "type": "EMPTY"
    }
  ]
}
```