### PR TITLE
Feat: 알림 설정 엔티티 필드 변경

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/entity/NotificationSetting.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/NotificationSetting.java
@@ -32,22 +32,10 @@ public class NotificationSetting extends BaseEntity {
     private Boolean remindAlarm = true;
 
     @Builder.Default
-    @Column(name = "receive_request", nullable = false)
-    private Boolean receiveRequest = true;
+    @Column(name = "teum", nullable = false)
+    private Boolean teum = true;
 
     @Builder.Default
-    @Column(name = "accept_request", nullable = false)
-    private Boolean acceptRequest = true;
-
-    @Builder.Default
-    @Column(name = "reject_request", nullable = false)
-    private Boolean rejectRequest = true;
-
-    @Builder.Default
-    @Column(name = "change_time", nullable = false)
-    private Boolean changeTime = true;
-
-    @Builder.Default
-    @Column(name = "is_canceled", nullable = false)
-    private Boolean isCanceled = true;
+    @Column(name = "follow", nullable = false)
+    private Boolean follow = true;
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -97,10 +97,6 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Notification> notifications;
 
-    // 알림 설정
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
-    private NotificationSetting notificationSetting;
-
     // 내가 팔로우하는 사람들
     @OneToMany(mappedBy = "follower", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Friend> followings = new ArrayList<>();

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -97,6 +97,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Notification> notifications;
 
+    // 알림 설정
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private NotificationSetting notificationSetting;
+
     // 내가 팔로우하는 사람들
     @OneToMany(mappedBy = "follower", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Friend> followings = new ArrayList<>();


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#234
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 마이페이지에서 토글로 변경할 수 있는 알림 항목이 ‘오늘의 일정’, ‘리마인드 알림’, ‘팔로우’, ‘틈 요청’이므로 이에 맞춰 notification_setting 테이블 필드를 수정했습니다.
### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
X
### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경사항

* **기능 업데이트**
  * 알림 설정이 정리되어 설정 항목이 간소화되고 관리가 쉬워졌습니다.
  * 새 알림 옵션(팀 알림 및 팔로우 알림)이 추가되어 더 세부적으로 수신 여부를 제어할 수 있습니다.
* **리팩터**
  * 사용자와 알림 설정 간의 연관이 새로 도입되어 설정이 사용자와 함께 자동으로 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->