### PR TITLE
Feat: 소셜 로그인 API 구현 - 구글

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -26,14 +26,14 @@ public class AuthController {
 
     @Operation(
             summary = "소셜 로그인",
-            description = "카카오, 네이버에 대한 소셜 플랫폼을 통한 로그인을 처리합니다."
+            description = "카카오, 네이버, 구글에 대한 소셜 플랫폼을 통한 로그인을 처리합니다."
     )
     @PostMapping(value = "/social-login/{socialType}", produces = "application/json")
     public ApiResponse<AuthResponseDto.LoginResponse> socialLogin(
             @Parameter(
-                    description = "소셜 로그인 타입 (naver 또는 kakao)",
+                    description = "소셜 로그인 타입 (kakao 또는 naver 또는 google)",
                     required = true,
-                    schema = @Schema(type = "string", allowableValues = {"naver", "kakao"}, example = "kakao")
+                    schema = @Schema(type = "string", allowableValues = {"kakao", "naver", "google"}, example = "kakao")
             )
             @PathVariable("socialType") String socialType,
             @Valid @RequestBody AuthRequestDto.SocialLoginRequest request

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
@@ -16,9 +16,9 @@ public class AuthRequestDto {
     @Schema(title = "인증 - 소셜 로그인 Request")
     public static class SocialLoginRequest {
 
-        @NotBlank(message = "액세스 토큰은 필수입니다.")
-        @Schema(description = "소셜 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
-        private String accessToken;
+        @NotBlank(message = "소셜 타입별 토큰은 필수입니다.")
+        @Schema(description = "소셜 타입별 토큰. 카카오/네이버는 accessToken, 구글은 idToken을 전달", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        private String token;
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
@@ -15,6 +15,7 @@ public enum AuthErrorStatus implements BaseErrorCode {
     KAKAO_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "카카오 사용자 정보 조회에 실패했습니다."),
     NAVER_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4003", "네이버 사용자 정보 조회에 실패했습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4004", "유효하지 않은 리프레시 토큰입니다."),
+    GOOGLE_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4005", "구글 사용자 정보 조회에 실패했습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4011", "리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH40112", "리프레시 토큰이 일치하지 않습니다."),
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -40,6 +40,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Resource(name = "kakaoOAuthServiceImpl") private OAuthService kakaoOAuthService;
     @Resource(name = "naverOAuthServiceImpl") private OAuthService naverOAuthService;
+    @Resource(name = "googleOAuthServiceImpl") private OAuthService googleOAuthService;
     private final UserService userService;
 
     private final JwtProvider jwtProvider;
@@ -61,7 +62,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public AuthResponseDto.LoginResponse socialLogin(String socialType, AuthRequestDto.SocialLoginRequest request) {
         // 1. 소셜 로그인 - 사용자 정보 불러오기
-        OAuthUserInfo userInfo = getUserInfo(SocialType.valueOf(socialType.toUpperCase()), request.getAccessToken());
+        OAuthUserInfo userInfo = getUserInfo(SocialType.valueOf(socialType.toUpperCase()), request.getToken());
 
         // 2. 사용자 조회 (없으면 생성)
         User user = userService.findOrCreateUser(userInfo);
@@ -220,12 +221,14 @@ public class AuthServiceImpl implements AuthService {
 
 
     // SocialType 따라 로그인 분기 처리
-    private OAuthUserInfo getUserInfo(SocialType socialType, String accessToken) {
+    private OAuthUserInfo getUserInfo(SocialType socialType, String token) {
         switch (socialType) {
             case SocialType.KAKAO:
-                return kakaoOAuthService.getUserInfoWithAccessToken(accessToken);
+                return kakaoOAuthService.getUserInfoWithAccessToken(token);
             case SocialType.NAVER:
-                return naverOAuthService.getUserInfoWithAccessToken(accessToken);
+                return naverOAuthService.getUserInfoWithAccessToken(token);
+            case SocialType.GOOGLE:
+                return googleOAuthService.getUserInfoWithIdToken(token);
             default:
                 throw new AuthException(AuthErrorStatus.INVALID_SOCIAL_TYPE);
         }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
@@ -1,0 +1,42 @@
+package umc.teumteum.server.domain.auth.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.auth.converter.AuthConverter;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.auth.exception.AuthException;
+import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthServiceImpl implements OAuthService {
+
+    private final GoogleIdTokenVerifier googleIdTokenVerifier;
+
+    // 사용자 정보 조회
+    @Override
+    public OAuthUserInfo getUserInfoWithIdToken(String idToken) {
+        try {
+            // 1. ID Token 검증
+            GoogleIdToken googleIdToken = googleIdTokenVerifier.verify(idToken);
+            if (googleIdToken == null) {
+                throw new AuthException(AuthErrorStatus.GOOGLE_USER_INFO_FAILED);
+            }
+
+            // 2. 사용자 정보 추출
+            Payload payload = googleIdToken.getPayload();
+            String socialId = payload.getSubject();
+            String email = payload.getEmail();
+
+            // 3. OAuthUserInfo 반환
+            return AuthConverter.toOAuthUserInfo(SocialType.GOOGLE, socialId, email);
+
+        } catch (Exception e) {
+            throw new AuthException(AuthErrorStatus.GOOGLE_USER_INFO_FAILED);
+        }
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
@@ -3,5 +3,11 @@ package umc.teumteum.server.domain.auth.service;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 
 public interface OAuthService {
-    OAuthUserInfo getUserInfoWithAccessToken(String accessToken);
+    default OAuthUserInfo getUserInfoWithAccessToken(String accessToken) {
+        throw new UnsupportedOperationException("해당 소셜에서는 accessToken 지원하지 않음");
+    }
+
+    default OAuthUserInfo getUserInfoWithIdToken(String idToken) {
+        throw new UnsupportedOperationException("해당 소셜에서는 idToken 지원하지 않음");
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/enums/SocialType.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/enums/SocialType.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.user.entity.enums;
 
 public enum SocialType {
-    NAVER,    // 네이버
-    KAKAO,    // 카카오
+    KAKAO,      // 카카오
+    NAVER,      // 네이버
+    GOOGLE,     // 구글
 }

--- a/src/main/java/umc/teumteum/server/global/config/GoogleOAuthConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/GoogleOAuthConfig.java
@@ -1,0 +1,24 @@
+package umc.teumteum.server.global.config;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+
+@Configuration
+public class GoogleOAuthConfig {
+
+  @Value("${oauth.google.client-id}")
+  private String clientId;
+
+  @Bean
+  public GoogleIdTokenVerifier googleIdTokenVerifier() {
+    return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+            .setAudience(Collections.singletonList(clientId))
+            .build();
+  }
+}


### PR DESCRIPTION
### 👀 관련 이슈
#231 

### ✨ 작업한 내용
- **구글 클라우드에 프로젝트 생성 및 설정**
- **기존 소셜 로그인 API에 구글 추가**
  - 이전 카카오/네이버와 달리 AccessToken이 아닌 `IdToken을 전달받아` 소셜 로그인을 진행합니다. (자세한 내용은 이슈 참고)
  - 공통으로 로그인 Request를 사용하기 위해 필드명을 `accessToken -> token`으로 변경한 관계로 FE에서도 수정이 필요합니다.
      (‼️ But, FE에서의 작업 일정을 고려하여 머지는 추후 진행할 예정 ‼️)

### 🌀 PR Point
X

### 🍰 참고사항
- 구글 추가로 인해 DB 최신화 필요
  ```
    alter table user
        modify social_type enum ('KAKAO', 'NAVER', 'GOOGLE') not null;
  ```
- 서브모듈 최신화 필요
- FE 개발 이전이기 때문에, `dev/test/prod` 모두 웹용 구글 클라이언트 ID로 임시 설정한 상태
-> 추후, FE 개발 시작하면 `prod`는 안드로이드용 클라이언트 ID로 변경 필요

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
| 소셜 로그인 API (구글) | <img width="1000" height="1500" alt="image" src="https://github.com/user-attachments/assets/b8681bdc-40c0-486b-b256-425424e26a2d" /> |

