### PR TITLE
Refactor: 반복일정 등록 API - 수면패턴 중복 허용

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -21,7 +21,6 @@ public enum UserErrorStatus implements BaseErrorCode {
     INVALID_IMAGE_NAME(HttpStatus.BAD_REQUEST, "ONBOARDING4005", "잘못된 파일명에 대한 등록 요청입니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "ONBOARDING4006", "시작/종료 시간이 잘못 설정된 반복 일정이 존재합니다."),
     ROUTINE_TIME_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4007", "반복 일정 간 시간 충돌이 발생했습니다."),
-    ROUTINE_SLEEP_CONFLICT(HttpStatus.BAD_REQUEST, "ONBOARDING4008", "수면 패턴과 반복 일정 간 시간 충돌이 발생했습니다."),
     INVALID_REMIND_ALARM_VALUE(HttpStatus.BAD_REQUEST, "ONBOARDING4009", "리마인드 알림은 1분, 3분, 5분, 10분, 30분 중에서만 설정 가능합니다."),
     EXPIRED_UPLOAD_SESSION(HttpStatus.BAD_REQUEST, "ONBOARDING4010", "프로필 이미지 업로드 세션이 만료되었습니다."),
     INVALID_SLEEP_DURATION(HttpStatus.BAD_REQUEST, "ONBOARDING4011", "수면 패턴은 최대 23시간까지 설정 가능합니다."),

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -225,18 +225,18 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 4. 반복 일정끼리의 충돌 확인
         validateRoutineConflictsByDay(routinesByDay);
 
-        // 5. 수면패턴과의 충돌 확인
-        validateSleepPatternConflictsByDay(routinesByDay, user);
+//        // 5. 수면패턴과의 충돌 확인
+//        validateSleepPatternConflictsByDay(routinesByDay, user);
 
-        // 6. 반복 일정 저장
+        // 5. 반복 일정 저장
         List<Routine> newRoutines = OnboardingConverter.toRoutineList(request.getRoutine(), user);
         routineJdbcRepository.batchInsertRoutines(newRoutines);
 
-        // 7. 오늘 요일에 해당하는 저장된 Routine만 조회 (기본키값 필요)
+        // 6. 오늘 요일에 해당하는 저장된 Routine만 조회 (기본키값 필요)
         Weekday todayWeekday = Weekday.from(LocalDate.now().getDayOfWeek());
         List<Routine> todayRoutines = routineRepository.findByUserAndWeekday(user, todayWeekday);
 
-        // 8. 오늘에 해당하는 반복일정은 스케줄에 추가
+        // 7. 오늘에 해당하는 반복일정은 스케줄에 추가
         List<Schedule> routineSchedules = OnboardingConverter.toScheduleList(todayRoutines, user, LocalDate.now());
         scheduleJdbcRepository.batchInsertSchedules(routineSchedules);
     }
@@ -323,50 +323,50 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
-    // 수면패턴과 반복일정 간의 충돌 확인
-    private void validateSleepPatternConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay, User user) {
-        // 1. 수면패턴 저장 여부 확인 (선택입력이기 때문)
-        if (user.getSleepTime() == null && user.getWakeTime() == null) {
-            return;
-        }
+//    // 수면패턴과 반복일정 간의 충돌 확인
+//    private void validateSleepPatternConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay, User user) {
+//        // 1. 수면패턴 저장 여부 확인 (선택입력이기 때문)
+//        if (user.getSleepTime() == null && user.getWakeTime() == null) {
+//            return;
+//        }
+//
+//        // 2. 수면패턴을 TimeRange로 변환
+//        List<TimeRange> sleepTimeRanges = getSleepTimeRanges(user.getSleepTime(), user.getWakeTime());
+//
+//        // 3. 반복일정과 수면패턴 시간 충돌 검증
+//        routinesByDay.values().stream()
+//                .map(dayRoutines -> {
+//
+//                    List<TimeRange> allTimeRanges = new ArrayList<>();
+//
+//                    // 반복일정 추가
+//                    allTimeRanges.addAll(dayRoutines.stream()
+//                            .map(TimeRange::from)
+//                            .toList());
+//
+//                    // 수면패턴 추가
+//                    allTimeRanges.addAll(sleepTimeRanges);
+//
+//                    return allTimeRanges;
+//                })
+//                .forEach(allTimeRanges ->
+//                        timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
+//    }
 
-        // 2. 수면패턴을 TimeRange로 변환
-        List<TimeRange> sleepTimeRanges = getSleepTimeRanges(user.getSleepTime(), user.getWakeTime());
 
-        // 3. 반복일정과 수면패턴 시간 충돌 검증
-        routinesByDay.values().stream()
-                .map(dayRoutines -> {
-
-                    List<TimeRange> allTimeRanges = new ArrayList<>();
-
-                    // 반복일정 추가
-                    allTimeRanges.addAll(dayRoutines.stream()
-                            .map(TimeRange::from)
-                            .toList());
-
-                    // 수면패턴 추가
-                    allTimeRanges.addAll(sleepTimeRanges);
-
-                    return allTimeRanges;
-                })
-                .forEach(allTimeRanges ->
-                        timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
-    }
-
-
-    // 수면패턴을 TimeRange 리스트로 변환
-    private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
-        // 1. 다음 날까지 이어지는 수면 (ex. 22:00~08:00)
-        if (sleepTime.isAfter(wakeTime) && !wakeTime.equals(LocalTime.MIDNIGHT)) {
-            return List.of(
-                    TimeRange.of(sleepTime, LocalTime.MIDNIGHT),
-                    TimeRange.of(LocalTime.MIDNIGHT, wakeTime)
-            );
-        }
-
-        // 2. 같은 날 안에서 끝나는 수면 (ex. 06:00~14:00, 18:00~00:00, 00:00~00:00)
-        return List.of(TimeRange.of(sleepTime, wakeTime));
-    }
+//    // 수면패턴을 TimeRange 리스트로 변환
+//    private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
+//        // 1. 다음 날까지 이어지는 수면 (ex. 22:00~08:00)
+//        if (sleepTime.isAfter(wakeTime) && !wakeTime.equals(LocalTime.MIDNIGHT)) {
+//            return List.of(
+//                    TimeRange.of(sleepTime, LocalTime.MIDNIGHT),
+//                    TimeRange.of(LocalTime.MIDNIGHT, wakeTime)
+//            );
+//        }
+//
+//        // 2. 같은 날 안에서 끝나는 수면 (ex. 06:00~14:00, 18:00~00:00, 00:00~00:00)
+//        return List.of(TimeRange.of(sleepTime, wakeTime));
+//    }
 
     // 프로필 이미지 키 get
     private String getProfileImageKey(String userId, String sessionId) {

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -225,9 +225,6 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 4. 반복 일정끼리의 충돌 확인
         validateRoutineConflictsByDay(routinesByDay);
 
-//        // 5. 수면패턴과의 충돌 확인
-//        validateSleepPatternConflictsByDay(routinesByDay, user);
-
         // 5. 반복 일정 저장
         List<Routine> newRoutines = OnboardingConverter.toRoutineList(request.getRoutine(), user);
         routineJdbcRepository.batchInsertRoutines(newRoutines);
@@ -323,55 +320,11 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
-//    // 수면패턴과 반복일정 간의 충돌 확인
-//    private void validateSleepPatternConflictsByDay(Map<Weekday, List<OnboardingRequestDto.RoutineDTO>> routinesByDay, User user) {
-//        // 1. 수면패턴 저장 여부 확인 (선택입력이기 때문)
-//        if (user.getSleepTime() == null && user.getWakeTime() == null) {
-//            return;
-//        }
-//
-//        // 2. 수면패턴을 TimeRange로 변환
-//        List<TimeRange> sleepTimeRanges = getSleepTimeRanges(user.getSleepTime(), user.getWakeTime());
-//
-//        // 3. 반복일정과 수면패턴 시간 충돌 검증
-//        routinesByDay.values().stream()
-//                .map(dayRoutines -> {
-//
-//                    List<TimeRange> allTimeRanges = new ArrayList<>();
-//
-//                    // 반복일정 추가
-//                    allTimeRanges.addAll(dayRoutines.stream()
-//                            .map(TimeRange::from)
-//                            .toList());
-//
-//                    // 수면패턴 추가
-//                    allTimeRanges.addAll(sleepTimeRanges);
-//
-//                    return allTimeRanges;
-//                })
-//                .forEach(allTimeRanges ->
-//                        timeUtil.validateTimeRangeConflicts(allTimeRanges, UserErrorStatus.ROUTINE_SLEEP_CONFLICT));
-//    }
-
-
-//    // 수면패턴을 TimeRange 리스트로 변환
-//    private List<TimeRange> getSleepTimeRanges(LocalTime sleepTime, LocalTime wakeTime) {
-//        // 1. 다음 날까지 이어지는 수면 (ex. 22:00~08:00)
-//        if (sleepTime.isAfter(wakeTime) && !wakeTime.equals(LocalTime.MIDNIGHT)) {
-//            return List.of(
-//                    TimeRange.of(sleepTime, LocalTime.MIDNIGHT),
-//                    TimeRange.of(LocalTime.MIDNIGHT, wakeTime)
-//            );
-//        }
-//
-//        // 2. 같은 날 안에서 끝나는 수면 (ex. 06:00~14:00, 18:00~00:00, 00:00~00:00)
-//        return List.of(TimeRange.of(sleepTime, wakeTime));
-//    }
-
     // 프로필 이미지 키 get
     private String getProfileImageKey(String userId, String sessionId) {
         return String.format("PROFILE_IMAGE_FILE_NAME:%s:%s", userId, sessionId);
     }
+
 
     private void validateSleepPattern(LocalTime sleepTime, LocalTime wakeTime) {
         // sleepTime과 wakeTime 사이의 시간 차이를 분 단위로 계산 (같은 날 기준 계산)

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -1,22 +1,26 @@
 package umc.teumteum.server.unit.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.teumteum.server.domain.home.repository.ScheduleJdbcRepository;
-import umc.teumteum.server.domain.home.repository.ScheduleReminderJdbcRepository;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
@@ -24,7 +28,6 @@ import umc.teumteum.server.domain.user.entity.enums.UserStep;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.domain.user.exception.OnboardingException;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
-import umc.teumteum.server.domain.user.repository.RemindAlarmJdbcRepository;
 import umc.teumteum.server.domain.user.repository.RoutineJdbcRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.service.OnboardingServiceImpl;
@@ -32,7 +35,7 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.TimeUtil;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("OnboardingService 테스트 - 수면패턴 x 반복일정 조합")
+@DisplayName("OnboardingService 테스트")
 class OnboardingServiceTest {
 
     @InjectMocks
@@ -46,12 +49,6 @@ class OnboardingServiceTest {
 
     @Mock
     private ScheduleJdbcRepository scheduleJdbcRepository;
-
-    @Mock
-    private RemindAlarmJdbcRepository remindAlarmJdbcRepository;
-
-    @Mock
-    private ScheduleReminderJdbcRepository scheduleReminderJdbcRepository;
 
     @Spy
     private TimeUtil timeUtil = new TimeUtil();
@@ -69,344 +66,85 @@ class OnboardingServiceTest {
                 .build();
     }
 
-    // ==================== 수면패턴 시간 길이 검증 ====================
-
+    // ==================== 수면패턴 테스트 ====================
     @Test
     @DisplayName("수면패턴 23시간 미만 - 정상")
     void sleep_less23h_ok() {
+        // given
+        LocalTime sleepTime = LocalTime.of(22, 0);
+        LocalTime wakeTime = LocalTime.of(20, 0);
+
         // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(
-                    createSleepPattern(LocalTime.of(22, 0), LocalTime.of(20, 0)), testUser
-            );
-        }).doesNotThrowAnyException();
+        assertDoesNotThrow(() -> onboardingService.saveSleepPattern(createSleepPattern(sleepTime, wakeTime), testUser));
+        assertThat(testUser.getSleepTime()).isEqualTo(sleepTime);
+        assertThat(testUser.getWakeTime()).isEqualTo(wakeTime);
     }
 
     @Test
     @DisplayName("수면패턴 23시간 - 정상")
     void sleep_23h_ok() {
+        // given
+        LocalTime sleepTime = LocalTime.of(22, 0);
+        LocalTime wakeTime = LocalTime.of(21, 0);
+
         // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(
-                    createSleepPattern(LocalTime.of(22, 0), LocalTime.of(21, 0)), testUser
-            );
-        }).doesNotThrowAnyException();
+        assertDoesNotThrow(() -> onboardingService.saveSleepPattern(createSleepPattern(sleepTime, wakeTime), testUser));
+        assertThat(testUser.getSleepTime()).isEqualTo(sleepTime);
+        assertThat(testUser.getWakeTime()).isEqualTo(wakeTime);
     }
 
     @Test
     @DisplayName("수면패턴 23시간 초과 - 예외")
     void sleep_over23h_fail() {
+        // given
+        LocalTime sleepTime = LocalTime.of(22, 0);
+        LocalTime wakeTime = LocalTime.of(21, 30);
+
         // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(
-                    createSleepPattern(LocalTime.of(22, 0), LocalTime.of(21, 30)), testUser
-            );
-        }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_SLEEP_DURATION);
-        });
+        OnboardingException exception = assertThrows(OnboardingException.class,
+                () -> onboardingService.saveSleepPattern(createSleepPattern(sleepTime, wakeTime), testUser)
+        );
+        assertEquals(UserErrorStatus.INVALID_SLEEP_DURATION.getCode(), exception.getErrorReason().getCode());
+        assertEquals(UserErrorStatus.INVALID_SLEEP_DURATION.getMessage(), exception.getErrorReason().getMessage());
     }
 
-//    // ==================== 수면패턴A (22:00-07:00) ====================
-//
-//    @Test
-//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정A(09:00-18:00) - 정상")
-//    void sleepA_routineA_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-//            onboardingService.saveRoutines(createRoutineA(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정B(11:00-19:00) - 정상")
-//    void sleepA_routineB_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-//            onboardingService.saveRoutines(createRoutineB(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정C(20:00-00:00) - CONFLICT")
-//    void sleepA_routineC_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-//            onboardingService.saveRoutines(createRoutineC(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정D(00:00-04:00) - CONFLICT")
-//    void sleepA_routineD_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-//            onboardingService.saveRoutines(createRoutineD(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    // ==================== 수면패턴B (18:00-00:00) ====================
-//
-//    @Test
-//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정A(09:00-18:00) - 정상")
-//    void sleepB_routineA_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-//            onboardingService.saveRoutines(createRoutineA(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정B(11:00-19:00) - CONFLICT")
-//    void sleepB_routineB_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-//            onboardingService.saveRoutines(createRoutineB(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정C(20:00-00:00) - CONFLICT")
-//    void sleepB_routineC_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-//            onboardingService.saveRoutines(createRoutineC(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정D(00:00-04:00) - 정상")
-//    void sleepB_routineD_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-//            onboardingService.saveRoutines(createRoutineD(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    // ==================== 수면패턴C (00:00-09:00) ====================
-//
-//    @Test
-//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정A(09:00-18:00) - 정상")
-//    void sleepC_routineA_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-//            onboardingService.saveRoutines(createRoutineA(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정B(11:00-19:00) - 정상")
-//    void sleepC_routineB_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-//            onboardingService.saveRoutines(createRoutineB(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정C(20:00-00:00) - 정상")
-//    void sleepC_routineC_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-//            onboardingService.saveRoutines(createRoutineC(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정D(00:00-04:00) - CONFLICT")
-//    void sleepC_routineD_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-//            onboardingService.saveRoutines(createRoutineD(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    // ==================== 수면패턴D (11:00-20:00) ====================
-//
-//    @Test
-//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정A(09:00-18:00) - CONFLICT")
-//    void sleepD_routineA_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-//            onboardingService.saveRoutines(createRoutineA(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정B(11:00-19:00) - CONFLICT")
-//    void sleepD_routineB_conflict() {
-//        // when & then
-//        assertThatThrownBy(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-//            onboardingService.saveRoutines(createRoutineB(), testUser);
-//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정C(20:00-00:00) - 정상")
-//    void sleepD_routineC_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-//            onboardingService.saveRoutines(createRoutineC(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정D(00:00-04:00) - 정상")
-//    void sleepD_routineD_ok() {
-//        // when & then
-//        assertThatCode(() -> {
-//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-//            onboardingService.saveRoutines(createRoutineD(), testUser);
-//        }).doesNotThrowAnyException();
-//    }
-
-    // ==================== 특이 케이스 ====================
-
-    @Test
-    @DisplayName("반복일정 A~D - 정상")
-    void no_sleep() {
+    // ==================== 반복일정 테스트 ====================
+    @ParameterizedTest
+    @DisplayName("반복일정 정상 케이스")
+    @MethodSource("getValidRoutines")
+    void validRoutine(OnboardingRequestDto.RoutineListRequest routine) {
         // when & then
-        for (OnboardingRequestDto.RoutineListRequest routine : getAllRoutines()) {
-            assertThatCode(() -> {
-                onboardingService.saveRoutines(routine, testUser);
-            }).doesNotThrowAnyException();
-        }
+        assertDoesNotThrow(() -> onboardingService.saveRoutines(routine, testUser));
+        verify(routineJdbcRepository).batchInsertRoutines(anyList());
+    }
+
+    @ParameterizedTest
+    @DisplayName("반복일정 잘못된 시간범위")
+    @MethodSource("getInvalidRoutines")
+    void invalidRoutine(OnboardingRequestDto.RoutineListRequest routine) {
+        // when & then
+        OnboardingException exception = assertThrows(OnboardingException.class,
+                () -> onboardingService.saveRoutines(routine, testUser)
+        );
+        assertEquals(UserErrorStatus.INVALID_TIME_RANGE.getCode(), exception.getErrorReason().getCode());
+        assertEquals(UserErrorStatus.INVALID_TIME_RANGE.getMessage(), exception.getErrorReason().getMessage());
     }
 
     @Test
-    @DisplayName("반복일정E(00:00-00:00) - 24시간 일정")
-    void test_routineE() {
+    @DisplayName("반복일정 시간 충돌")
+    void conflictRoutine() {
+        // given
+        OnboardingRequestDto.RoutineListRequest request = createRoutines(
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(10, 0), LocalTime.of(14, 0), "틈틈 개발"),
+                createRoutineDTO(Weekday.MONDAY, LocalTime.of(13, 0), LocalTime.of(17, 0), "틈틈 개발")
+        );
+
         // when & then
-        // 수면패턴 등록X인 경우 정상
-        assertThatCode(() -> {
-            onboardingService.saveRoutines(createRoutineE(), testUser);
-        }).doesNotThrowAnyException();
-
-//        // 수면패턴 등록한 경우 예외
-//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-//            assertThatThrownBy(() -> {
-//                onboardingService.saveSleepPattern(sleepPattern, testUser);
-//                onboardingService.saveRoutines(createRoutineE(), testUser);
-//            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-//            });
-//        }
-    }
-
-    @Test
-    @DisplayName("반복일정F(23:00-02:00) - 잘못된 시간범위")
-    void test_routineF() {
-        // when & then
-        // 수면패턴 등록X인 경우 예외
-        assertThatCode(() -> {
-            onboardingService.saveRoutines(createRoutineF(), testUser);
-        }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-        });
-
-//        // 수면패턴 등록한 경우 예외
-//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-//            assertThatThrownBy(() -> {
-//                onboardingService.saveSleepPattern(sleepPattern, testUser);
-//                onboardingService.saveRoutines(createRoutineF(), testUser);
-//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-//            });
-//        }
-    }
-
-    @Test
-    @DisplayName("반복일정G(15:00-10:00) - 잘못된 시간범위")
-    void test_routineG() {
-        // when & then
-        // 수면패턴 등록X인 경우 예외
-        assertThatCode(() -> {
-            onboardingService.saveRoutines(createRoutineG(), testUser);
-        }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-        });
-
-//        // 수면패턴 등록한 경우 예외
-//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-//            assertThatThrownBy(() -> {
-//                onboardingService.saveSleepPattern(sleepPattern, testUser);
-//                onboardingService.saveRoutines(createRoutineG(), testUser);
-//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-//            });
-//        }
-    }
-
-    @Test
-    @DisplayName("반복일정H(13:00-13:00) - 잘못된 시간범위")
-    void test_routineH() {
-        // when & then
-        // 수면패턴 등록X인 경우 예외
-        assertThatCode(() -> {
-            onboardingService.saveRoutines(createRoutineH(), testUser);
-        }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-        });
-
-//        // 수면패턴 등록한 경우 예외
-//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-//            assertThatThrownBy(() -> {
-//                onboardingService.saveSleepPattern(sleepPattern, testUser);
-//                onboardingService.saveRoutines(createRoutineH(), testUser);
-//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-//            });
-//        }
-    }
-
-    @Test
-    @DisplayName("반복일정I(같은 요일 시간 겹침) - 반복일정 충돌")
-    void test_routineI() {
-        // when & then
-        // 수면패턴 등록X인 경우 예외
-        assertThatCode(() -> {
-            onboardingService.saveRoutines(createRoutineI(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
-        });
-
-//        // 수면패턴 등록한 경우 예외
-//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-//            assertThatThrownBy(() -> {
-//                onboardingService.saveSleepPattern(sleepPattern, testUser);
-//                onboardingService.saveRoutines(createRoutineI(), testUser);
-//            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
-//            });
-//        }
+        GlobalHandler exception = assertThrows(GlobalHandler.class,
+                () -> onboardingService.saveRoutines(request, testUser)
+        );
+        assertEquals(UserErrorStatus.ROUTINE_TIME_CONFLICT.getCode(), exception.getErrorReason().getCode());
+        assertEquals(UserErrorStatus.ROUTINE_TIME_CONFLICT.getMessage(), exception.getErrorReason().getMessage());
     }
 
     // ==================== 헬퍼 메서드 ====================
@@ -417,159 +155,42 @@ class OnboardingServiceTest {
                 .wakeTime(wakeTime)
                 .build();
     }
-//
-//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternA() {
-//        // A: 22:00-07:00
-//        return createSleepPattern(LocalTime.of(22, 0), LocalTime.of(7, 0));
-//    }
-//
-//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternB() {
-//        // B: 18:00-00:00
-//        return createSleepPattern(LocalTime.of(18, 0), LocalTime.MIDNIGHT);
-//    }
-//
-//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternC() {
-//        // C: 00:00-09:00
-//        return createSleepPattern(LocalTime.MIDNIGHT, LocalTime.of(9, 0));
-//    }
-//
-//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternD() {
-//        // D: 11:00-20:00
-//        return createSleepPattern(LocalTime.of(11, 0), LocalTime.of(20, 0));
-//    }
-
 
     // 반복일정 생성 메서드
-    private OnboardingRequestDto.RoutineListRequest createRoutine(Weekday[] weekdays, LocalTime[] startTimes, LocalTime[] endTimes, String[] titles) {
-        List<OnboardingRequestDto.RoutineDTO> routines = new ArrayList<>();
-        for (int i = 0; i < weekdays.length; i++) {
-            routines.add(createRoutineDTO(weekdays[i], startTimes[i], endTimes[i], titles[i]));
-        }
+    // 정상 반복일정 생성 메서드
+    private static List<OnboardingRequestDto.RoutineListRequest> getValidRoutines() {
+        return List.of(
+                createRoutines(createRoutineDTO(Weekday.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), "틈틈 개발")),
+                createRoutines(createRoutineDTO(Weekday.TUESDAY, LocalTime.of(11, 0), LocalTime.of(19, 0), "틈틈 개발")),
+                createRoutines(createRoutineDTO(Weekday.WEDNESDAY, LocalTime.of(20, 0), LocalTime.MIDNIGHT, "틈틈 개발")),
+                createRoutines(createRoutineDTO(Weekday.THURSDAY, LocalTime.MIDNIGHT, LocalTime.of(4, 0), "틈틈 개발")),
+                createRoutines(createRoutineDTO(Weekday.FRIDAY, LocalTime.MIDNIGHT, LocalTime.MIDNIGHT, "틈틈 개발"))
+        );
+    }
 
+    // 비정상 반복일정 생성 메서드
+    private static List<OnboardingRequestDto.RoutineListRequest> getInvalidRoutines() {
+        return List.of(
+                createRoutines(createRoutineDTO(Weekday.MONDAY, LocalTime.of(23, 0), LocalTime.of(2, 0), "잘못된 시간 범위")),
+                createRoutines(createRoutineDTO(Weekday.TUESDAY, LocalTime.of(15, 0), LocalTime.of(10, 0), "잘못된 시간 범위")),
+                createRoutines(createRoutineDTO(Weekday.WEDNESDAY, LocalTime.of(13, 0), LocalTime.of(13, 0), "잘못된 시간 범위"))
+        );
+    }
+
+    private static OnboardingRequestDto.RoutineListRequest createRoutines(OnboardingRequestDto.RoutineDTO... routines) {
         return OnboardingRequestDto.RoutineListRequest.builder()
-                .routine(routines)
+                .routine(List.of(routines))
                 .build();
     }
 
-    private OnboardingRequestDto.RoutineDTO createRoutineDTO(Weekday weekday, LocalTime startTime, LocalTime endTime, String title) {
+    private static OnboardingRequestDto.RoutineDTO createRoutineDTO(Weekday weekday, LocalTime startTime,
+                                                                    LocalTime endTime,
+                                                                    String title) {
         return OnboardingRequestDto.RoutineDTO.builder()
                 .weekday(weekday)
                 .startTime(startTime)
                 .endTime(endTime)
                 .title(title)
                 .build();
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineA() {
-        // A: 09:00-18:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(9, 0)},
-                new LocalTime[]{LocalTime.of(18, 0)},
-                new String[]{"틈틈 개발"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineB() {
-        // B: 11:00-19:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(11, 0)},
-                new LocalTime[]{LocalTime.of(19, 0)},
-                new String[]{"틈틈 개발"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineC() {
-        // C: 20:00-00:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(20, 0)},
-                new LocalTime[]{LocalTime.MIDNIGHT},
-                new String[]{"틈틈 개발"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineD() {
-        // D: 00:00-04:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.MIDNIGHT},
-                new LocalTime[]{LocalTime.of(4, 0)},
-                new String[]{"틈틈 개발"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineE() {
-        // E: 00:00-00:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.MIDNIGHT},
-                new LocalTime[]{LocalTime.MIDNIGHT},
-                new String[]{"틈틈 개발"}
-        );
-    }
-
-
-//    // 전체 수면패턴 생성 메서드
-//    private List<OnboardingRequestDto.SleepPatternRequest> getAllSleepPatterns() {
-//        return List.of(
-//                createSleepPatternA(),
-//                createSleepPatternB(),
-//                createSleepPatternC(),
-//                createSleepPatternD()
-//        );
-//    }
-
-    // 전체 반복일정 생성 메서드
-    private List<OnboardingRequestDto.RoutineListRequest> getAllRoutines() {
-        return List.of(
-                createRoutineA(),
-                createRoutineB(),
-                createRoutineC(),
-                createRoutineD()
-        );
-    }
-
-
-    // 예외 관련
-    private OnboardingRequestDto.RoutineListRequest createRoutineF() {
-        // F: 예외 23:00-02:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(23, 0)},
-                new LocalTime[]{LocalTime.of(2, 0)},
-                new String[]{"다음 날로 넘어감"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineG() {
-        // G: 예외 15:00-10:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(15, 0)},
-                new LocalTime[]{LocalTime.of(10, 0)},
-                new String[]{"잘못된 시간 범위"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineH() {
-        // H: 예외 13:00-13:00
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(13, 0)},
-                new LocalTime[]{LocalTime.of(13, 0)},
-                new String[]{"24시간 일정 - 다음 날로 넘어감"}
-        );
-    }
-
-    private OnboardingRequestDto.RoutineListRequest createRoutineI() {
-        // I: 예외 반복일정 충돌
-        return createRoutine(
-                new Weekday[]{Weekday.MONDAY, Weekday.MONDAY},
-                new LocalTime[]{LocalTime.of(10, 0), LocalTime.of(13, 0)},
-                new LocalTime[]{LocalTime.of(14, 0), LocalTime.of(17, 0)},
-                new String[]{"틈틈 개발", "틈틈 개발"}
-        );
     }
 }

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -1,6 +1,12 @@
 package umc.teumteum.server.unit.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +17,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.teumteum.server.domain.home.repository.ScheduleJdbcRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleReminderJdbcRepository;
-import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
@@ -25,13 +30,6 @@ import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.service.OnboardingServiceImpl;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.TimeUtil;
-
-import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OnboardingService 테스트 - 수면패턴 x 반복일정 조합")
@@ -108,192 +106,192 @@ class OnboardingServiceTest {
         });
     }
 
-    // ==================== 수면패턴A (22:00-07:00) ====================
-
-    @Test
-    @DisplayName("수면패턴A(22:00-07:00) + 반복일정A(09:00-18:00) - 정상")
-    void sleepA_routineA_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-            onboardingService.saveRoutines(createRoutineA(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴A(22:00-07:00) + 반복일정B(11:00-19:00) - 정상")
-    void sleepA_routineB_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-            onboardingService.saveRoutines(createRoutineB(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴A(22:00-07:00) + 반복일정C(20:00-00:00) - CONFLICT")
-    void sleepA_routineC_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-            onboardingService.saveRoutines(createRoutineC(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    @Test
-    @DisplayName("수면패턴A(22:00-07:00) + 반복일정D(00:00-04:00) - CONFLICT")
-    void sleepA_routineD_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
-            onboardingService.saveRoutines(createRoutineD(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    // ==================== 수면패턴B (18:00-00:00) ====================
-
-    @Test
-    @DisplayName("수면패턴B(18:00-00:00) + 반복일정A(09:00-18:00) - 정상")
-    void sleepB_routineA_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-            onboardingService.saveRoutines(createRoutineA(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴B(18:00-00:00) + 반복일정B(11:00-19:00) - CONFLICT")
-    void sleepB_routineB_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-            onboardingService.saveRoutines(createRoutineB(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    @Test
-    @DisplayName("수면패턴B(18:00-00:00) + 반복일정C(20:00-00:00) - CONFLICT")
-    void sleepB_routineC_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-            onboardingService.saveRoutines(createRoutineC(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    @Test
-    @DisplayName("수면패턴B(18:00-00:00) + 반복일정D(00:00-04:00) - 정상")
-    void sleepB_routineD_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
-            onboardingService.saveRoutines(createRoutineD(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    // ==================== 수면패턴C (00:00-09:00) ====================
-
-    @Test
-    @DisplayName("수면패턴C(00:00-09:00) + 반복일정A(09:00-18:00) - 정상")
-    void sleepC_routineA_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-            onboardingService.saveRoutines(createRoutineA(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴C(00:00-09:00) + 반복일정B(11:00-19:00) - 정상")
-    void sleepC_routineB_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-            onboardingService.saveRoutines(createRoutineB(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴C(00:00-09:00) + 반복일정C(20:00-00:00) - 정상")
-    void sleepC_routineC_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-            onboardingService.saveRoutines(createRoutineC(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴C(00:00-09:00) + 반복일정D(00:00-04:00) - CONFLICT")
-    void sleepC_routineD_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
-            onboardingService.saveRoutines(createRoutineD(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    // ==================== 수면패턴D (11:00-20:00) ====================
-
-    @Test
-    @DisplayName("수면패턴D(11:00-20:00) + 반복일정A(09:00-18:00) - CONFLICT")
-    void sleepD_routineA_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-            onboardingService.saveRoutines(createRoutineA(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    @Test
-    @DisplayName("수면패턴D(11:00-20:00) + 반복일정B(11:00-19:00) - CONFLICT")
-    void sleepD_routineB_conflict() {
-        // when & then
-        assertThatThrownBy(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-            onboardingService.saveRoutines(createRoutineB(), testUser);
-        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-        });
-    }
-
-    @Test
-    @DisplayName("수면패턴D(11:00-20:00) + 반복일정C(20:00-00:00) - 정상")
-    void sleepD_routineC_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-            onboardingService.saveRoutines(createRoutineC(), testUser);
-        }).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("수면패턴D(11:00-20:00) + 반복일정D(00:00-04:00) - 정상")
-    void sleepD_routineD_ok() {
-        // when & then
-        assertThatCode(() -> {
-            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
-            onboardingService.saveRoutines(createRoutineD(), testUser);
-        }).doesNotThrowAnyException();
-    }
+//    // ==================== 수면패턴A (22:00-07:00) ====================
+//
+//    @Test
+//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정A(09:00-18:00) - 정상")
+//    void sleepA_routineA_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+//            onboardingService.saveRoutines(createRoutineA(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정B(11:00-19:00) - 정상")
+//    void sleepA_routineB_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+//            onboardingService.saveRoutines(createRoutineB(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정C(20:00-00:00) - CONFLICT")
+//    void sleepA_routineC_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+//            onboardingService.saveRoutines(createRoutineC(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴A(22:00-07:00) + 반복일정D(00:00-04:00) - CONFLICT")
+//    void sleepA_routineD_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternA(), testUser);
+//            onboardingService.saveRoutines(createRoutineD(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    // ==================== 수면패턴B (18:00-00:00) ====================
+//
+//    @Test
+//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정A(09:00-18:00) - 정상")
+//    void sleepB_routineA_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+//            onboardingService.saveRoutines(createRoutineA(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정B(11:00-19:00) - CONFLICT")
+//    void sleepB_routineB_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+//            onboardingService.saveRoutines(createRoutineB(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정C(20:00-00:00) - CONFLICT")
+//    void sleepB_routineC_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+//            onboardingService.saveRoutines(createRoutineC(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴B(18:00-00:00) + 반복일정D(00:00-04:00) - 정상")
+//    void sleepB_routineD_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternB(), testUser);
+//            onboardingService.saveRoutines(createRoutineD(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    // ==================== 수면패턴C (00:00-09:00) ====================
+//
+//    @Test
+//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정A(09:00-18:00) - 정상")
+//    void sleepC_routineA_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+//            onboardingService.saveRoutines(createRoutineA(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정B(11:00-19:00) - 정상")
+//    void sleepC_routineB_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+//            onboardingService.saveRoutines(createRoutineB(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정C(20:00-00:00) - 정상")
+//    void sleepC_routineC_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+//            onboardingService.saveRoutines(createRoutineC(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴C(00:00-09:00) + 반복일정D(00:00-04:00) - CONFLICT")
+//    void sleepC_routineD_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternC(), testUser);
+//            onboardingService.saveRoutines(createRoutineD(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    // ==================== 수면패턴D (11:00-20:00) ====================
+//
+//    @Test
+//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정A(09:00-18:00) - CONFLICT")
+//    void sleepD_routineA_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+//            onboardingService.saveRoutines(createRoutineA(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정B(11:00-19:00) - CONFLICT")
+//    void sleepD_routineB_conflict() {
+//        // when & then
+//        assertThatThrownBy(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+//            onboardingService.saveRoutines(createRoutineB(), testUser);
+//        }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//            assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정C(20:00-00:00) - 정상")
+//    void sleepD_routineC_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+//            onboardingService.saveRoutines(createRoutineC(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
+//
+//    @Test
+//    @DisplayName("수면패턴D(11:00-20:00) + 반복일정D(00:00-04:00) - 정상")
+//    void sleepD_routineD_ok() {
+//        // when & then
+//        assertThatCode(() -> {
+//            onboardingService.saveSleepPattern(createSleepPatternD(), testUser);
+//            onboardingService.saveRoutines(createRoutineD(), testUser);
+//        }).doesNotThrowAnyException();
+//    }
 
     // ==================== 특이 케이스 ====================
 
     @Test
-    @DisplayName("수면패턴 등록하지 않은 경우 반복일정 A~D - 정상")
+    @DisplayName("반복일정 A~D - 정상")
     void no_sleep() {
         // when & then
         for (OnboardingRequestDto.RoutineListRequest routine : getAllRoutines()) {
@@ -312,15 +310,15 @@ class OnboardingServiceTest {
             onboardingService.saveRoutines(createRoutineE(), testUser);
         }).doesNotThrowAnyException();
 
-        // 수면패턴 등록한 경우 예외
-        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-            assertThatThrownBy(() -> {
-                onboardingService.saveSleepPattern(sleepPattern, testUser);
-                onboardingService.saveRoutines(createRoutineE(), testUser);
-            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
-            });
-        }
+//        // 수면패턴 등록한 경우 예외
+//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+//            assertThatThrownBy(() -> {
+//                onboardingService.saveSleepPattern(sleepPattern, testUser);
+//                onboardingService.saveRoutines(createRoutineE(), testUser);
+//            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_SLEEP_CONFLICT);
+//            });
+//        }
     }
 
     @Test
@@ -334,15 +332,15 @@ class OnboardingServiceTest {
             assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
         });
 
-        // 수면패턴 등록한 경우 예외
-        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-            assertThatThrownBy(() -> {
-                onboardingService.saveSleepPattern(sleepPattern, testUser);
-                onboardingService.saveRoutines(createRoutineF(), testUser);
-            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-            });
-        }
+//        // 수면패턴 등록한 경우 예외
+//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+//            assertThatThrownBy(() -> {
+//                onboardingService.saveSleepPattern(sleepPattern, testUser);
+//                onboardingService.saveRoutines(createRoutineF(), testUser);
+//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
+//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+//            });
+//        }
     }
 
     @Test
@@ -356,15 +354,15 @@ class OnboardingServiceTest {
             assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
         });
 
-        // 수면패턴 등록한 경우 예외
-        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-            assertThatThrownBy(() -> {
-                onboardingService.saveSleepPattern(sleepPattern, testUser);
-                onboardingService.saveRoutines(createRoutineG(), testUser);
-            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-            });
-        }
+//        // 수면패턴 등록한 경우 예외
+//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+//            assertThatThrownBy(() -> {
+//                onboardingService.saveSleepPattern(sleepPattern, testUser);
+//                onboardingService.saveRoutines(createRoutineG(), testUser);
+//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
+//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+//            });
+//        }
     }
 
     @Test
@@ -378,15 +376,15 @@ class OnboardingServiceTest {
             assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
         });
 
-        // 수면패턴 등록한 경우 예외
-        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-            assertThatThrownBy(() -> {
-                onboardingService.saveSleepPattern(sleepPattern, testUser);
-                onboardingService.saveRoutines(createRoutineH(), testUser);
-            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
-                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
-            });
-        }
+//        // 수면패턴 등록한 경우 예외
+//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+//            assertThatThrownBy(() -> {
+//                onboardingService.saveSleepPattern(sleepPattern, testUser);
+//                onboardingService.saveRoutines(createRoutineH(), testUser);
+//            }).isInstanceOfSatisfying(OnboardingException.class, ex -> {
+//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.INVALID_TIME_RANGE);
+//            });
+//        }
     }
 
     @Test
@@ -400,15 +398,15 @@ class OnboardingServiceTest {
             assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
         });
 
-        // 수면패턴 등록한 경우 예외
-        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
-            assertThatThrownBy(() -> {
-                onboardingService.saveSleepPattern(sleepPattern, testUser);
-                onboardingService.saveRoutines(createRoutineI(), testUser);
-            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
-                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
-            });
-        }
+//        // 수면패턴 등록한 경우 예외
+//        for (OnboardingRequestDto.SleepPatternRequest sleepPattern : getAllSleepPatterns()) {
+//            assertThatThrownBy(() -> {
+//                onboardingService.saveSleepPattern(sleepPattern, testUser);
+//                onboardingService.saveRoutines(createRoutineI(), testUser);
+//            }).isInstanceOfSatisfying(GlobalHandler.class, ex -> {
+//                assertThat(ex.getCode()).isEqualTo(UserErrorStatus.ROUTINE_TIME_CONFLICT);
+//            });
+//        }
     }
 
     // ==================== 헬퍼 메서드 ====================
@@ -419,26 +417,26 @@ class OnboardingServiceTest {
                 .wakeTime(wakeTime)
                 .build();
     }
-
-    private OnboardingRequestDto.SleepPatternRequest createSleepPatternA() {
-        // A: 22:00-07:00
-        return createSleepPattern(LocalTime.of(22, 0), LocalTime.of(7, 0));
-    }
-
-    private OnboardingRequestDto.SleepPatternRequest createSleepPatternB() {
-        // B: 18:00-00:00
-        return createSleepPattern(LocalTime.of(18, 0), LocalTime.MIDNIGHT);
-    }
-
-    private OnboardingRequestDto.SleepPatternRequest createSleepPatternC() {
-        // C: 00:00-09:00
-        return createSleepPattern(LocalTime.MIDNIGHT, LocalTime.of(9, 0));
-    }
-
-    private OnboardingRequestDto.SleepPatternRequest createSleepPatternD() {
-        // D: 11:00-20:00
-        return createSleepPattern(LocalTime.of(11, 0), LocalTime.of(20, 0));
-    }
+//
+//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternA() {
+//        // A: 22:00-07:00
+//        return createSleepPattern(LocalTime.of(22, 0), LocalTime.of(7, 0));
+//    }
+//
+//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternB() {
+//        // B: 18:00-00:00
+//        return createSleepPattern(LocalTime.of(18, 0), LocalTime.MIDNIGHT);
+//    }
+//
+//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternC() {
+//        // C: 00:00-09:00
+//        return createSleepPattern(LocalTime.MIDNIGHT, LocalTime.of(9, 0));
+//    }
+//
+//    private OnboardingRequestDto.SleepPatternRequest createSleepPatternD() {
+//        // D: 11:00-20:00
+//        return createSleepPattern(LocalTime.of(11, 0), LocalTime.of(20, 0));
+//    }
 
 
     // 반복일정 생성 메서드
@@ -513,16 +511,17 @@ class OnboardingServiceTest {
     }
 
 
-    // 전체 수면패턴&반복일정 생성 메서드
-    private List<OnboardingRequestDto.SleepPatternRequest> getAllSleepPatterns() {
-        return List.of(
-                createSleepPatternA(),
-                createSleepPatternB(),
-                createSleepPatternC(),
-                createSleepPatternD()
-        );
-    }
+//    // 전체 수면패턴 생성 메서드
+//    private List<OnboardingRequestDto.SleepPatternRequest> getAllSleepPatterns() {
+//        return List.of(
+//                createSleepPatternA(),
+//                createSleepPatternB(),
+//                createSleepPatternC(),
+//                createSleepPatternD()
+//        );
+//    }
 
+    // 전체 반복일정 생성 메서드
     private List<OnboardingRequestDto.RoutineListRequest> getAllRoutines() {
         return List.of(
                 createRoutineA(),


### PR DESCRIPTION
### 👀 관련 이슈
#238 

### ✨ 작업한 내용
기획 변경에 따라, 반복일정 등록 API에 존재하던 수면패턴과의 충돌 검증 로직을 삭제하여 중복을 허용했습니다.
(코드는 일단 주석 처리하고 추후 아예 삭제 진행하도록 하겠습니다..)

※ 테스트 코드 수정or추가하고 머지할 예정

### 🌀 PR Point
X

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
| 수면패턴 등록 진행 (22:00~11:00) | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/02535398-906b-48c3-8446-cbbc42737ac5"/> |
| 반복일정 등록 진행 (08:00~11:00) | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/cb28a223-72fc-4b09-9cf4-6f2e5e9ed603"/> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토**
  * 온보딩 흐름에서 수면-일정 충돌 검증 로직이 제거되었습니다.
  * 온보딩 저장/스케줄링 단계의 실행 순서 라벨이 일부 조정되었습니다.
  * 수면-일정 충돌 관련 오류 상수가 제거되었습니다.

* **테스트**
  * 수면 패턴 관련 상세 테스트들이 제거/통합되어 테스트가 간소화되고 파라미터화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->