### PR TITLE
Test : NotificationServiceImpl/NotificationType/FCMServiceImpl 단위 테스트 추가

### DIFF
--- a/src/test/java/umc/teumteum/server/unit/fcm/service/FcmServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/fcm/service/FcmServiceTest.java
@@ -1,5 +1,7 @@
 package umc.teumteum.server.unit.fcm.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,6 +21,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.teumteum.server.domain.fcm.converter.FcmConverter;
 import umc.teumteum.server.domain.fcm.entity.FcmToken;
+import umc.teumteum.server.domain.fcm.exception.FcmHandler;
+import umc.teumteum.server.domain.fcm.exception.status.FcmErrorStatus;
 import umc.teumteum.server.domain.fcm.repository.FcmTokenRepository;
 import umc.teumteum.server.domain.fcm.service.FcmServiceImpl;
 import umc.teumteum.server.domain.user.entity.User;
@@ -103,6 +107,60 @@ public class FcmServiceTest {
     verify(fcmTokenRepository).save(newToken);
 
   }
+
+  @Test
+  @DisplayName("[detachFcmToken] - TC1 정상적인 활성 토큰이라면 비활성화 처리한다.")
+  void detach_fcm_active_token() {
+    //given
+    String token = "thisismockfcmtoken";
+    FcmToken existingToken = mock(FcmToken.class);
+    when(fcmTokenRepository.findByTokenAndUser(token, testUser)).thenReturn(Optional.of(existingToken));
+    when(existingToken.getIsActive()).thenReturn(true);
+
+    //when
+    fcmService.detachFcmToken(testUser, token);
+
+    //then
+    verify(existingToken).deactivate();
+
+  }
+
+  @Test
+  @DisplayName("[detachFcmToken] - TC2 해당 유저의 토큰이 존재하지 않으면 예외를 발생시킨다.")
+  void detach_fcm_not_found_throws_exception() {
+    //given
+    String token = "thisismockfcmtoken";
+    when(fcmTokenRepository.findByTokenAndUser(token, testUser)).thenReturn(Optional.empty());
+
+    //when
+    //then
+    FcmHandler exception = assertThrows(FcmHandler.class, () -> fcmService.detachFcmToken(testUser, token));
+    assertEquals(FcmErrorStatus.FCM_BAD_REQUEST.getCode(), exception.getErrorReason().getCode());
+    assertEquals(FcmErrorStatus.FCM_BAD_REQUEST.getMessage(), exception.getErrorReason().getMessage());
+
+
+
+
+  }
+
+  @Test
+  @DisplayName("[detachFcmToken] - TC3 이미 비활성화된 토큰이라면 예외를 발생시킨다.")
+  void detach_fcm_already_deactive_throws_exception() {
+    //given
+    String token = "thisismockfcmtoken";
+    FcmToken existingToken = mock(FcmToken.class);
+    when(fcmTokenRepository.findByTokenAndUser(token, testUser)).thenReturn(Optional.of(existingToken));
+    when(existingToken.getIsActive()).thenReturn(false);
+
+    //when
+    //then
+    FcmHandler exception = assertThrows(FcmHandler.class, () -> fcmService.detachFcmToken(testUser, token));
+    assertEquals(FcmErrorStatus.FCM_ALREADY_DEACTIVATED.getCode(), exception.getErrorReason().getCode());
+    assertEquals(FcmErrorStatus.FCM_ALREADY_DEACTIVATED.getMessage(), exception.getErrorReason().getMessage());
+
+  }
+
+
 
 
 

--- a/src/test/java/umc/teumteum/server/unit/fcm/service/FcmServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/fcm/service/FcmServiceTest.java
@@ -1,0 +1,112 @@
+package umc.teumteum.server.unit.fcm.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.fcm.converter.FcmConverter;
+import umc.teumteum.server.domain.fcm.entity.FcmToken;
+import umc.teumteum.server.domain.fcm.repository.FcmTokenRepository;
+import umc.teumteum.server.domain.fcm.service.FcmServiceImpl;
+import umc.teumteum.server.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmServiceImpl - Fcm Token 관련 서비스 메서드 단위 테스트")
+public class FcmServiceTest {
+  @Mock
+  private FcmTokenRepository fcmTokenRepository;
+
+  @InjectMocks
+  private FcmServiceImpl fcmService;
+
+  @Mock
+  private User testUser;
+
+  private MockedStatic<FcmConverter> converterMock;
+
+  @BeforeEach
+  void setUp() {
+    converterMock = Mockito.mockStatic(FcmConverter.class);
+
+  }
+
+  @AfterEach
+  void tearDown() {
+    converterMock.close();
+  }
+
+  @Test
+  @DisplayName("[registerFcmToken] - TC1 기존에 활성화된 FCM 토큰이 존재하면 아무 작업도 하지 않는다.")
+  void register_fcm_existing_active_token() {
+    //given
+    String token = "thisismockfcmtoken";
+    FcmToken existingToken = mock(FcmToken.class);
+
+    when(fcmTokenRepository.findByToken(token)).thenReturn(Optional.of(existingToken));
+    when(existingToken.getIsActive()).thenReturn(true);
+
+    //when
+    fcmService.registerFcmToken(testUser, token);
+
+    //then
+    verify(existingToken, never()).activate();
+    verify(fcmTokenRepository, never()).save(any());
+
+
+
+  }
+  @Test
+  @DisplayName("[registerFcmToken] - TC2 기존에 비활성화된 FCM 토큰이 존재하면 활성화한다.")
+  void register_fcm_existing_deactive_token() {
+    //given
+    String token = "thisismockfcmtoken";
+    FcmToken existingToken = mock(FcmToken.class);
+
+    when(fcmTokenRepository.findByToken(token)).thenReturn(Optional.of(existingToken));
+    when(existingToken.getIsActive()).thenReturn(false);
+
+    //when
+    fcmService.registerFcmToken(testUser, token);
+
+    //then
+    verify(existingToken).activate();
+    verify(fcmTokenRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("[registerFcmToken] - TC3 해당 FCM 토큰이 존재하지 않으면 새로 등록한다.")
+  void register_fcm_save_new_token() {
+    //given
+    String token = "thisismockfcmtoken";
+    FcmToken newToken = mock(FcmToken.class);
+
+    when(fcmTokenRepository.findByToken(token)).thenReturn(Optional.empty());
+    converterMock.when(() -> FcmConverter.toFcmToken(testUser, token)).thenReturn(newToken);
+
+    //when
+    fcmService.registerFcmToken(testUser, token);
+
+    //then
+    verify(fcmTokenRepository).save(newToken);
+
+  }
+
+
+
+
+
+
+}

--- a/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
+++ b/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
@@ -41,6 +41,7 @@ import umc.teumteum.server.global.notification.sender.FcmNotificationSender;
 import umc.teumteum.server.global.scheduler.DailyTodoReminerScheduler;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("DailyTodoReminerScheduler - DailyTodoReminerScheduler 관련 단위 테스트")
 public class DailyTodoReminderSchedulerTest {
   @Mock
   private ScheduleRepository scheduleRepository;

--- a/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
@@ -35,6 +35,7 @@ import umc.teumteum.server.domain.home.service.ActivityServiceImpl;
 import umc.teumteum.server.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("ActivityServiceImpl - Activity(채움활동) 관련 단위 테스트")
 class ActivityServiceTest {
 
   @Mock

--- a/src/test/java/umc/teumteum/server/unit/notification/NotificationEnumTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/NotificationEnumTest.java
@@ -1,0 +1,155 @@
+package umc.teumteum.server.unit.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
+import umc.teumteum.server.domain.notification.entity.enums.RelatedEntityType;
+
+@DisplayName("NotificationEnum - Notification enum 관련 단위 테스트")
+public class NotificationEnumTest {
+  @Test
+  @DisplayName("[shouldBeStored / isPushOnly] DAILY_TODO는 저장 안되고 푸시 전용이다")
+  void dailyTodo_pushOnly() {
+    // given
+    NotificationType type = NotificationType.DAILY_TODO;
+
+    // when
+    // then
+    assertFalse(type.isStorable());
+    assertTrue(type.isPushOnly());
+
+  }
+
+  @Test
+  @DisplayName("[shouldBeStored / isPushOnly] DAILY_TODO를 제외한 나머지는 알림 목록에서 조회가능하애 하기 때문에 저장된다.")
+  void others_shouldBeStored() {
+    // given
+    // when
+    // then
+    for (NotificationType type : NotificationType.values()) {
+      if(type == NotificationType.DAILY_TODO) continue;
+      assertTrue(type.isStorable());
+      assertFalse(type.isPushOnly());
+    }
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.DAILY_TODO] DAILY_TODO RelatedEntityType은 NONE이다.")
+  void DAILY_TODO_is_NONE() {
+    // given
+    NotificationType type = NotificationType.DAILY_TODO;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.NONE);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_REQUEST] TEUM_REQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
+  void TEUM_REQUEST_is_TEUM_REQUEST() {
+    // given
+    NotificationType type = NotificationType.TEUM_REQUEST;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.TEUM_REQUEST);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_ACCEPTED] TEUM_ACCEPTED RelatedEntityType은 TEUM_RESPONSE이다..")
+  void TEUM_ACCEPTED_is_TEUM_RESPONSE() {
+    // given
+    NotificationType type = NotificationType.TEUM_ACCEPTED;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.TEUM_RESPONSE);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_DECLINED] TEUM_DECLINED의 RelatedEntityType은 TEUM_RESPONSE이다..")
+  void TEUM_DECLINED_is_TEUM_RESPONSE() {
+    // given
+    NotificationType type = NotificationType.TEUM_DECLINED;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.TEUM_RESPONSE);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_SUGGESTED] TEUM_SUGGESTED의 RelatedEntityType은 TEUM_RESPONSE이다.")
+  void TEUM_SUGGESTED_is_TEUM_RESPONSE() {
+    // given
+    NotificationType type = NotificationType.TEUM_SUGGESTED;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.TEUM_RESPONSE);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_CANCELED] TEUM_CANCELED의 RelatedEntityType은 SCHEDULE이다.")
+  void TEUM_CANCELED_is_SCHEDULE() {
+    // given
+    NotificationType type = NotificationType.TEUM_CANCELED;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.SCHEDULE);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.TEUM_REQUEST_REREQUEST] TEUM_REQUEST_REREQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
+  void TEUM_REQUEST_REREQUEST_is_TEUM_REQUEST() {
+    // given
+    NotificationType type = NotificationType.TEUM_REQUEST_REREQUEST;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.TEUM_REQUEST);
+
+  }
+
+  @Test
+  @DisplayName("[NotificatoinType.FOLLOW] FOLLOW의 RelatedEntityType은 FRIEND이다.")
+  void FOLLOW_is_FRIEND() {
+    // given
+    NotificationType type = NotificationType.FOLLOW;
+    RelatedEntityType relatedEntityType = type.getRelatedEntityType();
+    // when
+    // then
+    assertEquals(relatedEntityType, RelatedEntityType.FRIEND);
+
+  }
+
+  @Test
+  @DisplayName("[RelationEntityType] RelationEntityType enum이 정상적으로 등록되어 있다.")
+  void relationEntityType_check() {
+    // given
+    RelatedEntityType[] values = RelatedEntityType.values();
+    // when
+    assertEquals(5, values.length);
+    // then
+    assertNotNull(RelatedEntityType.valueOf("NONE"));
+    assertNotNull(RelatedEntityType.valueOf("TEUM_REQUEST"));
+    assertNotNull(RelatedEntityType.valueOf("TEUM_RESPONSE"));
+    assertNotNull(RelatedEntityType.valueOf("SCHEDULE"));
+    assertNotNull(RelatedEntityType.valueOf("FRIEND"));
+
+  }
+
+
+}

--- a/src/test/java/umc/teumteum/server/unit/notification/NotificationEnumTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/NotificationEnumTest.java
@@ -13,7 +13,7 @@ import umc.teumteum.server.domain.notification.entity.enums.RelatedEntityType;
 @DisplayName("NotificationEnum - Notification enum 관련 단위 테스트")
 public class NotificationEnumTest {
   @Test
-  @DisplayName("[shouldBeStored / isPushOnly] DAILY_TODO는 저장 안되고 푸시 전용이다")
+  @DisplayName("[shouldBeStored / isPushOnly] - TC1 DAILY_TODO는 저장 안되고 푸시 전용이다")
   void dailyTodo_pushOnly() {
     // given
     NotificationType type = NotificationType.DAILY_TODO;
@@ -26,7 +26,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[shouldBeStored / isPushOnly] DAILY_TODO를 제외한 나머지는 알림 목록에서 조회가능하애 하기 때문에 저장된다.")
+  @DisplayName("[shouldBeStored / isPushOnly] - TC2 DAILY_TODO를 제외한 나머지는 알림 목록에서 조회가능하애 하기 때문에 저장된다.")
   void others_shouldBeStored() {
     // given
     // when
@@ -40,7 +40,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.DAILY_TODO] DAILY_TODO RelatedEntityType은 NONE이다.")
+  @DisplayName("[NotificatoinType.DAILY_TODO] - TC3 DAILY_TODO RelatedEntityType은 NONE이다.")
   void DAILY_TODO_is_NONE() {
     // given
     NotificationType type = NotificationType.DAILY_TODO;
@@ -52,7 +52,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_REQUEST] TEUM_REQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
+  @DisplayName("[NotificatoinType.TEUM_REQUEST] - TC4 TEUM_REQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
   void TEUM_REQUEST_is_TEUM_REQUEST() {
     // given
     NotificationType type = NotificationType.TEUM_REQUEST;
@@ -64,7 +64,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_ACCEPTED] TEUM_ACCEPTED RelatedEntityType은 TEUM_RESPONSE이다..")
+  @DisplayName("[NotificatoinType.TEUM_ACCEPTED] - TC5 TEUM_ACCEPTED RelatedEntityType은 TEUM_RESPONSE이다..")
   void TEUM_ACCEPTED_is_TEUM_RESPONSE() {
     // given
     NotificationType type = NotificationType.TEUM_ACCEPTED;
@@ -76,7 +76,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_DECLINED] TEUM_DECLINED의 RelatedEntityType은 TEUM_RESPONSE이다..")
+  @DisplayName("[NotificatoinType.TEUM_DECLINED] - TC6 TEUM_DECLINED의 RelatedEntityType은 TEUM_RESPONSE이다..")
   void TEUM_DECLINED_is_TEUM_RESPONSE() {
     // given
     NotificationType type = NotificationType.TEUM_DECLINED;
@@ -88,7 +88,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_SUGGESTED] TEUM_SUGGESTED의 RelatedEntityType은 TEUM_RESPONSE이다.")
+  @DisplayName("[NotificatoinType.TEUM_SUGGESTED] - TC7 TEUM_SUGGESTED의 RelatedEntityType은 TEUM_RESPONSE이다.")
   void TEUM_SUGGESTED_is_TEUM_RESPONSE() {
     // given
     NotificationType type = NotificationType.TEUM_SUGGESTED;
@@ -100,7 +100,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_CANCELED] TEUM_CANCELED의 RelatedEntityType은 SCHEDULE이다.")
+  @DisplayName("[NotificatoinType.TEUM_CANCELED] - TC8 TEUM_CANCELED의 RelatedEntityType은 SCHEDULE이다.")
   void TEUM_CANCELED_is_SCHEDULE() {
     // given
     NotificationType type = NotificationType.TEUM_CANCELED;
@@ -112,7 +112,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.TEUM_REQUEST_REREQUEST] TEUM_REQUEST_REREQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
+  @DisplayName("[NotificatoinType.TEUM_REQUEST_REREQUEST] - TC9 TEUM_REQUEST_REREQUEST의 RelatedEntityType은 TEUM_REQUEST이다.")
   void TEUM_REQUEST_REREQUEST_is_TEUM_REQUEST() {
     // given
     NotificationType type = NotificationType.TEUM_REQUEST_REREQUEST;
@@ -124,7 +124,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[NotificatoinType.FOLLOW] FOLLOW의 RelatedEntityType은 FRIEND이다.")
+  @DisplayName("[NotificatoinType.FOLLOW] - TC10 FOLLOW의 RelatedEntityType은 FRIEND이다.")
   void FOLLOW_is_FRIEND() {
     // given
     NotificationType type = NotificationType.FOLLOW;
@@ -136,7 +136,7 @@ public class NotificationEnumTest {
   }
 
   @Test
-  @DisplayName("[RelationEntityType] RelationEntityType enum이 정상적으로 등록되어 있다.")
+  @DisplayName("[RelationEntityType] - TC11 RelationEntityType enum이 정상적으로 등록되어 있다.")
   void relationEntityType_check() {
     // given
     RelatedEntityType[] values = RelatedEntityType.values();

--- a/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
@@ -1,0 +1,145 @@
+//package umc.teumteum.server.unit.notification.service;
+//
+//
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.when;
+//import static org.mockito.Mockito.withSettings;
+//
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.MockedStatic;
+//import org.mockito.Mockito;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import umc.teumteum.server.domain.friend.repository.FriendRepository;
+//import umc.teumteum.server.domain.notification.converter.NotificationConverter;
+//import umc.teumteum.server.domain.notification.entity.Notification;
+//import umc.teumteum.server.domain.notification.entity.enums.RelatedEntityType;
+//import umc.teumteum.server.domain.notification.repository.NotificationRepository;
+//import umc.teumteum.server.domain.notification.service.NotificationService;
+//import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+//import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
+//import umc.teumteum.server.domain.user.entity.User;
+//import umc.teumteum.server.global.util.S3Util;
+//
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("NotificationServiceImpl - Notification 관련 서비스 메서드 단위 테스트")
+//public class NotificationServiceTest {
+//  @InjectMocks
+//  private NotificationService notificationServiceImpl;
+//
+//  @Mock
+//  private NotificationRepository notificationRepository;
+//  @Mock
+//  private TeumResponseRepository teumResponseRepository;
+//  @Mock
+//  private TeumRequestRepository teumRequestRepository;
+//  @Mock
+//  private FriendRepository friendRepository;
+//
+//  @Mock
+//  private S3Util s3Util;
+//
+//  @Mock
+//  private User testUser;
+//
+//  private MockedStatic<NotificationConverter> converterMock;
+//
+//  @BeforeEach
+//  void setUp() {
+//    converterMock = Mockito.mockStatic(NotificationConverter.class);
+//
+//  }
+//
+//  @AfterEach
+//  void tearDown() {
+//    converterMock.close();
+//
+//  }
+//
+//  @Test
+//  @DisplayName("[getNotifications] - TC1 모든 타입 매핑, DTO 변환이 정상작동하는지 확인한다.")
+//  void getNotifications_all_types_mapped() {
+//    // given
+//    Notification notification = mockNoti(31, RelatedEntityType.TEUM_REQUEST, 1);
+//
+//    // when
+//
+//    // then
+//
+//  }
+//
+//
+//  @Test
+//  @DisplayName("[getNotifications] - TC2 관련 엔티티가 없으면 해당 알림은 필터링 된다.")
+//  void getNotifications_all_types_mapped() {
+//    // given
+//
+//    // when
+//
+//    // then
+//
+//
+//  }
+//
+//  @Test
+//  @DisplayName("[getNotifications] - TC3 hasNext true/페이지/사이즈가 Converter로 그대로 전달된다. (페이징 정상 작동 확인)")
+//  void getNotifications_all_types_mapped() {
+//    // given
+//
+//    // when
+//
+//    // then
+//
+//
+//  }
+//
+//  @Test
+//  @DisplayName("[getNotifications] - TC4 S3 프리사인 URL 키와 만료시간 검증")
+//  void getNotifications_all_types_mapped() {
+//    // given
+//
+//    // when
+//
+//    // then
+//
+//
+//  }
+//
+//  @Test
+//  @DisplayName("[getNotifications] - TC5 알수 없는 타입은 제외된다.")
+//  void getNotifications_all_types_mapped() {
+//    // given
+//
+//    // when
+//
+//    // then
+//
+//
+//  }
+//
+//  // 헬퍼 메서드
+//  private Notification mockNoti(Long id, RelatedEntityType relationEntityType, Long relatedId) {
+//    Notification notification = mock(Notification.class);
+//    when(notification.getId()).thenReturn(id);
+//
+//    Object notificationType = mock(Object.class, withSettings().lenient());
+//
+//
+//
+//
+//  }
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//}

--- a/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
@@ -1,145 +1,301 @@
-//package umc.teumteum.server.unit.notification.service;
-//
-//
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.when;
-//import static org.mockito.Mockito.withSettings;
-//
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockedStatic;
-//import org.mockito.Mockito;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import umc.teumteum.server.domain.friend.repository.FriendRepository;
-//import umc.teumteum.server.domain.notification.converter.NotificationConverter;
-//import umc.teumteum.server.domain.notification.entity.Notification;
-//import umc.teumteum.server.domain.notification.entity.enums.RelatedEntityType;
-//import umc.teumteum.server.domain.notification.repository.NotificationRepository;
-//import umc.teumteum.server.domain.notification.service.NotificationService;
-//import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
-//import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
-//import umc.teumteum.server.domain.user.entity.User;
-//import umc.teumteum.server.global.util.S3Util;
-//
-//@ExtendWith(MockitoExtension.class)
-//@DisplayName("NotificationServiceImpl - Notification 관련 서비스 메서드 단위 테스트")
-//public class NotificationServiceTest {
-//  @InjectMocks
-//  private NotificationService notificationServiceImpl;
-//
-//  @Mock
-//  private NotificationRepository notificationRepository;
-//  @Mock
-//  private TeumResponseRepository teumResponseRepository;
-//  @Mock
-//  private TeumRequestRepository teumRequestRepository;
-//  @Mock
-//  private FriendRepository friendRepository;
-//
-//  @Mock
-//  private S3Util s3Util;
-//
-//  @Mock
-//  private User testUser;
-//
-//  private MockedStatic<NotificationConverter> converterMock;
-//
-//  @BeforeEach
-//  void setUp() {
-//    converterMock = Mockito.mockStatic(NotificationConverter.class);
-//
-//  }
-//
-//  @AfterEach
-//  void tearDown() {
-//    converterMock.close();
-//
-//  }
-//
-//  @Test
-//  @DisplayName("[getNotifications] - TC1 모든 타입 매핑, DTO 변환이 정상작동하는지 확인한다.")
-//  void getNotifications_all_types_mapped() {
-//    // given
-//    Notification notification = mockNoti(31, RelatedEntityType.TEUM_REQUEST, 1);
-//
-//    // when
-//
-//    // then
-//
-//  }
-//
-//
-//  @Test
-//  @DisplayName("[getNotifications] - TC2 관련 엔티티가 없으면 해당 알림은 필터링 된다.")
-//  void getNotifications_all_types_mapped() {
-//    // given
-//
-//    // when
-//
-//    // then
-//
-//
-//  }
-//
-//  @Test
-//  @DisplayName("[getNotifications] - TC3 hasNext true/페이지/사이즈가 Converter로 그대로 전달된다. (페이징 정상 작동 확인)")
-//  void getNotifications_all_types_mapped() {
-//    // given
-//
-//    // when
-//
-//    // then
-//
-//
-//  }
-//
-//  @Test
-//  @DisplayName("[getNotifications] - TC4 S3 프리사인 URL 키와 만료시간 검증")
-//  void getNotifications_all_types_mapped() {
-//    // given
-//
-//    // when
-//
-//    // then
-//
-//
-//  }
-//
-//  @Test
-//  @DisplayName("[getNotifications] - TC5 알수 없는 타입은 제외된다.")
-//  void getNotifications_all_types_mapped() {
-//    // given
-//
-//    // when
-//
-//    // then
-//
-//
-//  }
-//
-//  // 헬퍼 메서드
-//  private Notification mockNoti(Long id, RelatedEntityType relationEntityType, Long relatedId) {
-//    Notification notification = mock(Notification.class);
-//    when(notification.getId()).thenReturn(id);
-//
-//    Object notificationType = mock(Object.class, withSettings().lenient());
-//
-//
-//
-//
-//  }
-//
-//
-//
-//
-//
-//
-//
-//
-//
-//}
+package umc.teumteum.server.unit.notification.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import umc.teumteum.server.domain.friend.entity.Friend;
+import umc.teumteum.server.domain.friend.repository.FriendRepository;
+import umc.teumteum.server.domain.notification.converter.NotificationConverter;
+import umc.teumteum.server.domain.notification.dto.NotificationResponseDto;
+import umc.teumteum.server.domain.notification.entity.Notification;
+import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
+import umc.teumteum.server.domain.notification.repository.NotificationRepository;
+import umc.teumteum.server.domain.notification.service.NotificationServiceImpl;
+import umc.teumteum.server.domain.teum.entity.*;
+import umc.teumteum.server.domain.teum.repository.*;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.util.S3Util;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationServiceImpl - Notification 관련 서비스 메서드 단위 테스트")
+public class NotificationServiceTest {
+
+  @InjectMocks
+  private NotificationServiceImpl notificationServiceImpl;
+
+  @Mock
+  private NotificationRepository notificationRepository;
+  @Mock
+  private TeumResponseRepository teumResponseRepository;
+  @Mock
+  private TeumRequestRepository teumRequestRepository;
+  @Mock
+  private FriendRepository friendRepository;
+
+  @Mock
+  private S3Util s3Util;
+
+  @Mock
+  private User testUser;
+
+  private MockedStatic<NotificationConverter> converterMock;
+
+  @BeforeEach
+  void setUp() {
+    converterMock = Mockito.mockStatic(NotificationConverter.class);
+
+  }
+
+  @AfterEach
+  void tearDown() {
+    converterMock.close();
+
+  }
+
+  @Test
+  @DisplayName("[getNotifications] - TC1 모든 타입 매핑, DTO 변환이 정상작동하는지 확인한다.")
+  void all_types_mapped_and_converted() {
+    // given
+    int page = 1;
+    int size = 10;
+
+      // 알림 종류들 : RESPONSE, SCHEDULE(둘 다 TeumResponse), REQUEST(TeumRequest), FRIEND(Friend)
+    Notification n1 = mockNoti(1L, NotificationType.TEUM_ACCEPTED, 101L); // TEUM_RESPONSE
+    Notification n2 = mockNoti(2L, NotificationType.TEUM_CANCELED, 102L); // SCHEDULE
+    Notification n3 = mockNoti(3L, NotificationType.TEUM_REQUEST, 103L); // TEUM_REQUEST
+    Notification n4 = mockNoti(4L, NotificationType.FOLLOW, 104L); // FRIEND
+
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Slice<Notification> slices = new SliceImpl<>(List.of(n1, n2, n3, n4), pageable, false);
+    when(notificationRepository.findByUserOrderByCreatedAtDesc(eq(testUser),
+        any(Pageable.class))).thenReturn(slices);
+
+      // 관련 유저들, 프로필 이미지 조회 부분 mocking
+    User testFriend1 = mock(User.class); when(testFriend1.getProfileImageName()).thenReturn("tf1.png");
+    User testFriend2 = mock(User.class); when(testFriend2.getProfileImageName()).thenReturn("tf2.png");
+    User testFriend3 = mock(User.class); when(testFriend3.getProfileImageName()).thenReturn("tf3.png");
+    User testFriend4 = mock(User.class); when(testFriend4.getProfileImageName()).thenReturn("tf4.png");
+
+      // 관련 엔티티 mock, repodisoty stubbing
+    TeumResponse teumResponse_related_accepted = mock(TeumResponse.class);
+    when(teumResponse_related_accepted.getReceiverUser()).thenReturn(testFriend1);
+    when(teumResponseRepository.findById(101L)).thenReturn(Optional.of(teumResponse_related_accepted));
+
+    TeumResponse tuemResponse_related_canceled = mock(TeumResponse.class);
+    when(tuemResponse_related_canceled.getReceiverUser()).thenReturn(testFriend2);
+    when(teumResponseRepository.findById(102L)).thenReturn(Optional.of(tuemResponse_related_canceled));
+
+    TeumRequest teumRequest = mock(TeumRequest.class);
+    when(teumRequest.getUser()).thenReturn(testFriend3);
+    when(teumRequestRepository.findById(103L)).thenReturn(Optional.of(teumRequest));
+
+    Friend friend = mock(Friend.class);
+    when(friend.getFollower()).thenReturn(testFriend4);
+    when(friendRepository.findById(104L)).thenReturn(Optional.of(friend));
+
+    when(s3Util.toPresignedUrl(startsWith("profile/"), any(Duration.class)))
+        .thenReturn("https://presigned/mock/test");
+
+      // NotificationResponseDto.NotificationDto mocking
+    NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+        .thenReturn(dto);
+
+      // NotificatoinResponseDto.SliceResposneDto mocking
+    NotificationResponseDto.SliceResponseDto expected = mock(NotificationResponseDto.SliceResponseDto.class);
+    converterMock.when(() -> NotificationConverter.toSliceResponseDto(anyList(), eq(false), eq(page), eq(size))).thenReturn(expected);
+
+    // when
+    NotificationResponseDto.SliceResponseDto actualResponse = notificationServiceImpl.getNotifications(
+        testUser, page, size);
+
+    // then
+      // 1. 통과 기준 : 타입별로 변환이 잘 되었는지 확인
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n1), eq(testFriend1), anyString()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n2), eq(testFriend2), anyString()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n3), eq(testFriend3), anyString()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n4), eq(testFriend4), anyString()));
+
+      // 2. 통과 기준 : S3 presigned URL 호출 확인
+    verify(s3Util, atLeast(4)).toPresignedUrl(startsWith("profile/"), eq(Duration.ofMinutes(30)));
+
+  }
+
+  @Test
+  @DisplayName("[getNotifications] - TC2 관련 엔티티가 없으면 해당 알림은 필터링 된다.")
+  void filter_when_related_not_found() {
+    int page = 1, size = 10;
+
+    Notification exist = mockNoti(1L, NotificationType.TEUM_REQUEST, 201L);
+    Notification none  = mockNoti(2L, NotificationType.FOLLOW,       202L);
+
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Slice<Notification> slices = new SliceImpl<>(List.of(exist,none), pageable, false);
+    when(notificationRepository.findByUserOrderByCreatedAtDesc(eq(testUser),
+        any(Pageable.class))).thenReturn(slices);
+
+    User testFriend = mock(User.class);
+    when(testFriend.getProfileImageName()).thenReturn("tf1.png");
+    TeumRequest tq = mock(TeumRequest.class);
+    when(tq.getUser()).thenReturn(testFriend);
+
+    when(teumRequestRepository.findById(201L)).thenReturn(Optional.of(tq));
+    when(friendRepository.findById(202L)).thenReturn(Optional.empty());
+    when(s3Util.toPresignedUrl(startsWith("profile/"), any(Duration.class)))
+        .thenReturn("https://presigned/mock/test");
+
+    NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+        .thenReturn(dto);
+
+    NotificationResponseDto.SliceResponseDto expected = mock(NotificationResponseDto.SliceResponseDto.class);
+    converterMock.when(() -> NotificationConverter.toSliceResponseDto(
+            argThat(list -> list.size() == 1), eq(false), eq(page), eq(size)))
+        .thenReturn(expected);
+
+    // when
+    NotificationResponseDto.SliceResponseDto actual =
+        notificationServiceImpl.getNotifications(testUser, page, size);
+
+    // then
+    assertSame(expected, actual);
+      // 1. 통과 기준 : 필터링 되야 되는 none은 절대로 호출 안됨
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(none), any(), any()), never());
+      // 2. 통과 기준 : 필터링 되면 안되는 exist는 호출됨
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(exist), eq(testFriend), anyString()));
+
+  }
+
+  @Test
+  @DisplayName("[getNotifications] - TC3 hasNext, page, size 파라미터가 변환기에 그대로 전달")
+  void hasNext_and_pagination_params() {
+    int page = 3, size = 5;
+
+    Notification n = mockNoti(1L, NotificationType.FOLLOW, 301L);
+    Slice<Notification> slice = new SliceImpl<>(List.of(n), PageRequest.of(page-1, size), true);
+    when(notificationRepository.findByUserOrderByCreatedAtDesc(eq(testUser), any(Pageable.class)))
+        .thenReturn(slice);
+
+    User testFriend = mock(User.class); when(testFriend.getProfileImageName()).thenReturn("tf1.png");
+    Friend fr = mock(Friend.class); when(fr.getFollower()).thenReturn(testFriend);
+    when(friendRepository.findById(301L)).thenReturn(Optional.of(fr));
+    when(s3Util.toPresignedUrl(startsWith("profile/"), any(Duration.class)))
+        .thenReturn("https://presigned/mock/test");
+
+    NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any())).thenReturn(dto);
+
+    NotificationResponseDto.SliceResponseDto expected = mock(NotificationResponseDto.SliceResponseDto.class);
+    converterMock.when(() -> NotificationConverter.toSliceResponseDto(anyList(), eq(true), eq(page), eq(size)))
+        .thenReturn(expected);
+
+    // when
+    NotificationResponseDto.SliceResponseDto actual =
+        notificationServiceImpl.getNotifications(testUser, page, size);
+
+    // then
+    assertSame(expected, actual);
+
+  }
+
+  @Test
+  @DisplayName("[getNotifications] - TC4 S3 presigned URL: 키와 만료시간 검증")
+  void verify_presigned_url() {
+    // given
+    int page = 3, size = 5;
+
+    Notification n = mockNoti(1L, NotificationType.TEUM_REQUEST, 401L);
+
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Slice<Notification> slices = new SliceImpl<>(List.of(n), pageable, false);
+    when(notificationRepository.findByUserOrderByCreatedAtDesc(eq(testUser), any(Pageable.class))).thenReturn(slices);
+
+    User testFriend = mock(User.class);
+    when(testFriend.getProfileImageName()).thenReturn("tf1.png");
+    TeumRequest tq = mock(TeumRequest.class); when(tq.getUser()).thenReturn(testFriend);
+    when(teumRequestRepository.findById(401L)).thenReturn(Optional.of(tq));
+
+
+    when(s3Util.toPresignedUrl(anyString(), any())).thenReturn("url");
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+        .thenReturn(mock(NotificationResponseDto.NotificationDto.class));
+    converterMock.when(() -> NotificationConverter.toSliceResponseDto(anyList(), anyBoolean(), anyInt(), anyInt()))
+        .thenReturn(mock(NotificationResponseDto.SliceResponseDto.class));
+
+    // when
+    notificationServiceImpl.getNotifications(testUser, page, size);
+
+    // then
+    ArgumentCaptor<String> keyCap = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Duration> durCap = ArgumentCaptor.forClass(Duration.class);
+    verify(s3Util).toPresignedUrl(keyCap.capture(), durCap.capture());
+
+    assertEquals("profile/tf1.png", keyCap.getValue());
+    assertEquals(Duration.ofMinutes(30), durCap.getValue());
+
+  }
+
+
+  @Test
+  @DisplayName("[getNotifications] - TC5 TODO type의 경우 switch 문에서 default로 처리되야됨")
+  void getNotifications_all_types_mapped() {
+    // given
+    int page = 1, size = 10;
+
+    Notification todoNoti = mockNoti(1L, NotificationType.DAILY_TODO, 501L);
+
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Slice<Notification> slices = new SliceImpl<>(List.of(todoNoti), pageable, false);
+    when(notificationRepository.findByUserOrderByCreatedAtDesc(eq(testUser), any(Pageable.class))).thenReturn(slices);
+
+    converterMock.when(() -> NotificationConverter.toSliceResponseDto(
+            argThat(List::isEmpty), eq(false), eq(1), eq(10)))
+        .thenReturn(mock(NotificationResponseDto.SliceResponseDto.class));
+
+    // when
+    notificationServiceImpl.getNotifications(testUser, 1, 10);
+
+    // then
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(any(), any(), any()), never());
+    verifyNoInteractions(teumRequestRepository, teumResponseRepository, friendRepository);
+
+  }
+
+  // 헬퍼 메서드
+  private Notification mockNoti(Long id, NotificationType type, Long relatedId) {
+    Notification notification = mock(Notification.class);
+    when(notification.getId()).thenReturn(id);
+    when(notification.getType()).thenReturn(type);
+    when(notification.getRelatedId()).thenReturn(relatedId);
+    return notification;
+
+  }
+
+}


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#219 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
FCM ServiceImpl, NotificationServiceImpl에 대해 단위 테스트 코드를 작성하였습니다.
NotificationType ↔ RelatedEntityType 매핑, isStorable()/isPushOnly() 동작을 명확히 보장하기 위한 enum 단위 테스트 코드를 작성하였습니다.

작성한 테스트 코드가 최종적으로 정상 작동함을 확인하였습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
### 1) NotificationServiceTest 단위 테스트 추가

**TC1: 모든 타입 매핑 및 DTO 변환 정상 동작 검증**
- TEUM_RESPONSE(SCHEDULE 포함), TEUM_REQUEST, FRIEND에 대해 각 리포지토리 findById → 관련 User 매핑
- S3Util.toPresignedUrl("profile/{image}", 30분) 호출 확인
- NotificationConverter.toNotificationDto 각 알림별 1회 호출 검증

**TC2: 관련 엔티티 미존재 시 필터링 확인**
- Optional.empty() 반환 시 toNotificationDto 호출되지 않음(never()) 검증

**TC3: hasNext/page/size 인자가 toSliceResponseDto로 그대로 전달되는지 검증**

**TC4: Presigned URL 키/만료시간 정확성 검증**
- 키: profile/{profileImageName} / 만료: Duration.ofMinutes(30)

**TC5: DAILY_TODO(RelatedEntityType.NONE)는 default 분기로 스킵되는지 검증**
- 관련 repo 상호작용 없음 / toNotificationDto 호출 없음

**테스트 포인트**
NotificationConverter는 static mock 사용 (열고 닫기 @BeforeEach/@AfterEach)
중요: resolveRelatedUsers가 비지 않도록 모든 findById stubbing 추가

### 2) enum 단위 테스트 추가 (NotificationEnumTest)

TC1: DAILY_TODO는 저장되지 않고(isStorable=false) 푸시 전용(isPushOnly=true)
TC2: 그 외 타입은 저장(isStorable=true) & 푸시 전용 아님
TC3~TC10: 각 NotificationType의 RelatedEntityType 매핑 정확성 검증
TC11: RelatedEntityType 값 정의 검증 (NONE/TEUM_REQUEST/TEUM_RESPONSE/SCHEDULE/FRIEND)


### 3) FcmServiceTest 단위 테스트 추가

**registerFcmToken**
TC1: 기존 활성 토큰 존재 → 아무 작업도 하지 않음
TC2: 기존 비활성 토큰 존재 → 활성화
TC3: 기존 토큰 없음 → 신규 저장 (static FcmConverter.toFcmToken 사용)

**detachFcmToken**
TC1: 활성 토큰 → 비활성화
TC2: 해당 유저의 토큰 없음 → 예외(FcmErrorStatus.FCM_BAD_REQUEST)
TC3: 이미 비활성화된 토큰 → 예외(FcmErrorStatus.FCM_ALREADY_DEACTIVATED

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
<img width="906" height="389" alt="스크린샷 2025-08-22 오전 12 30 15" src="https://github.com/user-attachments/assets/b36b6f8f-938b-4b39-a4de-97537a50e666" />
<img width="906" height="159" alt="스크린샷 2025-08-22 오전 12 41 17" src="https://github.com/user-attachments/assets/92138c2e-0d75-4f2e-a6cf-5b9bd1ae8bbf" />

