### PR TITLE
Feat: 투두, 위시 관련 중복 로직

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/WishRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/WishRequestDto.java
@@ -50,8 +50,5 @@ public class WishRequestDto {
         @NotNull
         @Schema(description = "종료 시간", example = "2025-07-24T11:00")
         private LocalDateTime endTime;
-        @NotNull
-        @Schema(description = "강제 등록 여부", example = "false")
-        private Boolean isForce;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -70,9 +70,6 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
-        // 충돌 검사
-        conflictValidator.validateTodo(user,dto.getStartTime(), dto.getEndTime());
-
         // 1. 스케줄 저장
         Schedule schedule = scheduleConverter.toSchedule(dto,user);
         Schedule savedSchedule = scheduleRepository.save(schedule);
@@ -178,17 +175,14 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
-        // 5. 충돌 검사
-        conflictValidator.validateTodo(user,dto.getStartTime(), dto.getEndTime());
-
-        // 6. 스케줄 필드 업데이트
+        // 5. 스케줄 필드 업데이트
         schedule.updateField(dto);
 
-        // 7. 스케줄 리마인드 알림 제거 -> 새로운 리마인드 알림 저장
-        // 7-1. 기존 리마인드 알림 삭제
+        // 6. 스케줄 리마인드 알림 제거 -> 새로운 리마인드 알림 저장
+        // 6-1. 기존 리마인드 알림 삭제
         scheduleReminderRepository.deleteByScheduleId(scheduleId);
 
-        // 7-2. 리마인드 알림 필드 업데이트
+        // 6-2. 리마인드 알림 필드 업데이트
         if (dto.getRemindAlarm() != null && !dto.getRemindAlarm().isEmpty()) {
             List<ScheduleReminder> reminders =
                     scheduleConverter.toScheduleReminders(schedule, dto.getRemindAlarm());
@@ -465,11 +459,7 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
-        // 3 중복 스케줄 체크
-        // 3-1. 틈 & 수면패턴 중복 검사 -> 등록 불가
-        conflictValidator.validateTodo(user,dto.getStartTime(),dto.getEndTime());
-
-        // 3-2. 스케줄 중복 검사 -> 등록 가능
+        // 3 중복 스케줄 체크 -> 스케줄 중복 검사
         LocalDate date = dto.getStartTime().toLocalDate();
         LocalDateTime startTime = dto.getStartTime();
         LocalDateTime endTime = dto.getEndTime();
@@ -478,8 +468,7 @@ public class HomeServiceImpl implements HomeService {
                 user.getId(), date, startTime, endTime
         );
 
-        if (hasConflict && !dto.getIsForce()) {
-            // force가 false고 일정이 겹치면 예외
+        if (hasConflict) {
             throw new HomeException(HomeErrorStatus._SCHEDULE_CONFLICT);
         }
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#232
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
투두를 등록할 때, 모든 타입과 중복 등록이 가능하여 중복 검증 로직을 삭제했습니다.
위시를 등록할 때는 투두와 겹치더라도 강제 등록 여부를 확인하고 등록할 수 있었습니다. 변경된 로직에서는 투두와 겹치게 등록할 수 없기때문에 강제 등록 여부를 확인하기 위한 DTO 필드를 없애고 투두와 겹친다면 에러가 발생하도록 수정했습니다. 

[투두]

- 기존: 수면패턴 검증 & 미확정 틈 요청 검증
- 변경: 모든 타입과 중복 가능 -> 중복 검증 제거

[위시]

- 기존: 직접 생성한 투두와 중복 가능
- 변경: 직접 생성한 투두와 중복 불가 -> 중복 검증 추가

### 🌀 PR Point
투두 등록 POST `/api/home/todo`
위시 등록 POST `/api/wishes/{wishId}/assign`

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일정 충돌 방지 기능이 강화되었습니다. 더 이상 일정 충돌을 무시하고 등록할 수 없습니다.
  * 원하는 일정 추가 시 일정 충돌 감지가 항상 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->