### PR TITLE
Feat : Ci에 JaCoCo Coverage 추가 및 이벤트별 실행되는 로직 분리

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,21 +77,30 @@ jobs:
 
 
 
-      - name: Generate JaCoCo coverage report (timed)
-        if: always()
-        continue-on-error: true
+
+      - name: Generate JaCoCo coverage report (timed + enforce gate)
         run: |
+          # 필요시 여기서 최소치 오버라이드 가능(예: 65% / 40%)
+          # export COVERAGE_MIN=0.60 COVERAGE_BRANCH_MIN=0.30
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
-            ./gradlew --no-daemon jacocoTestReport jacocoTestCoverageVerification |& tee jacoco.log
+            ./gradlew --no-daemon jacocoTestReport jacocoTestCoverageVerification \
+              -Dspring.profiles.active=test \
+              -Pcoverage.min=${COVERAGE_MIN:-0.60} \
+              -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.30} \
+              --stacktrace --info |& tee jacoco.log
+      
 
       - name: Coverage summary
-        if: always() && hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
+        if: hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: '**/build/reports/jacoco/test/jacocoTestReport.xml'
           badge: true
           format: 'markdown'
           output: 'both'
+          thresholds: 60 80
+          fail_below_min: false
+
 
       - name: Add coverage comment to PR
         if: github.event_name == 'pull_request' && hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
@@ -100,6 +109,7 @@ jobs:
           header: coverage
           recreate: true
           path: code-coverage-results.md
+
 
       - name: Upload JaCoCo HTML report
         if: always() && hashFiles('**/build/reports/jacoco/test/html/index.html') != ''

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,12 +54,6 @@ jobs:
       - name: Verify Config folders
         run: ls -al config
 
-      - name: Build and Test with 'test' profile
-        run: |
-          echo " >>> Running Gradle build with 'test' profile"
-          ./gradlew --no-daemon clean build -Dspring.profiles.active=test
-          
-
       - name: Build and Test with 'test' profile (timed)
         run: |
           echo " >>> Running Gradle build with 'test' profile"
@@ -79,6 +73,47 @@ jobs:
         with:
           name: build-log-baseline
           path: build.log
+
+
+
+
+      - name: Generate JaCoCo coverage report (timed)
+        if: always()
+        continue-on-error: true
+        run: |
+          /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
+            ./gradlew --no-daemon jacocoTestReport jacocoTestCoverageVerification |& tee jacoco.log
+
+      - name: Coverage summary
+        if: always() && hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          badge: true
+          format: 'markdown'
+          output: 'both'
+
+      - name: Add coverage comment to PR
+        if: github.event_name == 'pull_request' && hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Upload JaCoCo HTML report
+        if: always() && hashFiles('**/build/reports/jacoco/test/html/index.html') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: '**/build/reports/jacoco/test/html'
+
+      - name: Upload jacoco log
+        if: always() && hashFiles('jacoco.log') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-log
+          path: jacoco.log
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,8 +80,6 @@ jobs:
 
       - name: Generate JaCoCo coverage report (timed + enforce gate)
         run: |
-          # 필요시 여기서 최소치 오버라이드 가능(예: 65% / 40%)
-          # export COVERAGE_MIN=0.60 COVERAGE_BRANCH_MIN=0.30
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
             ./gradlew --no-daemon jacocoTestReport jacocoTestCoverageVerification \
               -Dspring.profiles.active=test \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,8 +105,8 @@ jobs:
         if: always() && github.event_name == 'pull_request' && github.base_ref == 'develop' && steps.cov.outputs.file != ''
         env:
           JACOCO_XML: ${{ steps.cov.outputs.file }}
-          COV_MIN: ${{ env.COVERAGE_MIN || '0.01' }}
-          COV_BRANCH_MIN: ${{ env.COVERAGE_BRANCH_MIN || '0.01' }}
+          COV_MIN: ${{ env.COVERAGE_MIN || '0.10' }}
+          COV_BRANCH_MIN: ${{ env.COVERAGE_BRANCH_MIN || '0.05' }}
         run: |
           python - <<'PY'
           import os

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,11 +81,13 @@ jobs:
       - name: Generate JaCoCo coverage report (timed + enforce gate)
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
-            ./gradlew --no-daemon jacocoTestReport jacocoTestCoverageVerification \
+            ./gradlew --no-daemon \
               -Dspring.profiles.active=test \
-              -Pcoverage.min=${COVERAGE_MIN:-0.60} \
-              -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.30} \
-              --stacktrace --info |& tee jacoco.log
+              test jacocoTestReport jacocoTestCoverageVerification \
+              -Pcoverage.min=${COVERAGE_MIN:-0.01} \
+              -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.01} \
+              --rerun-tasks --stacktrace --info |& tee jacoco.log
+
       
 
       - name: Coverage summary

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -96,30 +96,44 @@ jobs:
 
       - name: Coverage & gate (Job Summary)
         if: always() && steps.cov.outputs.file != ''
+        env:
+          JACOCO_XML: ${{ steps.cov.outputs.file }}
+          COV_MIN: ${{ env.COVERAGE_MIN || '0.01' }}
+          COV_BRANCH_MIN: ${{ env.COVERAGE_BRANCH_MIN || '0.01' }}
         run: |
-          set -e
-          FILE="${{ steps.cov.outputs.file }}"
-          CMIN="${COVERAGE_MIN:-0.01}"
-          CBRMIN="${COVERAGE_BRANCH_MIN:-0.01}"
-          LINE=$(grep -oP '<counter type="LINE"[^>]*/>' "$FILE" | head -n1 || true)
-          BR=$(grep -oP '<counter type="BRANCH"[^>]*/>' "$FILE" | head -n1 || true)
-          LM=$(echo "$LINE" | grep -oP 'missed="\d+"' | cut -d'"' -f2); LC=$(echo "$LINE" | grep -oP 'covered="\d+"' | cut -d'"' -f2)
-          BM=$(echo "$BR"   | grep -oP 'missed="\d+"' | cut -d'"' -f2); BC=$(echo "$BR"   | grep -oP 'covered="\d+"' | cut -d'"' -f2)
-          LT=$(( (${LM:-0}) + (${LC:-0}) )); BT=$(( (${BM:-0}) + (${BC:-0}) ))
-          LP=$(awk -v c=${LC:-0} -v t=${LT:-0} 'BEGIN{printf (t>0?"%.2f":"0.00"), (t>0? c/t*100:0)}')
-          BP=$(awk -v c=${BC:-0} -v t=${BT:-0} 'BEGIN{printf (t>0?"%.2f":"0.00"), (t>0? c/t*100:0)}')
-          LMIN=$(awk -v x=$CMIN   'BEGIN{printf "%.2f", x*100}')
-          BMIN=$(awk -v x=$CBRMIN 'BEGIN{printf "%.2f", x*100}')
-          LRES=$(awk -v a=$LP -v b=$LMIN 'BEGIN{print (a>=b)?"PASS":"FAIL"}')
-          BRES=$(awk -v a=$BP -v b=$BMIN 'BEGIN{print (a>=b)?"PASS":"FAIL"}')
-          {
-            echo "## Coverage & Gate"
-            echo ""
-            echo "| Metric | Current | Gate | Result |"
-            echo "|--------|--------:|-----:|:------:|"
-            echo "| Lines  | ${LP}% | ${LMIN}% | ${LRES} |"
-            echo "| Branch | ${BP}% | ${BMIN}% | ${BRES} |"
-          } >> $GITHUB_STEP_SUMMARY
+          python - <<'PY'
+          import os, xml.etree.ElementTree as ET
+
+          path = os.environ["JACOCO_XML"]
+          cov_min = float(os.environ.get("COV_MIN", "0.01")) * 100.0
+          br_min  = float(os.environ.get("COV_BRANCH_MIN", "0.01")) * 100.0
+
+          tree = ET.parse(path)
+          root = tree.getroot()  # <report ...>
+
+          def pct(counter_type):
+              c = next((x for x in root.findall("counter") if x.get("type")==counter_type), None)
+              if c is None: return 0.0
+              missed = int(c.get("missed", 0)); covered = int(c.get("covered", 0))
+              total = missed + covered
+              return (covered / total * 100.0) if total else 0.0
+
+          line_pct   = pct("LINE")
+          branch_pct = pct("BRANCH")
+
+          line_res   = "PASS" if line_pct   >= cov_min else "FAIL"
+          branch_res = "PASS" if branch_pct >= br_min  else "FAIL"
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("## JaCoCo XML path\n")
+              f.write(f"{path}\n\n")
+              f.write("## Coverage & Gate\n\n")
+              f.write("| Metric | Current | Gate | Result |\n")
+              f.write("|--------|--------:|-----:|:------:|\n")
+              f.write(f"| Lines  | {line_pct:.2f}% | {cov_min:.2f}% | {line_res} |\n")
+              f.write(f"| Branch | {branch_pct:.2f}% | {br_min:.2f}% | {branch_res} |\n")
+          PY
+      
 
       - name: Upload coverage HTML
         if: always()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,8 @@ jobs:
       pull-requests: write
 
     steps:
+    # 1. Checkout & Environment Settings
+    # 저장소와 서브모듈을 가져오고 빌드 환경 설정
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -46,12 +48,27 @@ jobs:
       - name: Verify Config folders
         run: ls -al config
 
-      - name: Build & Test (test profile, timed)
+
+
+    # 2. Build&Test (Branch dependent logic)
+    # 이벤트 종류에 따라 실행되는 로직이 다름
+    # - feature 브랜치 push 시 : build + test 수행
+    # - develop 으로의 PR 시  : build만 수행 (테스트는 아래 JaCoCo 단계에서 수행)
+
+      - name: Build & Test (feature branches)
+        if: github.event_name == 'push'
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB" \
             ./gradlew --no-daemon clean build -Dspring.profiles.active=test --profile |& tee build.log
 
+      - name: Build only (for PR to develop)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+        run: |
+          /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (build-only)" \
+            ./gradlew --no-daemon clean assemble -Dspring.profiles.active=test --profile |& tee build.log
+
       - name: Generate coverage (JaCoCo, timed)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
             ./gradlew --no-daemon \
@@ -61,9 +78,12 @@ jobs:
               -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.01} \
               --rerun-tasks |& tee jacoco.log
 
+      # 3. Coverage Analysis
+      # (only PR for develop branch)
+      # JaCoCo 결과 파일을 탐색함. 그리고 커버리지 수치를 요약해 Job Summary에 표시
       - name: Find coverage xml
         id: cov
-        if: always()
+        if: always() && github.event_name == 'pull_request' && github.base_ref == 'develop'
         run: |
           set -e
           CAND="build/reports/jacoco/test/jacocoTestReport.xml"
@@ -82,48 +102,62 @@ jobs:
           echo "Found coverage xml: $FILE (bytes: $(wc -c < "$FILE"))"
 
       - name: Coverage & gate (Job Summary)
-        if: always() && steps.cov.outputs.file != ''
+        if: always() && github.event_name == 'pull_request' && github.base_ref == 'develop' && steps.cov.outputs.file != ''
         env:
           JACOCO_XML: ${{ steps.cov.outputs.file }}
           COV_MIN: ${{ env.COVERAGE_MIN || '0.01' }}
           COV_BRANCH_MIN: ${{ env.COVERAGE_BRANCH_MIN || '0.01' }}
         run: |
           python - <<'PY'
-          import os, xml.etree.ElementTree as ET
+          import os
+          import xml.etree.ElementTree as ET
 
-          path = os.environ["JACOCO_XML"]
+          path = os.environ.get("JACOCO_XML")
           cov_min = float(os.environ.get("COV_MIN", "0.01")) * 100.0
           br_min  = float(os.environ.get("COV_BRANCH_MIN", "0.01")) * 100.0
 
-          tree = ET.parse(path)
-          root = tree.getroot()  # <report ...>
-
-          def pct(counter_type):
-              c = next((x for x in root.findall("counter") if x.get("type")==counter_type), None)
-              if c is None: return 0.0
-              missed = int(c.get("missed", 0)); covered = int(c.get("covered", 0))
+          def pct(root, counter_type):
+              c = next((x for x in root.findall("counter") if x.get("type") == counter_type), None)
+              if c is None:
+                  return 0.0
+              missed = int(c.get("missed", 0))
+              covered = int(c.get("covered", 0))
               total = missed + covered
-              return (covered / total * 100.0) if total else 0.0
+              return (covered / total * 100.0) if total > 0 else 0.0
 
-          line_pct   = pct("LINE")
-          branch_pct = pct("BRANCH")
+          try:
+              tree = ET.parse(path)
+              root = tree.getroot()
 
-          line_res   = "PASS" if line_pct   >= cov_min else "FAIL"
-          branch_res = "PASS" if branch_pct >= br_min  else "FAIL"
+              line_pct = pct(root, "LINE")
+              branch_pct = pct(root, "BRANCH")
 
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
-              f.write("## JaCoCo XML path\n")
-              f.write(f"{path}\n\n")
-              f.write("## Coverage & Gate\n\n")
-              f.write("| Metric | Current | Gate | Result |\n")
-              f.write("|--------|--------:|-----:|:------:|\n")
-              f.write(f"| Lines  | {line_pct:.2f}% | {cov_min:.2f}% | {line_res} |\n")
-              f.write(f"| Branch | {branch_pct:.2f}% | {br_min:.2f}% | {branch_res} |\n")
+              line_res = "PASS " if line_pct >= cov_min else "FAIL"
+              branch_res = "PASS " if branch_pct >= br_min else "FAIL"
+
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+                  f.write("##  JaCoCo Coverage Report\n\n")
+                  f.write(f"**XML path:** `{path}`\n\n")
+                  f.write("| Metric | Current | Threshold | Result |\n")
+                  f.write("|:--------|---------:|----------:|:-------:|\n")
+                  f.write(f"| Lines  | {line_pct:.2f}% | {cov_min:.2f}% | {line_res} |\n")
+                  f.write(f"| Branch | {branch_pct:.2f}% | {br_min:.2f}% | {branch_res} |\n")
+
+              print(f"Line coverage: {line_pct:.2f}% (gate {cov_min:.2f}%) -> {line_res}")
+              print(f"Branch coverage: {branch_pct:.2f}% (gate {br_min:.2f}%) -> {branch_res}")
+
+          except Exception as e:
+              print(f"Coverage parsing failed: {e}")
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+                  f.write("##Coverage Parsing Failed\n\n")
+                  f.write(f"{str(e)}\n")
           PY
-      
 
+      # 4. Artifact Uploads & Reporting
+      # 빌드 로그, 테스트 리포트, 커버리지 HTML 등을 업로드하고,
+      # GitHub Summary 및 코멘트로 테스트 결과를 표시
       - name: Upload coverage HTML
-        if: always()
+        if: always() && github.event_name == 'pull_request' && github.base_ref == 'develop'
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
@@ -146,4 +180,3 @@ jobs:
         with:
           files: '**/build/test-results/test/TEST-*.xml'
           comment_mode: always
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,12 +43,15 @@ jobs:
           redis-remove-container: true
           redis-password: ${{ secrets.REDIS_TEST_PASSWORD }}
 
-      - name: Build & Test (test profile)
+      - name: Verify Config folders
+        run: ls -al config
+
+      - name: Build & Test (test profile, timed)
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB" \
             ./gradlew --no-daemon clean build -Dspring.profiles.active=test --profile |& tee build.log
 
-      - name: Generate coverage (JaCoCo)
+      - name: Generate coverage (JaCoCo, timed)
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
             ./gradlew --no-daemon \
@@ -63,13 +66,22 @@ jobs:
         if: always()
         run: |
           set -e
-          FILE="build/reports/jacoco/test/jacocoTestReport.xml"
-          if [ ! -f "$FILE" ]; then
-            FILE=$(ls -1 **/build/reports/jacoco/**/jacocoTestReport.xml 2>/dev/null | head -n1 || true)
+          CAND="build/reports/jacoco/test/jacocoTestReport.xml"
+          if [ -f "$CAND" ] && [ $(wc -c < "$CAND") -gt 100 ]; then
+            FILE="$CAND"
+          else
+            FILE=$(find . -path "*/build/reports/jacoco/*/jacocoTestReport.xml" -type f -size +100c | head -n 1 || true)
           fi
-          if [ -n "$FILE" ] && [ -f "$FILE" ]; then
-            echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILE" ]; then
+            echo "No valid jacocoTestReport.xml found."
+            echo "## Coverage" >> $GITHUB_STEP_SUMMARY
+            echo "_No JaCoCo XML found or file too small to parse._" >> $GITHUB_STEP_SUMMARY
+            exit 0
           fi
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          echo "Found coverage xml: $FILE (bytes: $(wc -c < "$FILE"))"
+          echo "## JaCoCo XML path" >> $GITHUB_STEP_SUMMARY
+          echo "$FILE" >> $GITHUB_STEP_SUMMARY
 
       - name: Coverage summary (markdown)
         if: always() && steps.cov.outputs.file != ''
@@ -85,6 +97,7 @@ jobs:
       - name: Coverage & gate (Job Summary)
         if: always() && steps.cov.outputs.file != ''
         run: |
+          set -e
           FILE="${{ steps.cov.outputs.file }}"
           CMIN="${COVERAGE_MIN:-0.01}"
           CBRMIN="${COVERAGE_BRANCH_MIN:-0.01}"
@@ -133,6 +146,3 @@ jobs:
           files: '**/build/test-results/test/TEST-*.xml'
           comment_mode: always
 
-      - name: Fail on test failures
-        if: failure()
-        run: exit 1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,19 +80,6 @@ jobs:
           fi
           echo "file=$FILE" >> "$GITHUB_OUTPUT"
           echo "Found coverage xml: $FILE (bytes: $(wc -c < "$FILE"))"
-          echo "## JaCoCo XML path" >> $GITHUB_STEP_SUMMARY
-          echo "$FILE" >> $GITHUB_STEP_SUMMARY
-
-      - name: Coverage summary (markdown)
-        if: always() && steps.cov.outputs.file != ''
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: ${{ steps.cov.outputs.file }}
-          badge: true
-          format: markdown
-          output: both
-          thresholds: 60 80
-          fail_below_min: false
 
       - name: Coverage & gate (Job Summary)
         if: always() && steps.cov.outputs.file != ''

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Verify Config folders
         run: ls -al config
 
+
+
+
+
       - name: Build and Test with 'test' profile (timed)
         run: |
           echo " >>> Running Gradle build with 'test' profile"
@@ -88,31 +92,53 @@ jobs:
               -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.01} \
               --rerun-tasks --stacktrace --info |& tee jacoco.log
 
-      
+      - name: Locate coverage xml
+        id: covfile
+        if: always()
+        run: |
+          set -e
+          FILES=$(ls -1 **/build/reports/jacoco/**/jacocoTestReport.xml | head -n 1 || true)
+          if [ -z "$FILES" ]; then
+            echo "No jacocoTestReport.xml found."
+            exit 0
+          fi
+          FILE="$FILES"
+          echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          echo "Found coverage xml: $FILE"
+          echo "Size (bytes):"
+          wc -c "$FILE" || true
+          echo "----- HEAD (first 40 lines) -----"
+          head -n 40 "$FILE" || true
+          echo "## JaCoCo XML path" >> $GITHUB_STEP_SUMMARY
+          echo "$FILE" >> $GITHUB_STEP_SUMMARY
 
       - name: Coverage summary
-        if: hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
+        if: always() && steps.covfile.outputs.file != ''
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          filename: ${{ steps.covfile.outputs.file }}
           badge: true
           format: 'markdown'
-          output: 'both'
+          output: 'both'   # Job Summary + code-coverage-results.md
           thresholds: 60 80
           fail_below_min: false
 
+      - name: Print coverage to logs
+        if: always() && steps.covfile.outputs.file != '' && hashFiles('code-coverage-results.md') != ''
+        run: |
+          echo "==== Coverage Summary ===="
+          cat code-coverage-results.md
 
       - name: Add coverage comment to PR
-        if: github.event_name == 'pull_request' && hashFiles('**/build/reports/jacoco/test/jacocoTestReport.xml') != ''
+        if: github.event_name == 'pull_request' && steps.covfile.outputs.file != '' && hashFiles('code-coverage-results.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: coverage
           recreate: true
           path: code-coverage-results.md
 
-
       - name: Upload JaCoCo HTML report
-        if: always() && hashFiles('**/build/reports/jacoco/test/html/index.html') != ''
+        if: always() && steps.covfile.outputs.file != ''
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
@@ -124,6 +150,7 @@ jobs:
         with:
           name: jacoco-log
           path: jacoco.log
+
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,29 @@ jobs:
         run: |
           echo " >>> Running Gradle build with 'test' profile"
           ./gradlew --no-daemon clean build -Dspring.profiles.active=test
+          
+
+      - name: Build and Test with 'test' profile (timed)
+        run: |
+          echo " >>> Running Gradle build with 'test' profile"
+          /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB" \
+            ./gradlew --no-daemon clean build -Dspring.profiles.active=test --profile |& tee build.log
+
+      - name: Upload Gradle profile report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-profile-baseline
+          path: '**/build/reports/profile'
+
+      - name: Upload build log (baseline)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log-baseline
+          path: build.log
+
+
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,13 +2,9 @@ name: CI with Gradle
 
 on:
   push:
-    branches-ignore:
-      - main
-      - develop
-
+    branches-ignore: [main, develop]
   pull_request:
-    branches:
-      - develop
+    branches: [develop]
 
 jobs:
   CI:
@@ -20,23 +16,22 @@ jobs:
       checks: write
       pull-requests: write
 
-
     steps:
-      - name: Checkout With Submodules
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           submodules: recursive
           fetch-depth: 0
 
-      - name: Update Git Submodules
-        run: git submodule update --init --recursive
-
-      - name: Set up JDK 21
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: '21'
-          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
@@ -48,41 +43,12 @@ jobs:
           redis-remove-container: true
           redis-password: ${{ secrets.REDIS_TEST_PASSWORD }}
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Verify Config folders
-        run: ls -al config
-
-
-
-
-
-      - name: Build and Test with 'test' profile (timed)
+      - name: Build & Test (test profile)
         run: |
-          echo " >>> Running Gradle build with 'test' profile"
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB" \
             ./gradlew --no-daemon clean build -Dspring.profiles.active=test --profile |& tee build.log
 
-      - name: Upload Gradle profile report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle-profile-baseline
-          path: '**/build/reports/profile'
-
-      - name: Upload build log (baseline)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-log-baseline
-          path: build.log
-
-
-
-
-
-      - name: Generate JaCoCo coverage report (timed + enforce gate)
+      - name: Generate coverage (JaCoCo)
         run: |
           /usr/bin/time -f "elapsed=%E cpu=%P mem=%MKB (jacoco)" \
             ./gradlew --no-daemon \
@@ -90,84 +56,83 @@ jobs:
               test jacocoTestReport jacocoTestCoverageVerification \
               -Pcoverage.min=${COVERAGE_MIN:-0.01} \
               -Pcoverage.branchMin=${COVERAGE_BRANCH_MIN:-0.01} \
-              --rerun-tasks --stacktrace --info |& tee jacoco.log
+              --rerun-tasks |& tee jacoco.log
 
-      - name: Locate coverage xml
-        id: covfile
+      - name: Find coverage xml
+        id: cov
         if: always()
         run: |
           set -e
-          FILES=$(ls -1 **/build/reports/jacoco/**/jacocoTestReport.xml | head -n 1 || true)
-          if [ -z "$FILES" ]; then
-            echo "No jacocoTestReport.xml found."
-            exit 0
+          FILE="build/reports/jacoco/test/jacocoTestReport.xml"
+          if [ ! -f "$FILE" ]; then
+            FILE=$(ls -1 **/build/reports/jacoco/**/jacocoTestReport.xml 2>/dev/null | head -n1 || true)
           fi
-          FILE="$FILES"
-          echo "file=$FILE" >> "$GITHUB_OUTPUT"
-          echo "Found coverage xml: $FILE"
-          echo "Size (bytes):"
-          wc -c "$FILE" || true
-          echo "----- HEAD (first 40 lines) -----"
-          head -n 40 "$FILE" || true
-          echo "## JaCoCo XML path" >> $GITHUB_STEP_SUMMARY
-          echo "$FILE" >> $GITHUB_STEP_SUMMARY
+          if [ -n "$FILE" ] && [ -f "$FILE" ]; then
+            echo "file=$FILE" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Coverage summary
-        if: always() && steps.covfile.outputs.file != ''
+      - name: Coverage summary (markdown)
+        if: always() && steps.cov.outputs.file != ''
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: ${{ steps.covfile.outputs.file }}
+          filename: ${{ steps.cov.outputs.file }}
           badge: true
-          format: 'markdown'
-          output: 'both'   # Job Summary + code-coverage-results.md
+          format: markdown
+          output: both
           thresholds: 60 80
           fail_below_min: false
 
-      - name: Print coverage to logs
-        if: always() && steps.covfile.outputs.file != '' && hashFiles('code-coverage-results.md') != ''
+      - name: Coverage & gate (Job Summary)
+        if: always() && steps.cov.outputs.file != ''
         run: |
-          echo "==== Coverage Summary ===="
-          cat code-coverage-results.md
+          FILE="${{ steps.cov.outputs.file }}"
+          CMIN="${COVERAGE_MIN:-0.01}"
+          CBRMIN="${COVERAGE_BRANCH_MIN:-0.01}"
+          LINE=$(grep -oP '<counter type="LINE"[^>]*/>' "$FILE" | head -n1 || true)
+          BR=$(grep -oP '<counter type="BRANCH"[^>]*/>' "$FILE" | head -n1 || true)
+          LM=$(echo "$LINE" | grep -oP 'missed="\d+"' | cut -d'"' -f2); LC=$(echo "$LINE" | grep -oP 'covered="\d+"' | cut -d'"' -f2)
+          BM=$(echo "$BR"   | grep -oP 'missed="\d+"' | cut -d'"' -f2); BC=$(echo "$BR"   | grep -oP 'covered="\d+"' | cut -d'"' -f2)
+          LT=$(( (${LM:-0}) + (${LC:-0}) )); BT=$(( (${BM:-0}) + (${BC:-0}) ))
+          LP=$(awk -v c=${LC:-0} -v t=${LT:-0} 'BEGIN{printf (t>0?"%.2f":"0.00"), (t>0? c/t*100:0)}')
+          BP=$(awk -v c=${BC:-0} -v t=${BT:-0} 'BEGIN{printf (t>0?"%.2f":"0.00"), (t>0? c/t*100:0)}')
+          LMIN=$(awk -v x=$CMIN   'BEGIN{printf "%.2f", x*100}')
+          BMIN=$(awk -v x=$CBRMIN 'BEGIN{printf "%.2f", x*100}')
+          LRES=$(awk -v a=$LP -v b=$LMIN 'BEGIN{print (a>=b)?"PASS":"FAIL"}')
+          BRES=$(awk -v a=$BP -v b=$BMIN 'BEGIN{print (a>=b)?"PASS":"FAIL"}')
+          {
+            echo "## Coverage & Gate"
+            echo ""
+            echo "| Metric | Current | Gate | Result |"
+            echo "|--------|--------:|-----:|:------:|"
+            echo "| Lines  | ${LP}% | ${LMIN}% | ${LRES} |"
+            echo "| Branch | ${BP}% | ${BMIN}% | ${BRES} |"
+          } >> $GITHUB_STEP_SUMMARY
 
-      - name: Add coverage comment to PR
-        if: github.event_name == 'pull_request' && steps.covfile.outputs.file != '' && hashFiles('code-coverage-results.md') != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: coverage
-          recreate: true
-          path: code-coverage-results.md
-
-      - name: Upload JaCoCo HTML report
-        if: always() && steps.covfile.outputs.file != ''
+      - name: Upload coverage HTML
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: jacoco-html-report
           path: '**/build/reports/jacoco/test/html'
+          if-no-files-found: ignore
 
-      - name: Upload jacoco log
-        if: always() && hashFiles('jacoco.log') != ''
+      - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-log
-          path: jacoco.log
-
-
-
+          name: ci-logs
+          path: |
+            build.log
+            jacoco.log
+          if-no-files-found: ignore
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: '**/build/test-results/test/TEST-*.xml'
           comment_mode: always
 
-      - name: Build summary
-        if: success()
-        run: |
-          echo "Gradle build successfully completed with tests (profile: test)"
-
-      - name: Mark failure if tests failed
+      - name: Fail on test failures
         if: failure()
-        run: |
-          echo "Tests failed. Please check the test logs for detail"
-          exit 1
+        run: exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -28,29 +28,33 @@ jacoco {
 	toolVersion = "0.8.10"
 }
 
-jacocoTestReport {
+
+def coverageMin       = (project.findProperty('coverage.min') ?: '0.60') as BigDecimal
+def coverageBranchMin = (project.findProperty('coverage.branchMin') ?: '0.30') as BigDecimal
+
+tasks.named('jacocoTestCoverageVerification') {
 	dependsOn tasks.named('test')
-	reports {
-		xml.required.set(true)
-		html.required.set(true)
-		csv.required.set(false)
-
-	}
-}
-
-jacocoTestCoverageVerification {
 	violationRules {
 		rule {
+			element = 'BUNDLE'
 			limit {
-				counter = 'INSTRUCTION'
+				counter = 'LINE'
 				value   = 'COVEREDRATIO'
-				minimum = 0.60
+				minimum = coverageMin
+			}
+			limit {
+				counter = 'BRANCH'
+				value   = 'COVEREDRATIO'
+				minimum = coverageBranchMin
 			}
 		}
 	}
 }
 
-check.dependsOn jacocoTestCoverageVerification
+
+tasks.named('check') {
+	dependsOn tasks.named('jacocoTestCoverageVerification')
+}
 
 dependencies {
 	// Spring Basic
@@ -103,10 +107,7 @@ dependencies {
 	// Prometheus, Grafana
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-
 }
-
 
 task copyYml(type: Copy){
 	copy{
@@ -122,6 +123,21 @@ tasks.named('test') {
 			"-Djdk.attach.allowAttachSelf=true",
 			"-XX:+EnableDynamicAgentLoading"
 	]
-	filter { includeTestsMatching "*" }
-	finalizedBy 'jacocoTestReport'
+	finalizedBy(tasks.jacocoTestReport)
 }
+
+tasks.named('jacocoTestReport') {
+	dependsOn tasks.named('test')
+
+	executionData.from = fileTree(dir: "$buildDir", includes: [
+			"jacoco/test.exec",
+			"jacoco/test/*.exec"
+	]).filter { it.exists() && it.length() > 0 }
+
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+		csv.required.set(false)
+	}
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'umc.teumteum'
@@ -22,6 +23,34 @@ configurations {
 repositories {
 	mavenCentral()
 }
+
+jacoco {
+	toolVersion = "0.8.10"
+}
+
+jacocoTestReport {
+	dependsOn tasks.named('test')
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+		csv.required.set(false)
+
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			limit {
+				counter = 'INSTRUCTION'
+				value   = 'COVEREDRATIO'
+				minimum = 0.60
+			}
+		}
+	}
+}
+
+check.dependsOn jacocoTestCoverageVerification
 
 dependencies {
 	// Spring Basic
@@ -91,8 +120,8 @@ tasks.named('test') {
 	useJUnitPlatform()
 	jvmArgs += [
 			"-Djdk.attach.allowAttachSelf=true",
-			"-XX:+EnableDynamicAgentLoading"]
-	filter {
-		includeTestsMatching "*"
-	}
+			"-XX:+EnableDynamicAgentLoading"
+	]
+	filter { includeTestsMatching "*" }
+	finalizedBy 'jacocoTestReport'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,36 @@ jacoco {
 	toolVersion = "0.8.10"
 }
 
-
 def coverageMin       = (project.findProperty('coverage.min') ?: '0.60') as BigDecimal
 def coverageBranchMin = (project.findProperty('coverage.branchMin') ?: '0.30') as BigDecimal
 
+tasks.named('test') {
+	useJUnitPlatform()
+	jvmArgs += [
+			"-Djdk.attach.allowAttachSelf=true",
+			"-XX:+EnableDynamicAgentLoading"
+	]
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.named('jacocoTestReport') {
+	dependsOn tasks.named('test')
+
+	executionData.from = fileTree(dir: "$buildDir", includes: [
+			"jacoco/test.exec",
+			"jacoco/test/*.exec"
+	]).filter { it.exists() && it.length() > 0 }
+
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+		csv.required.set(false)
+	}
+}
+
 tasks.named('jacocoTestCoverageVerification') {
 	dependsOn tasks.named('test')
+	mustRunAfter tasks.named('jacocoTestReport')
 	violationRules {
 		rule {
 			element = 'BUNDLE'
@@ -50,7 +74,6 @@ tasks.named('jacocoTestCoverageVerification') {
 		}
 	}
 }
-
 
 tasks.named('check') {
 	dependsOn tasks.named('jacocoTestCoverageVerification')
@@ -109,35 +132,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
-task copyYml(type: Copy){
-	copy{
+task copyYml(type: Copy) {
+	copy {
 		from './config'
 		include '*.properties'
 		into 'src/main/resources'
 	}
 }
-
-tasks.named('test') {
-	useJUnitPlatform()
-	jvmArgs += [
-			"-Djdk.attach.allowAttachSelf=true",
-			"-XX:+EnableDynamicAgentLoading"
-	]
-	finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.named('jacocoTestReport') {
-	dependsOn tasks.named('test')
-
-	executionData.from = fileTree(dir: "$buildDir", includes: [
-			"jacoco/test.exec",
-			"jacoco/test/*.exec"
-	]).filter { it.exists() && it.length() > 0 }
-
-	reports {
-		xml.required.set(true)
-		html.required.set(true)
-		csv.required.set(false)
-	}
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ jacoco {
 	toolVersion = "0.8.10"
 }
 
-def coverageMin       = (project.findProperty('coverage.min') ?: '0.60') as BigDecimal
-def coverageBranchMin = (project.findProperty('coverage.branchMin') ?: '0.30') as BigDecimal
+def coverageMin       = (project.findProperty('coverage.min') ?: '0.10') as BigDecimal
+def coverageBranchMin = (project.findProperty('coverage.branchMin') ?: '0.05') as BigDecimal
 
 tasks.named('test') {
 	useJUnitPlatform()


### PR DESCRIPTION
### 👀 관련 이슈
#230 

### ✨ 작업한 내용
Github Actions CI 설정을 리팩터링 했습니다.
주로 변경된 부분은 다음과 같습니다.

1. 테스트 커버리지(Jacoco Coverage) 레포트 추가
2. 이벤트별 빌드 동작 분리

###  JaCoCo 커버리지

- JaCoCo는 Java 프로젝트에서 **테스트 코드가 실제 소스 코드를 얼마나 실행했는지(=커버리지)** 를 측정하는 도구입니다.  즉, 테스트가 코드 로직을 얼마나 검증하고 있는지를 수치(%)로 표현합니다.

- CI 환경에서는 PR 생성 시 자동으로 JaCoCo가 실행됩니다. (그냥 push 시에는 실행되지 않음)
  커버리지 리포트(jacocoTestReport) 를 생성하고
  커버리지 검증(jacocoTestCoverageVerification) 을 통해 기준치 이하일 경우 빌드를 실패시킵니다.

- 라인(Line) 커버리지
  → 전체 코드 라인 중 테스트에서 실제 실행된 라인의 비율입니다.  
  예: 100줄 중 60줄이 테스트 중 실행되면 60%  

- 브랜치(Branch) 커버리지
  → 조건문(`if`, `switch`) 등의 분기(branch)가 테스트에서 얼마나 수행되었는지를 나타냅니다.  
  예: `if (a > 0)` 구문의 true/false 양쪽이 모두 실행되면 100%, 한 쪽만 실행되면 50%

### 이벤트별 CI 동작 구조

| 이벤트 종류 | 주요 스텝 | 설명 |
|--------------|------------|------|
| **push (feature 브랜치 등)** | Build & Test | 새로운 기능 개발 시 빠른 단위 테스트 검증만 수행 |
| **pull_request → develop** | Build only → JaCoCo Coverage | 병합 전 품질 검증을 위해 빌드 후 테스트 및 커버리지 계산 수행 |
| **push → develop / main** | 실행 제외 | 배포용 브랜치는 CI 실행 대상에서 제외 |

> 즉, feature 브랜치에서는 단순 테스트만 빠르게 검증하고,  develop으로의 PR 시에는 커버리지 분석까지 수행합니다. ( push 시 커버리지 분석까지 실행되면 시간이 너무 오래 걸려 제외했습니다..! )

### 리포트 및 결과 저장

CI 실행 후, 다음 결과물이 자동으로 업로드됩니다.

| 항목 | 설명 |
|------|------|
| **JaCoCo HTML Report (jacoco-html-report)** | 테스트 커버리지 시각화 리포트. 코드별 실행 비율을 색상으로 확인 가능 |
| **Build Logs (ci-logs)** | `build.log`, `jacoco.log` 등 빌드와 테스트 실행 로그 저장 |
| **Test Results** | 단위 테스트 결과 XML 파일을 기반으로, PR 코멘트에 자동 표시 |

<img width="838" height="120" alt="스크린샷 2025-10-11 오후 3 09 12" src="https://github.com/user-attachments/assets/12a2b0c1-baa0-4790-a5eb-4ac1237fff57" />


<img width="615" height="193" alt="스크린샷 2025-10-11 오후 3 07 56" src="https://github.com/user-attachments/assets/f39a50b6-dbb5-48a1-9a22-ca8a835e7a36" />

#### 아티팩트란?
- **아티팩트**는 GitHub Actions 실행 결과로 생성된 파일(빌드 산출물)입니다.  
- 예를 들어 HTML 리포트, 로그 파일 등이 이에 해당합니다.  
- CI 실행이 완료된 후 **GitHub Actions 탭 → 해당 워크플로우 실행 페이지 → “Artifacts” 섹션** 에서 직접 다운로드할 수 있습니다.




### 🍰 참고사항
- 현재 커버리지 기준은 **라인 10% / 브랜치 5%** 로 설정되어 있습니다.  
  (기능 구현이 어느정도 완료된 후, 이 값을 늘리면서 테스트 코드 작성을 진행하면 좋을 것 같습니다!)
- JaCoCo 기준치는 `COVERAGE_MIN`, `COVERAGE_BRANCH_MIN` 환경 변수로 조정할 수 있습니다.
- 기준치 변경 시, Gradle의 기준치도 함께 맞췃서 변경
해야 합니다.

<img width="844" height="298" alt="스크린샷 2025-10-11 오후 3 11 04" src="https://github.com/user-attachments/assets/e114e4db-fa9d-4ab2-904d-68cef87131aa" />

