### PR TITLE
Feat: 틈 관련 수정 사항 반영

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/notification/service/NotificationUseCases.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/service/NotificationUseCases.java
@@ -57,34 +57,6 @@ public class NotificationUseCases {
     );
   }
 
-  // 틈 요청 알림(1:다) : sender -> receivers
-  public void notifyTeumRequestBatch(User sender, List<User> receivers, Long requestId, TeumRequestDto.TeumRequest request) {
-    String content = NotificationType.TEUM_REQUEST.getContent();
-
-    int totalReceivers = (request.getReceiverUserIds() == null) ? 0 : request.getReceiverUserIds().size();
-    int othersCount = Math.max(0, totalReceivers - 1);
-
-    Map<String, String> data = new java.util.HashMap<>();
-    data.put("senderId", String.valueOf(sender.getId()));
-    data.put("senderName", sender.getNickname());
-    data.put("title", request.getTitle());
-    data.put("description", request.getDescription() == null ? "" : request.getDescription());
-    data.put("date", request.getDate());
-    data.put("startTime", request.getStartTime());
-    data.put("endTime", request.getEndTime());
-    data.put("graphicId", String.valueOf(request.getGraphicId()));
-    data.put("isGroup", String.valueOf(othersCount > 0));
-    data.put("othersCount", String.valueOf(othersCount));
-
-    orchestrator.saveAndPushToMany(
-        receivers,
-        NotificationType.TEUM_REQUEST,
-        content,
-        requestId,
-        data
-    );
-  }
-
   // 틈 응답 알림
   public void notifyTeumResponse(User sender, User receiver, Long teumResponseId, boolean accepted) {
     NotificationType type = accepted ? NotificationType.TEUM_ACCEPTED : NotificationType.TEUM_DECLINED;

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -85,7 +85,11 @@ public class TeumController {
 
     @Operation(
             summary = "틈 응답 상태 변경",
-            description = "응답 ID(responseId)에 해당하는 응답의 상태를 변경합니다. 상태가 'accepted'인 경우 틈 생성 여부를 판단하여 반환합니다."
+            description = """
+            응답 ID(responseId)에 해당하는 응답의 상태를 변경합니다.
+            - ACCEPTED: 틈 요청을 수락하며, 일정이 생성됩니다.
+            - REJECTED: 틈 요청을 거절하며, 요청이 종료됩니다.
+            """
     )
     @PatchMapping("/response/{responseId}/status")
     public ApiResponse<TeumResponseDto.TeumStatusUpdate> updateResponseStatus(

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -45,26 +45,19 @@ public class TeumConverter {
                 .build();
     }
 
-    public List<TeumResponse> toTeumResponses(
-            List<Long> receiverUserIds, Long senderId,
-            TeumRequest request, Function<Long, User> userFetcher
-    ) {
-        return receiverUserIds.stream()
-                .distinct()
-                .map(receiverId -> {
-                    if (receiverId.equals(senderId)) {
-                        throw new GeneralException(TeumErrorStatus.CANNOT_REQUEST_SELF);
-                    }
-                    User receiver = userFetcher.apply(receiverId);
-                    return TeumResponse.builder()
-                            .teumRequest(request)
-                            .receiverUser(receiver)
-                            .status(ResponseStatus.PENDING)
-                            .readAt(null)
-                            .build();
-                })
-                .toList();
+    public TeumResponse toTeumResponse(Long receiverUserId, Long senderId, TeumRequest request, Function<Long, User> userFetcher) {
+        if (receiverUserId.equals(senderId)) {
+            throw new GeneralException(TeumErrorStatus.CANNOT_REQUEST_SELF);
+        }
+        User receiver = userFetcher.apply(receiverUserId);
+        return TeumResponse.builder()
+                .teumRequest(request)
+                .receiverUser(receiver)
+                .status(ResponseStatus.PENDING)
+                .readAt(null)
+                .build();
     }
+
 
     public TeumResponseDto.TeumReceived toReceivedResponseDto(TeumResponse response, String senderProfileImageUrl) {
         TeumRequest request = response.getTeumRequest();

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
@@ -57,9 +57,9 @@ public class TeumRequestDto {
         @Schema(description = "그래픽 ID", example = "1")
         private Long graphicId;
 
-        @NotEmpty
-        @Schema(description = "수신자 ID 배열", example = "[0, 1]")
-        private List<Long> receiverUserIds;
+        @NotNull
+        @Schema(description = "수신자 ID (한 명만 가능)", example = "2")
+        private Long receiverUserId;
 
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
@@ -85,7 +85,7 @@ public class TeumRequestDto {
     @Schema(title = "TeumStatusUpdate : 틈 응답 상태 변경 DTO")
     public static class TeumStatusUpdate {
 
-        @Schema(description = "응답 상태", example = "ACCEPTED", allowableValues = {"ACCEPTED", "DECLINED", "SUGGESTED"})
+        @Schema(description = "응답 상태", example = "ACCEPTED", allowableValues = {"ACCEPTED", "REJECTED"})
         private String status;
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -222,41 +222,43 @@ public class TeumServiceImpl implements TeumService {
         boolean isAccepted = newStatus == ResponseStatus.ACCEPTED;
         Long teumId = null;
 
+        TeumRequest request = response.getTeumRequest();
+        User receiver = response.getReceiverUser();
+        User requester = request.getUser();
+
         if (isAccepted) {
-            TeumRequest request = response.getTeumRequest();
-            User receiver = response.getReceiverUser();
 
-            // 수락 시 응답자 개인 일정 충돌 검증
-            LocalDate date = request.getDate();
-            LocalTime startTime = request.getStartTime();
-            LocalTime endTime = request.getEndTime();
-
-            conflictValidator.validateTeum(receiver, date, startTime, endTime);
-
-            // 수신자(응답자) 일정 생성
+            // 스케줄 생성: 수신자(응답자)
             Schedule receiverSchedule = teumConverter.toScheduleFromTeumRequest(request, receiver);
             scheduleRepository.save(receiverSchedule);
 
-            // 요청자 본인의 스케줄이 없는 경우에만 생성
-            User requester = request.getUser();
+            // 스케줄 생성: 요청자(없으면 생성)
             if (!scheduleRepository.existsByTeumRequestAndUser(request, requester)) {
                 Schedule requesterSchedule = teumConverter.toScheduleFromTeumRequest(request, requester);
                 scheduleRepository.save(requesterSchedule);
             }
 
-            // 수신자 본인 스케줄 ID 반환
+            // 응답자 스케줄 ID 반환
             teumId = receiverSchedule.getId();
+
+            // 1:1 확정 → 요청 종료
+            request.markAsClosed();
+
+        } else {
+            if (newStatus == ResponseStatus.REJECTED || newStatus == ResponseStatus.LEFT) {
+                request.markAsClosed();
+            }
         }
-        // [추가] 알림 전송
-        User sender = response.getReceiverUser();
-        User receiver = response.getTeumRequest().getUser();
+
+        // 알림 (응답자 → 요청자)
         notificationUseCases.notifyTeumResponse(
-            sender,
-            receiver,
-            response.getId(),
-            isAccepted
+                receiver,
+                requester,
+                response.getId(),
+                isAccepted
         );
 
+        // 응답 DTO
         return teumConverter.toStatusUpdateResponseDto(newStatus, isAccepted, teumId);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -71,45 +71,38 @@ public class TeumServiceImpl implements TeumService {
         // 시작 시간이 현재 시각보다 과거인지 검증
         validateStartTimeNotPast(date, startTime);
 
-        // 모든 사용자 조회 (요청자 + 수신자)
-        List<User> receivers = dto.getReceiverUserIds().stream()
-                .map(this::getUserOrThrow)
-                .toList();
-        List<User> allParticipants = new ArrayList<>(receivers);
-        allParticipants.add(user);
+        // 수신자 조회 (단일 사용자)
+        User receiver = getUserOrThrow(dto.getReceiverUserId());
 
-        // Validator 호출
-        conflictValidator.validateTeumForUsers(allParticipants, date, startTime, endTime);
+        // 요청자와 수신자 둘 다 시간 충돌 여부 검증
+        conflictValidator.validateTeumForUsers(
+                List.of(user, receiver),   // 두 명만 비교
+                date,
+                startTime,
+                endTime
+        );
 
         // 요청 객체 생성 및 저장
         TeumRequest request = teumConverter.toTeumRequest(dto, user);
-        List<TeumResponse> responses = teumConverter.toTeumResponses(
-                dto.getReceiverUserIds(),
+        TeumResponse response = teumConverter.toTeumResponse(
+                dto.getReceiverUserId(),
                 user.getId(),
                 request,
                 this::getUserOrThrow
         );
 
-        request.getTeumResponses().addAll(responses);
+        request.getTeumResponses().add(response);
         teumRequestRepository.save(request);
 
-      // [추가] 알림 전송
-        if (receivers.size() == 1) {
-            notificationUseCases.notifyTeumRequest(
-                user,
-                receivers.get(0),
+      // [추가] 단일 수신자 알림 전송
+        notificationUseCases.notifyTeumRequest(
+                user,          // 요청자
+                receiver,      // 단일 수신자
                 request.getId(),
                 dto
-            );
-        } else if (!receivers.isEmpty()) {
-            notificationUseCases.notifyTeumRequestBatch(
-                user,
-                receivers,
-                request.getId(),
-                dto
-            );
-        }
+        );
         return request.getId();
+
     }
 
     @Override

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -30,14 +30,13 @@ public class ConflictValidator {
     /**
      * 단일 사용자에 대한 Teum 시간 중복 검증 로직
      * - 사용자가 일정 생성 또는 Teum 응답을 시도할 때 호출
-     * - 일정, 미확정된 틈 요청, 반복 일정, 수면 시간과 겹침 여부를 검사
+     * - 일정, 반복 일정, 수면 시간과 겹침 여부를 검사
      */
     public void validateTeum(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
         LocalDateTime startDateTime = LocalDateTime.of(date, startTime);
         LocalDateTime endDateTime = LocalDateTime.of(date, endTime);
 
         checkWithSchedules(user, startDateTime, endDateTime);
-        checkWithTeumRequests(user, startDateTime, endDateTime);
         checkWithRoutines(user, date, startDateTime, endDateTime);
         checkWithSleepPattern(user, date, startDateTime, endDateTime);
     }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#247 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- **틈 요청을 다자간 -> 1:1 구조로 변경**
   - `receiverUserIds(List<Long>)` → `receiverUserId(Long)`로 수정
   - 요청 생성 시 한 명에게만 요청 가능하도록 변경
   - `TeumServiceImpl.createRequest()` 로직 단순화
 - **Converter 수정**
    -  `toTeumResponses()` → `toTeumResponse()` 단일 수신자 버전으로 변경
 - **알림 로직 정리**
    - `notifyTeumRequestBatch()` 제거
    - `notifyTeumRequest()` 단일 수신자 전송만 남김
 - **응답 상태 변경 로직 수정**
    - `updateResponseStatus()`에서 수락 시 충돌 검증 제거
 - **틈 요청 중복 처리 변경**
    - 확정된 일정만 에러 처리
    - 틈 응답 시 중복 확인 제거

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 1:1 구조로 변경되면서 `validateTeumForUsers()` 호출 로직이 여전히 2명 리스트로 처리되는데 이 부분이 `validateTeum()` 2회 호출로 바꾸는 게 더 명확할지 고민이 됩니다... 

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 재요청 API는 1:1 구조에 맞춰 동작 중
- 공통 가능 시간 API는 기존 구조 그대로 유지

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 틈 요청이 1:N에서 1:1 모델로 변경되어 한 요청당 단일 수신자만 처리됩니다. 다중 수신자 생성·알림 로직이 제거되고 요청/응답 흐름이 단순화되었습니다.
* **기능 변경**
  * 요청 페이로드와 상태값이 단일 수신자 및 허용 상태(ACCEPTED, REJECTED)에 맞게 업데이트되었습니다.
* **문서화**
  * 응답 상태 업데이트 API 설명이 더 상세하게 개선되었습니다.
* **검증**
  * 충돌 검사 범위가 일부 요청 기반 중복 확인을 제외하도록 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->