### PR TITLE
Fix: COMPLETED 포함하도록 조회 로직 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -25,7 +25,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("""
     SELECT s FROM Schedule s
     WHERE s.user.id = :userId
-      AND s.status = :status
+      AND s.status IN (:statuses)
       AND s.endTime >= :startOfDay
       AND s.startTime < :endOfDay
 """)
@@ -33,7 +33,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("userId") Long userId,
             @Param("startOfDay") LocalDateTime startOfDay,
             @Param("endOfDay") LocalDateTime endOfDay,
-            @Param("status") ScheduleStatus status
+            @Param("statuses") Collection<ScheduleStatus> statuses
     );
 
     @Query("""

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -405,7 +405,7 @@ public class TeumServiceImpl implements TeumService {
             LocalDateTime endOfDay = LocalDateTime.of(date, LocalTime.MAX);
 
             List<Schedule> schedules = scheduleRepository.findOverlappingSchedules(
-                    userId, startOfDay, endOfDay, ScheduleStatus.ACTIVE
+                    userId, startOfDay, endOfDay, Arrays.asList(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED)
             );
 
             schedules.stream()


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#226 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- ScheduleRepository.findOverlappingSchedules
  - JPQL을 IN (:statuses)로 변경
  - 파라미터를 Collection<ScheduleStatus> statuses로 교체

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|공통 가능 시간대 조회|<img width="1163" height="550" alt="image" src="https://github.com/user-attachments/assets/bd2f4b23-b141-48f0-8331-93006c667567" />|
> 1시 10분부터 5시 20분까지의 틈 존재 -> 1시 10분이 지나면서 COMPLETED + 취소 불가능 상태 -> 가능 시간대로 표현 Xx