### PR TITLE
Feat : 시간표 조회 API 구현 

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
+++ b/src/main/java/umc/teumteum/server/domain/home/controller/HomeController.java
@@ -113,4 +113,13 @@ public class HomeController {
         return ApiResponse.of(HomeSuccessStatus._ALARM_UPDATED,null);
     }
 
+    @GetMapping(value = "/timetable", produces = "application/json")
+    @Operation(summary = "시간표 조회 API",description = "오늘의 시간표를 조회하는 API입니다. query string으로 오늘 날짜를 입력해주세요.")
+    public ApiResponse<HomeResponseDto.TimeTableDto> getTimetable(
+            @Parameter(name = "date", description = "조회할 날짜", example = "2025-10-14") @RequestParam("date") LocalDate date,
+            @CurrentUser @Parameter(hidden = true) User user){
+        HomeResponseDto.TimeTableDto response = homeService.getTimeTable(date,user);
+        return ApiResponse.of(HomeSuccessStatus._TIMETABLE_LOADED,response);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -204,4 +204,14 @@ public class ScheduleConverter {
 
     }
 
+    // Schedule -> TimeTableDto
+    public HomeResponseDto.TimeTableDto toTimeTableDto(
+            List<HomeResponseDto.TimeSlotDto> sleepList,List<HomeResponseDto.TimeSlotDto> todoList) {
+        return HomeResponseDto.TimeTableDto.builder()
+                .sleep(sleepList)
+                .todo(todoList)
+                .build();
+    }
+
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/response/HomeResponseDto.java
@@ -77,7 +77,7 @@ public class HomeResponseDto {
   @Builder
   @Getter
   @AllArgsConstructor
-  @Schema(title = "ReminderDto : 온보딩 리망니드 알림 정보 응답 Dto")
+  @Schema(title = "ReminderDto : 온보딩 리마인드 알림 정보 응답 Dto")
   public static class ReminderDto {
     @Schema(description = "온보딩 리마인드 알림 설정 정보", example = "[1,5]")
     private List<Integer> reminders;
@@ -149,5 +149,31 @@ public class HomeResponseDto {
   public static class ReminderAlarmDto {
     private Integer alarm;
     private AlarmStatus status;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @Schema(title = "TimeSlotDto : 단일 시간 구간 Dto")
+  public static class TimeSlotDto {
+    @Schema(description = "시작 시간", example = "10:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "10:00")
+    @JsonSerialize(using = TimeSerializer.class)
+    private LocalTime endTime;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @Schema(title = "TimeTableDto : 시간표 조회 응답 Dto")
+  public static class TimeTableDto {
+    @Schema(description = "수면 패턴 배열", example = "[{startTime: '00:00', endTime: '07:30'}]")
+    private List<TimeSlotDto> sleep;
+
+    @Schema(description = "투두 배열", example = "[{startTime: '09:00', endTime: '10:30'}]")
+    private List<TimeSlotDto> todo;
   }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeSuccessStatus.java
@@ -27,6 +27,7 @@ public enum HomeSuccessStatus implements BaseCode {
     _TODOLIST_LOADED(HttpStatus.OK,"HOME20015","투두리스트가 성공적으로 조회되었습니다."),
     _REMINDER_LOADED(HttpStatus.OK, "HOME20016", "리마인드 알림 정보가 성공적으로 조회되었습니다."),
     _ALARM_UPDATED(HttpStatus.OK,"HOME20017","리마인드 알림 정보가 성공적으로 변경되었습니다."),
+    _TIMETABLE_LOADED(HttpStatus.OK,"HOME20018","시간표 정보가 성공적으로 조회되었습니다."),
     _ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2001", "채움활동 위시가 성공적으로 조회되었습니다."),
     _AI_ACTIVITY_LOADED(HttpStatus.OK, "ACTIVITY2002", "채움활동 ai컨텐츠가 성공적으로 조회되었습니다."),
     _AI_ACTIVITY_SAVE(HttpStatus.OK, "ACTIVITY2003", "선택된 채움활동 ai컨텐츠가 투두로 등록되었습니다.")

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeService.java
@@ -61,4 +61,7 @@ public interface HomeService {
 
     // 리마인드 알림 정보 변경
     void updateAlarm(HomeRequestDto.AlarmDto dto);
+
+    // 시간표 조회
+    HomeResponseDto.TimeTableDto getTimeTable(LocalDate date, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -732,6 +732,7 @@ public class HomeServiceImpl implements HomeService {
         }
     }
 
+    @Transactional(readOnly = true)
     @Override
     public HomeResponseDto.TimeTableDto getTimeTable(LocalDate date, User user) {
         // 시간표 조회

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -742,4 +742,97 @@ public class HomeServiceImpl implements HomeService {
             reminder.updateStatus(alarmStatus);
         }
     }
+
+    @Override
+    public HomeResponseDto.TimeTableDto getTimeTable(LocalDate date, User user) {
+        // 시간표 조회
+        // 1. 수면패턴, 투두 응답 배열 선언
+        List<HomeResponseDto.TimeSlotDto> sleepList = new ArrayList<>();
+        List<HomeResponseDto.TimeSlotDto> todoList = new ArrayList<>();
+
+        // 2. 수면패턴 불러오기 -> 배열 구성하기
+        LocalTime sleepTime = user.getSleepTime();
+        LocalTime wakeTime = user.getWakeTime();
+
+        if(sleepTime != null && wakeTime != null){
+            if(sleepTime.isAfter(wakeTime)){
+                // 자정 이전에 자는 경우
+                sleepList.add(new HomeResponseDto.TimeSlotDto(LocalTime.MIDNIGHT,wakeTime));
+                sleepList.add(new HomeResponseDto.TimeSlotDto(sleepTime,LocalTime.MAX));
+            } else{
+                // 자정 이후에 자는 경우
+                sleepList.add(new HomeResponseDto.TimeSlotDto(sleepTime,wakeTime));
+            }
+        }
+
+        // 3. 스케줄 정보 등록하기
+        LocalDateTime todayMidnight = date.atStartOfDay(); // 오늘 자정
+        LocalDateTime tomorrowMidnight = date.plusDays(1).atStartOfDay(); // 내일 자정
+
+        // 오늘 날짜에 해당하는 일정 조회
+        List<Schedule> scheduleList = scheduleRepository.findSchedulesOnDate(user, todayMidnight, tomorrowMidnight);
+
+        for(Schedule schedule : scheduleList){
+            // 삭제된 루틴 ->  표시 X
+            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+
+            // 취소된 틈 -> 표시 X
+            if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;
+
+            // 시작날짜가 어제인 경우
+            // 전날 시작되었다면 midnight부터 시작되도록 보정
+            LocalTime start = schedule.getStartTime().isBefore(todayMidnight)?
+                    LocalTime.MIDNIGHT : schedule.getStartTime().toLocalTime();
+
+            // 종료날짜가 내일인 경우
+            // 종료시간이 내일 0시 이전이면 그대로 / 내일 0시 이후면 LocalTime MAX로
+            LocalTime end = schedule.getEndTime().isBefore(tomorrowMidnight)?
+                    schedule.getEndTime().toLocalTime() : LocalTime.MAX;
+
+            todoList.add(new HomeResponseDto.TimeSlotDto(start, end));
+        }
+
+        // 4. 각 배열 startTime 기준으로 정렬하기
+        sleepList.sort(Comparator.comparing(HomeResponseDto.TimeSlotDto::getStartTime));
+        todoList.sort(Comparator.comparing(HomeResponseDto.TimeSlotDto::getStartTime));
+
+        // 5. 겹치는 투두 병합하기
+        todoList = mergeConflictTime(todoList);
+
+        // 6. 반환하기
+        HomeResponseDto.TimeTableDto result = scheduleConverter.toTimeTableDto(sleepList,todoList);
+        return result;
+    }
+
+    private List<HomeResponseDto.TimeSlotDto> mergeConflictTime(List<HomeResponseDto.TimeSlotDto> list) {
+        // 겹치는 Todo 일정 로직 처리
+        if(list.isEmpty()) return list;
+
+        List<HomeResponseDto.TimeSlotDto> result = new ArrayList<>();
+        HomeResponseDto.TimeSlotDto last = list.get(0); // 첫번째 투두
+        result.add(last);
+
+        for(int i = 1; i < list.size(); i++){
+            HomeResponseDto.TimeSlotDto current = list.get(i);
+
+            if(!current.getStartTime().isAfter(last.getEndTime())){
+                // current 투두의 시작시간이 last 투두의 종료시간과 같거나 이른 경우
+
+                // 둘중 늦은 endTime 으로 설정
+                LocalTime endTime = last.getEndTime().isAfter(current.getEndTime()) ? last.getEndTime() : current.getEndTime();
+
+                HomeResponseDto.TimeSlotDto merged = HomeResponseDto.TimeSlotDto.builder()
+                        .startTime(last.getStartTime()) // 이전 시작
+                        .endTime(endTime) // 현재 종료
+                        .build();
+
+                result.set(result.size() - 1, merged); // last를 merge로 바꿈
+                last = merged; // last 업데이트
+            } else{
+                result.add(current); // current 넣기
+                last = current; // last 업데이트
+            }
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#240
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
수면패턴과 투두가 겹칠 수 있도록 변경됨에 따라 시간표 조회 api 응답 구조를 기존 24시간 타임슬롯 형태에서 수면패턴, 투두를 각 배열로 반환하는 구조로 변경하였습니다.
각 슬롯을 시작시간과 종료시간을 담아 TimeTableDto 배열로 구성되고 이후에 투두 내에서 동일한 시간대에 겹치는 투두가 발생한다면 투두를 겹쳐 하나의 슬롯을 만드는 과정을 거칩니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
GET `/api/home/timetable?date={YYYY-MM-DD}`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
기존 시간표 조회 api는 위시 투두 등록에 사용되기 때문에 그대로 남겨두었습니다.

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 시간표 조회 API 추가 — 지정한 날짜에 대한 사용자의 하루 시간표(수면 슬롯 및 일정 슬롯 목록)를 조회해 반환합니다.
  * 시간표 항목의 중복/연속 구간을 병합해 보다 깔끔한 결과를 제공합니다.

* **버그 수정**
  * 알림 스키마의 표기 오류 "온보딩 리망니드"를 "온보딩 리마인드"로 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->