### PR TITLE
Fix : 시간표 중복 일정 처리 로직

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -432,9 +432,13 @@ public class HomeServiceImpl implements HomeService {
             if(last.getType().equals(current.getType()) &&
                     !current.getStartTime().isAfter(last.getEndTime())){
                 // current 투두의 시작시간이 last 투두의 종료시간과 같거나 이른 경우
+
+                // 둘중 늦은 endTime 으로 설정
+                LocalTime endTime = last.getEndTime().isAfter(current.getEndTime()) ? last.getEndTime() : current.getEndTime();
+
                 HomeResponseDto.TodayScheduleDto merged = HomeResponseDto.TodayScheduleDto.builder()
                         .startTime(last.getStartTime()) // 이전 시작
-                        .endTime(current.getEndTime()) // 현재 종료
+                        .endTime(endTime) // 현재 종료
                         .type(last.getType())
                         .build();
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#228
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
투두를 병합하는 과정에서 시작시간은 이전 투두의 startTime으로 종료시간은 이후 투두의 endTime으로 설정하면서 투두1이 투두2의 시간 범위 내에 시작시간과 종료 시간이 걸치게 되면 종료시간이 올바르게 설정되지 않는 로직상 오류를 발견했습니다.
투두를 병합할 때, 종료시간은 두 endTime 중 더 늦은 endTime으로 설정하도록 endTime 계산 방식을 수정했습니다.
ex)
투두1: 12:00 ~ 13:00
투두2: 11:00 ~ 18:00


### 🌀 PR Point
GET api/home/teum
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF
X