### PR TITLE
Feat : 반복일정 수정 로직 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -79,7 +79,7 @@ public class ScheduleConverter {
                 .endTime(date.atTime(routine.getEndTime()))
                 .isPublic(false)
                 .includeTeum(false)
-                .remindAlarm(List.of())
+                .remindAlarm(toOnboardingReminderDtos(onboardingReminders))
                 .profileUrl(profileUrls)
                 .build();
     }
@@ -93,6 +93,21 @@ public class ScheduleConverter {
                     HomeResponseDto.ReminderAlarmDto dto = new HomeResponseDto.ReminderAlarmDto();
                     dto.setAlarm(r.getReminderTime());
                     dto.setStatus(r.getAlarmStatus());
+                    return dto;
+                })
+                .toList();
+    }
+
+    // 온보딩 리마인드 알림 변혼
+    private List<HomeResponseDto.ReminderAlarmDto> toOnboardingReminderDtos(List<RemindAlarm> onboardingReminders) {
+        if (onboardingReminders == null || onboardingReminders.isEmpty()) return List.of();
+
+        return onboardingReminders.stream()
+                .filter(Objects::nonNull)
+                .map(ra -> {
+                    HomeResponseDto.ReminderAlarmDto dto = new HomeResponseDto.ReminderAlarmDto();
+                    dto.setAlarm(ra.getMinutesBefore());
+                    dto.setStatus(AlarmStatus.ACTIVE);
                     return dto;
                 })
                 .toList();

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -100,8 +100,8 @@ public class ScheduleConverter {
         if (onboardingReminders == null || onboardingReminders.isEmpty()) return List.of();
 
         return onboardingReminders.stream()
-                .sorted(Comparator.comparingInt(RemindAlarm::getMinutesBefore))
                 .filter(Objects::nonNull)
+                .sorted(Comparator.comparingInt(RemindAlarm::getMinutesBefore))
                 .map(ra -> {
                     HomeResponseDto.ReminderAlarmDto dto = new HomeResponseDto.ReminderAlarmDto();
                     dto.setAlarm(ra.getMinutesBefore());
@@ -222,7 +222,7 @@ public class ScheduleConverter {
     }
 
     // HomeRequestDto.TodoRequestDto -> Schedule (반복일정 수정)
-    public Schedule toScheduleFromRoutine(HomeRequestDto.TodoRequestDto dto,User user,Routine routine) {
+    public Schedule toScheduleFromRoutine(HomeRequestDto.TodoRequestDto dto,Routine routine) {
         return Schedule.builder()
                 .user(routine.getUser())
                 .title(dto.getTitle())

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -127,7 +127,6 @@ public class ScheduleConverter {
                 .includeTeum(false)
                 .type(ScheduleType.ROUTINE)
                 .status(ScheduleStatus.ACTIVE)
-                .isDeleted(true)
                 .routineStatus(RoutineStatus.DELETED)
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -95,11 +95,12 @@ public class ScheduleConverter {
                 .toList();
     }
 
-    // 온보딩 리마인드 알림 변혼
+    // 온보딩 리마인드 알림 변환
     private List<HomeResponseDto.ReminderAlarmDto> toOnboardingReminderDtos(List<RemindAlarm> onboardingReminders) {
         if (onboardingReminders == null || onboardingReminders.isEmpty()) return List.of();
 
         return onboardingReminders.stream()
+                .sorted(Comparator.comparingInt(RemindAlarm::getMinutesBefore))
                 .filter(Objects::nonNull)
                 .map(ra -> {
                     HomeResponseDto.ReminderAlarmDto dto = new HomeResponseDto.ReminderAlarmDto();
@@ -223,7 +224,7 @@ public class ScheduleConverter {
     // HomeRequestDto.TodoRequestDto -> Schedule (반복일정 수정)
     public Schedule toScheduleFromRoutine(HomeRequestDto.TodoRequestDto dto,User user,Routine routine) {
         return Schedule.builder()
-                .user(user)
+                .user(routine.getUser())
                 .title(dto.getTitle())
                 .description(dto.getDescription())
                 .type(ScheduleType.ROUTINE)

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -9,6 +9,7 @@ import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.user.entity.RemindAlarm;
@@ -202,6 +203,23 @@ public class ScheduleConverter {
                 .type(ScheduleType.ROUTINE)
                 .build();
 
+    }
+
+    // HomeRequestDto.TodoRequestDto -> Schedule (반복일정 수정)
+    public Schedule toScheduleFromRoutine(HomeRequestDto.TodoRequestDto dto,User user,Routine routine) {
+        return Schedule.builder()
+                .user(user)
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .type(ScheduleType.ROUTINE)
+                .date(dto.getStartTime().toLocalDate())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .isPublic(dto.getIsPublic())
+                .includeTeum(dto.getIncludeTeum())
+                .routineStatus(RoutineStatus.MODIFIED)
+                .routine(routine)
+                .build();
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -1,6 +1,8 @@
 package umc.teumteum.server.domain.home.converter;
 
 import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.dto.request.HomeRequestDto;
 import umc.teumteum.server.domain.home.dto.request.WishRequestDto;
@@ -21,6 +23,7 @@ import java.time.LocalTime;
 import java.util.*;
 
 @Component
+@RequiredArgsConstructor
 public class ScheduleConverter {
 
     // TodoRequestDTO -> Schedule
@@ -184,7 +187,7 @@ public class ScheduleConverter {
     }
 
     // Routine -> HomeResponseDto.TodolistDto (미래의 일정일 경우)
-    public HomeResponseDto.TodolistDto toVirtualRoutineDto(Routine routine,LocalDate date) {
+    public HomeResponseDto.TodolistDto toVirtualRoutineDto(Routine routine,LocalDate date, AlarmStatus alarmStatus) {
 
         // 가상의 ID 생성
         String dateStr = String.format("%04d%02d%02d", date.getYear(), date.getMonthValue(), date.getDayOfMonth());
@@ -200,7 +203,7 @@ public class ScheduleConverter {
                 .startTime(routine.getStartTime())
                 .endTime(endtime)
                 .isPublic(false)
-                .alarmStatus(AlarmStatus.NONE)
+                .alarmStatus(alarmStatus)
                 .type(ScheduleType.ROUTINE)
                 .build();
 
@@ -222,5 +225,4 @@ public class ScheduleConverter {
                 .routine(routine)
                 .build();
     }
-
 }

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -110,6 +110,7 @@ public class ScheduleConverter {
                 .type(ScheduleType.ROUTINE)
                 .status(ScheduleStatus.ACTIVE)
                 .isDeleted(true)
+                .routineStatus(RoutineStatus.DELETED)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -75,10 +75,6 @@ public class Schedule extends BaseEntity {
     @Column(name = "status", nullable = false)
     private ScheduleStatus status = ScheduleStatus.ACTIVE;
 
-    @Builder.Default
-    @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted = false;
-
     @Builder.Default()
     @Enumerated(EnumType.STRING)
     @Column(name = "routine_status", nullable = false)
@@ -114,11 +110,6 @@ public class Schedule extends BaseEntity {
 
     public void complete() {
         this.status = ScheduleStatus.COMPLETED;
-    }
-
-    // 루틴 삭제 처리
-    public void setIsDeleted(boolean isDeleted) {
-        this.isDeleted = isDeleted;
     }
 
     // 과거 & 현재 루틴 수정 처리

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -24,7 +24,15 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "schedule")
+@Table(
+        name = "schedule",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_routine_date",
+                        columnNames = {"user_id","routine_id","date"}
+                )
+        }
+)
 public class Schedule extends BaseEntity {
 
     @Id

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -113,4 +113,9 @@ public class Schedule extends BaseEntity {
         this.isDeleted = isDeleted;
     }
 
+    // 과거 & 현재 루틴 수정 처리
+    public void setRoutineStatus(RoutineStatus routineStatus) {
+        this.routineStatus = routineStatus;
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.teumteum.server.domain.home.dto.request.HomeRequestDto;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
@@ -69,6 +70,11 @@ public class Schedule extends BaseEntity {
     @Builder.Default
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
+
+    @Builder.Default()
+    @Enumerated(EnumType.STRING)
+    @Column(name = "routine_status", nullable = false)
+    private RoutineStatus routineStatus = RoutineStatus.ORIGINAL;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teum_request_id")

--- a/src/main/java/umc/teumteum/server/domain/home/entity/enums/RoutineStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/enums/RoutineStatus.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.home.entity.enums;
+
+public enum RoutineStatus {
+    ORIGINAL,
+    MODIFIED,
+    DELETED
+}

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -13,6 +13,7 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _INVALID_DURATION(HttpStatus.BAD_REQUEST,"HOME4002","잘못된 조회 기간입니다."),
     _CANNOT_UPDATE_ROUTINE(HttpStatus.BAD_REQUEST,"HOME4003","반복일정은 수정할 수 없습니다."),
     _INVALID_VIRTUAL_ID(HttpStatus.BAD_REQUEST,"HOME4004","잘못된 루틴 ID 형식입니다."),
+    _ROUTINE_OUT_OF_BOUND(HttpStatus.BAD_REQUEST,"HOME4005","반복 일정은 해당 날짜 내에서만 수정할 수 있습니다."),
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
     _CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "HOME4045", "카테고리는 필수 항목입니다."),

--- a/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/home/exception/status/HomeErrorStatus.java
@@ -13,7 +13,7 @@ public enum HomeErrorStatus implements BaseErrorCode {
     _INVALID_DURATION(HttpStatus.BAD_REQUEST,"HOME4002","잘못된 조회 기간입니다."),
     _CANNOT_UPDATE_ROUTINE(HttpStatus.BAD_REQUEST,"HOME4003","반복일정은 수정할 수 없습니다."),
     _INVALID_VIRTUAL_ID(HttpStatus.BAD_REQUEST,"HOME4004","잘못된 루틴 ID 형식입니다."),
-    _ROUTINE_OUT_OF_BOUND(HttpStatus.BAD_REQUEST,"HOME4005","반복 일정은 해당 날짜 내에서만 수정할 수 있습니다."),
+    _ROUTINE_FIELDS_IMMUTABLE(HttpStatus.BAD_REQUEST,"HOME4006","반복 일정은 리마인드 알림만 변경할 수 있으며, 기타 내용은 마이페이지에서 수정 가능합니다."),
     _SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "HOME4041", "해당 정보를 찾을 수 없습니다."),
     _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"HOME4042","해당 카테고리를 찾을 수 없습니다."),
     _CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "HOME4045", "카테고리는 필수 항목입니다."),

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
@@ -25,13 +25,13 @@ public class ScheduleJdbcRepository {
         String sql =  """
         INSERT INTO schedule
           (user_id, routine_id, title, description, 
-           date, start_time, end_time, type, status,
-           include_teum, is_public, routine_status,
+           date, start_time, end_time, type, 
+           status,include_teum, is_public, routine_status,
            created_at, updated_at)
         VALUES
           (?, ?, ?, ?, 
-           ?, ?, ?, ?, ?,
-           ?, ?, ?,
+           ?, ?, ?, ?,
+           ?, ?, ?, ?,
            NOW(), NOW())
         """;
 
@@ -101,7 +101,8 @@ public class ScheduleJdbcRepository {
         INSERT INTO schedule (
             user_id, title, description, type, date, start_time, end_time, 
             is_public, include_teum, status,
-            routine_id, teum_request_id, created_at, updated_at
+            routine_id, teum_request_id, routine_status,
+            created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
 
@@ -118,8 +119,9 @@ public class ScheduleJdbcRepository {
             ps.setString(10, schedule.getStatus().name());
             ps.setObject(11, schedule.getRoutine() != null ? schedule.getRoutine().getId() : null);
             ps.setObject(12, schedule.getTeumRequest() != null ? schedule.getTeumRequest().getId() : null);
-            ps.setTimestamp(13, now);
+            ps.setString(13, schedule.getRoutineStatus().name());
             ps.setTimestamp(14, now);
+            ps.setTimestamp(15, now);
         });
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
@@ -26,12 +26,12 @@ public class ScheduleJdbcRepository {
         INSERT INTO schedule
           (user_id, routine_id, title, description, 
            date, start_time, end_time, type, status,
-           include_teum, is_deleted, is_public,
+           include_teum, is_deleted, is_public, routine_status,
            created_at, updated_at)
         VALUES
           (?, ?, ?, ?, 
            ?, ?, ?, ?, ?,
-           ?, ?, ?,
+           ?, ?, ?, ?,
            NOW(), NOW())
         """;
 
@@ -55,6 +55,7 @@ public class ScheduleJdbcRepository {
                         ps.setBoolean(10,false);
                         ps.setBoolean(11,false);
                         ps.setBoolean(12, false);
+                        ps.setString(13,schedule.getRoutineStatus().toString());
                     }
 
                     @Override

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleJdbcRepository.java
@@ -26,12 +26,12 @@ public class ScheduleJdbcRepository {
         INSERT INTO schedule
           (user_id, routine_id, title, description, 
            date, start_time, end_time, type, status,
-           include_teum, is_deleted, is_public, routine_status,
+           include_teum, is_public, routine_status,
            created_at, updated_at)
         VALUES
           (?, ?, ?, ?, 
            ?, ?, ?, ?, ?,
-           ?, ?, ?, ?,
+           ?, ?, ?,
            NOW(), NOW())
         """;
 
@@ -54,8 +54,7 @@ public class ScheduleJdbcRepository {
 
                         ps.setBoolean(10,false);
                         ps.setBoolean(11,false);
-                        ps.setBoolean(12, false);
-                        ps.setString(13,schedule.getRoutineStatus().toString());
+                        ps.setString(12,schedule.getRoutineStatus().toString());
                     }
 
                     @Override
@@ -101,7 +100,7 @@ public class ScheduleJdbcRepository {
         String sql = """
         INSERT INTO schedule (
             user_id, title, description, type, date, start_time, end_time, 
-            is_public, include_teum, status, is_deleted, 
+            is_public, include_teum, status,
             routine_id, teum_request_id, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
@@ -117,11 +116,10 @@ public class ScheduleJdbcRepository {
             ps.setBoolean(8, schedule.getIsPublic());
             ps.setBoolean(9, schedule.getIncludeTeum());
             ps.setString(10, schedule.getStatus().name());
-            ps.setBoolean(11, schedule.getIsDeleted());
-            ps.setObject(12, schedule.getRoutine() != null ? schedule.getRoutine().getId() : null);
-            ps.setObject(13, schedule.getTeumRequest() != null ? schedule.getTeumRequest().getId() : null);
+            ps.setObject(11, schedule.getRoutine() != null ? schedule.getRoutine().getId() : null);
+            ps.setObject(12, schedule.getTeumRequest() != null ? schedule.getTeumRequest().getId() : null);
+            ps.setTimestamp(13, now);
             ps.setTimestamp(14, now);
-            ps.setTimestamp(15, now);
         });
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -57,7 +57,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       AND s.date = :date
       AND s.startTime = :startTime
       AND s.endTime = :endTime
-      AND s.isDeleted = true
+      AND s.routineStatus = umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
 """)
     boolean existsDeletedRoutineInstance(
             @Param("userId") Long userId,
@@ -72,7 +72,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       AND s.type = 'TEUM'
       AND s.status IN (:statuses)
       AND s.date BETWEEN :start AND :end
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
 """)
     List<LocalDate> findScheduledTeumsByDates(
             @Param("userId") Long userId,
@@ -86,23 +86,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     WHERE s.teumRequest = :teumRequest
       AND s.status IN :statuses
       AND s.type = 'TEUM'
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
 """)
     List<Schedule> findByTeumRequestAndStatusIn(
             @Param("teumRequest") TeumRequest teumRequest,
             @Param("statuses") List<ScheduleStatus> statuses
     );
 
-    boolean existsByUserAndDateAndRoutineAndIsDeletedTrue(User user, LocalDate today, Routine routine);
-
-    List<Schedule> findByUserAndDateAndIsDeletedFalseOrderByStartTime(User user, LocalDate date);
-
     @Query("""
     SELECT s FROM Schedule s
     WHERE s.user.id = :userId
       AND s.date = :date
       AND s.status IN :statuses
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
 """)
     List<Schedule> findByUserIdAndDateAndStatusIn(
             @Param("userId") Long userId,
@@ -114,7 +110,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     SELECT s
     FROM Schedule s
     WHERE s.user = :user
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
       AND s.startTime < :startOfTomorrow
       AND s.endTime > :startOfToday
     ORDER BY s.startTime ASC
@@ -126,7 +122,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("""
     SELECT s.routine FROM Schedule s
-    WHERE s.date = :date AND s.isDeleted = true AND s.routine IS NOT NULL""")
+    WHERE s.date = :date 
+    AND s.routineStatus = umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
+    AND s.routine IS NOT NULL""")
     List<Routine> findDeletedRoutinesByDate( @Param("date") LocalDate date);
 
     /**
@@ -195,7 +193,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     SELECT s FROM Schedule s
     WHERE s.user.id = :userId
       AND s.isPublic = true
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
     ORDER BY s.createdAt DESC
 """)
     List<Schedule> findAllPublicByUserId(@Param("userId") Long userId);
@@ -211,7 +209,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       AND s.type IN :types
       AND s.status = 'ACTIVE'
       AND s.isPublic = true
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
       AND s.date BETWEEN :start AND :end
 """)
     List<LocalDate> findPublicActiveTodos(
@@ -227,7 +225,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       AND s.type = 'TEUM'
       AND s.status IN :statuses
       AND s.isPublic = true
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
       AND s.date BETWEEN :start AND :end
 """)
     List<LocalDate> findPublicTeumDates(
@@ -266,7 +264,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     WHERE s.user.id = :userId
       AND s.date = :date
       AND s.isPublic = true
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
 """)
     List<Schedule> findPublicSchedulesByUserAndDate(
             @Param("userId") Long userId,
@@ -299,7 +297,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     SELECT s FROM Schedule s
     WHERE s.type = :type
       AND s.status = :status
-      AND s.isDeleted = false
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
       AND s.startTime <= :now
 """)
     List<Schedule> findAllExpiredActiveTeums(
@@ -315,7 +313,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
           and s.type = :type
           and s.routine is not null
           and s.user.id in :userIds
-          and s.isDeleted = false
+          and s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
     """)
     List<Schedule> findRoutines(
             @Param("date") LocalDate date,

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -283,9 +283,9 @@ public class HomeServiceImpl implements HomeService {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._SCHEDULE_NOT_FOUND));
 
-        // 2-1. 루틴 기반 스케줄일 경우
+        // 2-1. 루틴 기반 스케줄일 경우 -> routine_status = MODIFIED
         if (schedule.getRoutine() != null) {
-            schedule.setIsDeleted(true);
+            schedule.setRoutineStatus(RoutineStatus.DELETED);
             return;
         }
 

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.home.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -206,58 +207,97 @@ public class HomeServiceImpl implements HomeService {
         Routine routine = routineRepository.findById(routineId)
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._ROUTINE_NOT_FOUND));
 
-        // 2. 시간 검증
+        // 1. 필드 수정 여부 판단
         LocalDateTime start = dto.getStartTime();
         LocalDateTime end = dto.getEndTime();
 
-        // 2-1. 당일 날짜인지 검증
+        // 2-1. 날짜 수정 여부
         if(!start.toLocalDate().equals(date) || !end.toLocalDate().equals(date)){
-            throw new HomeException(HomeErrorStatus._ROUTINE_OUT_OF_BOUND);
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
         }
 
-        // 2-2. 시간 유효성 검사
-        if(end.isBefore(start) || end.isEqual(start)){
-            throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
+        // 2-2. 기타 필드 수정 여부
+        if(dto.getTitle() != null && !dto.getTitle().equals(routine.getTitle())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getDescription() != null && !dto.getDescription().equals(routine.getDescription())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getIsPublic() != null && !dto.getIsPublic().equals(false)) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getIncludeTeum() != null && !dto.getIncludeTeum().equals(false)) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getStartTime().toLocalTime() != null && !dto.getStartTime().toLocalTime().equals(routine.getStartTime())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getStartTime().toLocalTime() != null && !dto.getEndTime().toLocalTime().equals(routine.getEndTime())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
         }
 
         // 3. 스케줄 테이블에 저장
-        Schedule schedule = scheduleConverter.toScheduleFromRoutine(dto,user,routine);
-        Schedule savedSchedule = scheduleRepository.save(schedule);
+        Schedule schedule = getOrCreateRoutine(user,routine,date,dto);
 
         // 4. 리마인드 저장
+        scheduleReminderRepository.deleteByScheduleId(schedule.getId());
         if (dto.getRemindAlarm() != null && !dto.getRemindAlarm().isEmpty()) {
             List<ScheduleReminder> reminders =
-                    scheduleConverter.toScheduleReminders(savedSchedule, dto.getRemindAlarm());
+                    scheduleConverter.toScheduleReminders(schedule, dto.getRemindAlarm());
             scheduleReminderRepository.saveAll(reminders);
         }
+        return new HomeResponseDto.TodoIdDto(schedule.getId());
+    }
 
-        // 4. 반환
-        return new HomeResponseDto.TodoIdDto(savedSchedule.getId());
+    @Transactional
+    public Schedule getOrCreateRoutine(User user, Routine routine, LocalDate date, HomeRequestDto.TodoRequestDto dto) {
+        // 1. 이미 존재하는지 먼저 조회
+        Optional<Schedule> existing = scheduleRepository.findByUserAndRoutineAndDate(user, routine, date);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        // 2. 없으면 convert로 새로 생성
+        Schedule newSchedule = scheduleConverter.toScheduleFromRoutine(dto, user, routine);
+
+        try {
+            // 저장
+            return scheduleRepository.save(newSchedule);
+        } catch (DataIntegrityViolationException e) {
+            // 동시에 다른 요청이 먼저 저장했을 수도 있으니 다시 조회
+            return scheduleRepository.findByUserAndRoutineAndDate(user, routine, date)
+                    .orElseThrow(() -> new HomeException(HomeErrorStatus._SCHEDULE_NOT_FOUND));
+        }
     }
 
     @Transactional
     public HomeResponseDto.TodoIdDto updateCurrentRoutine(HomeRequestDto.TodoRequestDto dto, Schedule schedule) {
-        // 과거 & 오늘의 루틴 수정
+        // 스케줄테이블의 루틴 수정 (과거 & 현재 & 이미 수정한 미래의 루틴)
 
-        // 시간 검증
-         LocalDate targetDate = schedule.getDate();
-
-        // 1-1. 당일 날짜 내 검증
-        if(!dto.getStartTime().toLocalDate().equals(targetDate) ||
-                !dto.getEndTime().toLocalDate().equals(targetDate)){
-            throw new HomeException(HomeErrorStatus._ROUTINE_OUT_OF_BOUND);
+        // 1. 루틴은 상세 필드 수정 불가
+        if(dto.getTitle() != null && !dto.getTitle().equals(schedule.getTitle())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getDescription() != null && !dto.getDescription().equals(schedule.getDescription())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getIsPublic() != null && !dto.getIsPublic().equals(schedule.getIsPublic())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getIncludeTeum() != null && !dto.getIncludeTeum().equals(schedule.getIncludeTeum())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getStartTime() != null && !dto.getStartTime().isEqual(schedule.getStartTime())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
+        }
+        if (dto.getEndTime() != null && !dto.getEndTime().isEqual(schedule.getEndTime())) {
+            throw new HomeException(HomeErrorStatus._ROUTINE_FIELDS_IMMUTABLE);
         }
 
-        // 1-2. 시간 유효성 검사
-        if (dto.getEndTime().isBefore(dto.getStartTime()) || dto.getEndTime().isEqual(dto.getStartTime())) {
-            throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
-        }
-
-        // 2-1. 필드 업데이트
-        schedule.updateField(dto);
+        // 2. 필드 업데이트
         schedule.setRoutineStatus(RoutineStatus.MODIFIED);
 
-        // 2-2. 리마인더 생성
+        // 3. 리마인더 생성
         scheduleReminderRepository.deleteByScheduleId(schedule.getId());
         if (dto.getRemindAlarm() != null && !dto.getRemindAlarm().isEmpty()) {
             List<ScheduleReminder> reminders =

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -735,7 +735,7 @@ public class HomeServiceImpl implements HomeService {
 
         // 2. 삭제되지 않은 스케줄 필터링 & 삭제된 틈 필터링
         List<Schedule> validSchedules = allSchedules.stream()
-                .filter(s -> !s.getIsDeleted())
+                .filter(s -> !s.getRoutineStatus().equals(RoutineStatus.DELETED))
                 .filter(s -> !s.getStatus().equals(ScheduleStatus.CANCELLED))
                 .toList();
 
@@ -758,9 +758,6 @@ public class HomeServiceImpl implements HomeService {
                         alarmStatus = AlarmStatus.NONE;
                     } else if(scheduleReminders.stream().anyMatch(r -> r.getAlarmStatus() == AlarmStatus.ACTIVE)){
                         alarmStatus = AlarmStatus.ACTIVE;
-                    } else if(schedule.getType() == ScheduleType.ROUTINE) {
-                        // 데모데이까지 반복일정의 경우 알림은 NONE 수정불가
-                        alarmStatus = AlarmStatus.NONE;
                     } else{
                         alarmStatus = AlarmStatus.INACTIVE;
                     }
@@ -768,9 +765,11 @@ public class HomeServiceImpl implements HomeService {
                 })
                 .toList();
 
-        // 5. 삭제된 루틴 ID
-        Set<Long> deletedRoutineIds = allSchedules.stream()
-                .filter(s-> s.getRoutine() != null && s.getIsDeleted())
+        // 5. 삭제 or 수정된 루틴 ID
+        Set<Long> excludedRoutineIds = allSchedules.stream()
+                .filter(s-> s.getRoutine() != null)
+                .filter(s -> s.getRoutineStatus() ==  RoutineStatus.DELETED
+                                    || s.getRoutineStatus() == RoutineStatus.MODIFIED)
                 .map(s->s.getRoutine().getId())
                 .collect(Collectors.toSet());
 
@@ -782,10 +781,16 @@ public class HomeServiceImpl implements HomeService {
             Weekday todayWeekday = Weekday.valueOf(date.getDayOfWeek().name());
             List<Routine> routines = routineRepository.findByUserAndWeekday(user, todayWeekday);
 
-            // 6-2. 삭제되지 않은 루틴에 대해 가상의 ID 생성
+            // 6-2. 수정 or 삭제되지 않은 루틴에 대해 가상의 ID 생성
             routineDtos = routines.stream()
-                    .filter(r -> !deletedRoutineIds.contains(r.getId()))
-                    .map(r -> scheduleConverter.toVirtualRoutineDto(r, date))
+                    .filter(r -> !excludedRoutineIds.contains(r.getId()))
+                    .map(r -> {
+                        // 알림 상태 설정
+                        boolean hasAlarm = remindAlarmRepository.existsByUser(user);
+                        AlarmStatus alarmStatus = hasAlarm ? AlarmStatus.ACTIVE : AlarmStatus.NONE;
+                        // dto 변환
+                        return scheduleConverter.toVirtualRoutineDto(r, date, alarmStatus);
+                    })
                     .toList();
         }
 

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -473,7 +473,7 @@ public class HomeServiceImpl implements HomeService {
 
         for (Schedule schedule : schedules) {
             // 삭제된 루틴 ->  표시 X
-            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+            if(schedule.getRoutine() != null && schedule.getRoutineStatus() == RoutineStatus.DELETED) continue;
 
             // 취소된 틈 -> 표시 X
             if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;
@@ -672,7 +672,7 @@ public class HomeServiceImpl implements HomeService {
         for (Schedule schedule : schedules) {
             LocalDate date = schedule.getDate();
             // 3-1. 삭제된 루틴 ->  표시 X
-            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+            if(schedule.getRoutine() != null && schedule.getRoutineStatus() == RoutineStatus.DELETED) continue;
 
             // 3-2. 취소된 틈 -> 표시 X
             if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;
@@ -687,7 +687,7 @@ public class HomeServiceImpl implements HomeService {
 
             // 4-1. 스케줄에서 삭제된 날짜의 루틴ID만 모아둠
             Map<LocalDate, Set<Long>> deletedRoutine = schedules.stream()
-                    .filter(s -> s.getRoutine() != null && s.getIsDeleted())
+                    .filter(s -> s.getRoutine() != null && s.getRoutineStatus() == RoutineStatus.DELETED)
                     .collect(Collectors.groupingBy(
                             Schedule::getDate,
                             Collectors.mapping(

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -879,7 +879,7 @@ public class HomeServiceImpl implements HomeService {
 
         for(Schedule schedule : scheduleList){
             // 삭제된 루틴 ->  표시 X
-            if(schedule.getRoutine() != null && schedule.getIsDeleted()) continue;
+            if(schedule.getRoutine() != null && schedule.getRoutineStatus() ==  RoutineStatus.DELETED) continue;
 
             // 취소된 틈 -> 표시 X
             if(schedule.getStatus() == ScheduleStatus.CANCELLED) continue;

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -15,10 +15,7 @@ import umc.teumteum.server.domain.home.entity.Category;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.Wish;
-import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
-import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
-import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
-import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
+import umc.teumteum.server.domain.home.entity.enums.*;
 import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 import umc.teumteum.server.domain.home.exception.status.HomeErrorStatus;
 import umc.teumteum.server.domain.home.exception.HomeException;
@@ -161,11 +158,7 @@ public class HomeServiceImpl implements HomeService {
         // Todo(Schedule) 수정
         if (scheduleId < 0) {
             // 1. 미래의 반복일정 수정
-            /**
-             * 여기에 수정 로직 들어가야함
-             * 다른 메소드 호출로 처리하기
-             */
-            return updateRoutine(dto, scheduleId, user);
+            return updateFutureRoutine(dto, scheduleId, user);
         }
 
         // 2. 스케줄 테이블 조회
@@ -173,11 +166,8 @@ public class HomeServiceImpl implements HomeService {
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._SCHEDULE_NOT_FOUND));
 
         if (schedule.getType() == ScheduleType.ROUTINE) {
-            // 3. 현재, 과거의 반복일정은 수정할 수 없음
-            throw new HomeException(HomeErrorStatus._CANNOT_UPDATE_ROUTINE);
-            /**
-             * 여기에 현재 과저 반복일정 수정 로직 추가
-             */
+            // 3. 현재, 과거의 반복일정 수정
+            return updateCurrentRoutine(dto,schedule);
         }
 
         // 4. 시간 유효성 검사
@@ -205,7 +195,7 @@ public class HomeServiceImpl implements HomeService {
     }
 
     @Transactional
-    public HomeResponseDto.TodoIdDto updateRoutine(HomeRequestDto.TodoRequestDto dto, Long scheduleId, User user) {
+    public HomeResponseDto.TodoIdDto updateFutureRoutine(HomeRequestDto.TodoRequestDto dto, Long scheduleId, User user) {
         // 미래의 반복일정 수정로직
 
         // 1. 루틴 파싱
@@ -243,6 +233,38 @@ public class HomeServiceImpl implements HomeService {
 
         // 4. 반환
         return new HomeResponseDto.TodoIdDto(savedSchedule.getId());
+    }
+
+    @Transactional
+    public HomeResponseDto.TodoIdDto updateCurrentRoutine(HomeRequestDto.TodoRequestDto dto, Schedule schedule) {
+        // 과거 & 오늘의 루틴 수정
+
+        // 시간 검증
+         LocalDate targetDate = schedule.getDate();
+
+        // 1-1. 당일 날짜 내 검증
+        if(!dto.getStartTime().toLocalDate().equals(targetDate) ||
+                !dto.getEndTime().toLocalDate().equals(targetDate)){
+            throw new HomeException(HomeErrorStatus._ROUTINE_OUT_OF_BOUND);
+        }
+
+        // 1-2. 시간 유효성 검사
+        if (dto.getEndTime().isBefore(dto.getStartTime()) || dto.getEndTime().isEqual(dto.getStartTime())) {
+            throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
+        }
+
+        // 2-1. 필드 업데이트
+        schedule.updateField(dto);
+        schedule.setRoutineStatus(RoutineStatus.MODIFIED);
+
+        // 2-2. 리마인더 생성
+        scheduleReminderRepository.deleteByScheduleId(schedule.getId());
+        if (dto.getRemindAlarm() != null && !dto.getRemindAlarm().isEmpty()) {
+            List<ScheduleReminder> reminders =
+                    scheduleConverter.toScheduleReminders(schedule, dto.getRemindAlarm());
+            scheduleReminderRepository.saveAll(reminders);
+        }
+        return new HomeResponseDto.TodoIdDto(schedule.getId());
     }
 
     @Transactional

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -252,7 +252,7 @@ public class HomeServiceImpl implements HomeService {
         }
 
         // 2. 없으면 convert로 새로 생성
-        Schedule newSchedule = scheduleConverter.toScheduleFromRoutine(dto, user, routine);
+        Schedule newSchedule = scheduleConverter.toScheduleFromRoutine(dto, routine);
 
         try {
             // 저장

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -160,8 +160,12 @@ public class HomeServiceImpl implements HomeService {
     public HomeResponseDto.TodoIdDto updateTodoInfo(HomeRequestDto.TodoRequestDto dto, Long scheduleId, User user) {
         // Todo(Schedule) 수정
         if (scheduleId < 0) {
-            // 1. 미래의 반복일정은 수정할 수 없음
-            throw new HomeException(HomeErrorStatus._CANNOT_UPDATE_ROUTINE);
+            // 1. 미래의 반복일정 수정
+            /**
+             * 여기에 수정 로직 들어가야함
+             * 다른 메소드 호출로 처리하기
+             */
+            return updateRoutine(dto, scheduleId, user);
         }
 
         // 2. 스케줄 테이블 조회
@@ -171,6 +175,9 @@ public class HomeServiceImpl implements HomeService {
         if (schedule.getType() == ScheduleType.ROUTINE) {
             // 3. 현재, 과거의 반복일정은 수정할 수 없음
             throw new HomeException(HomeErrorStatus._CANNOT_UPDATE_ROUTINE);
+            /**
+             * 여기에 현재 과저 반복일정 수정 로직 추가
+             */
         }
 
         // 4. 시간 유효성 검사
@@ -195,6 +202,47 @@ public class HomeServiceImpl implements HomeService {
             scheduleReminderRepository.saveAll(reminders);
         }
         return new HomeResponseDto.TodoIdDto(schedule.getId());
+    }
+
+    @Transactional
+    public HomeResponseDto.TodoIdDto updateRoutine(HomeRequestDto.TodoRequestDto dto, Long scheduleId, User user) {
+        // 미래의 반복일정 수정로직
+
+        // 1. 루틴 파싱
+        HomeResponseDto.VirtualRoutineDto parsedRoutine =  getVirtualRoutine(scheduleId);
+        LocalDate date = parsedRoutine.getDate();
+        Long  routineId = parsedRoutine.getRoutineId();
+
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new HomeException(HomeErrorStatus._ROUTINE_NOT_FOUND));
+
+        // 2. 시간 검증
+        LocalDateTime start = dto.getStartTime();
+        LocalDateTime end = dto.getEndTime();
+
+        // 2-1. 당일 날짜인지 검증
+        if(!start.toLocalDate().equals(date) || !end.toLocalDate().equals(date)){
+            throw new HomeException(HomeErrorStatus._ROUTINE_OUT_OF_BOUND);
+        }
+
+        // 2-2. 시간 유효성 검사
+        if(end.isBefore(start) || end.isEqual(start)){
+            throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
+        }
+
+        // 3. 스케줄 테이블에 저장
+        Schedule schedule = scheduleConverter.toScheduleFromRoutine(dto,user,routine);
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+
+        // 4. 리마인드 저장
+        if (dto.getRemindAlarm() != null && !dto.getRemindAlarm().isEmpty()) {
+            List<ScheduleReminder> reminders =
+                    scheduleConverter.toScheduleReminders(savedSchedule, dto.getRemindAlarm());
+            scheduleReminderRepository.saveAll(reminders);
+        }
+
+        // 4. 반환
+        return new HomeResponseDto.TodoIdDto(savedSchedule.getId());
     }
 
     @Transactional

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
@@ -409,7 +410,7 @@ public class TeumServiceImpl implements TeumService {
             );
 
             schedules.stream()
-                    .filter(schedule -> !Boolean.TRUE.equals(schedule.getIsDeleted()))
+                    .filter(schedule -> schedule.getRoutineStatus() != RoutineStatus.DELETED)
                     .map(schedule -> teumConverter.sliceScheduleToDate(schedule, date))
                     .filter(Objects::nonNull)
                     .forEach(scheduledSlots::add);

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface RemindAlarmRepository extends JpaRepository<RemindAlarm, Long> {
     Optional<RemindAlarm> findByUser(User user);
     List<RemindAlarm> findAllByUser(User user);
+    Boolean existsByUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface RemindAlarmRepository extends JpaRepository<RemindAlarm, Long> {
     Optional<RemindAlarm> findByUser(User user);
     List<RemindAlarm> findAllByUser(User user);
-    Boolean existsByUser(User user);
+    boolean existsByUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/RoutineScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RoutineScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleJdbcRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
@@ -36,7 +37,7 @@ public class RoutineScheduler {
     private final ScheduleJdbcRepository scheduleJdbcRepository;
 
         @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-//    @Scheduled(cron = "0 0/08 * * * *", zone = "Asia/Seoul")
+//    @Scheduled(cron = "0 0/50 * * * *", zone = "Asia/Seoul")
     public void schedule() {
         log.info("[00:00] 반복일정 스케줄 테이블에 등록 시작");
 
@@ -82,6 +83,7 @@ public class RoutineScheduler {
                         .date(today)
                         .startTime(LocalDateTime.of(today, routine.getStartTime()))
                         .endTime(LocalDateTime.of(today, routine.getEndTime()))
+                        .routineStatus(RoutineStatus.ORIGINAL)
                         .build();
                 schedulesToInsert.add(routineSchedule);
             }

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.global.validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
@@ -129,7 +130,7 @@ public class ConflictValidator {
                 }
 
                 // Schedule이 존재하되 isDeleted == false면 → 충돌
-                if (!existing.get().getIsDeleted()) {
+                if (!existing.get().getRoutineStatus().equals(RoutineStatus.DELETED)) {
                     throw new GeneralException(ConflictErrorStatus.ROUTINE_CONFLICT);
                 }
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#242 
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
1. routine status 칼럼 추가
    - 스케줄 엔티티에서 is_deleted 칼럼 대신 routine_status enum 칼럼을 통해 원본, 수정, 삭제 여부를 구분하도록 변경했습니다. (기존의 is_deteled 기반 로직 모두 routine status 기준으로 변경했습니다.)
2. 반복일정 수정 로직
     - 특정 날짜의 반복일정이 수정되는 경우 스케줄 테이블에 데이터를 새로 생성하고 routine_status를 updated로 변경합니다.
3. 반복일정 스케줄러
     - 기존에는 삭제된 일정만 생성하지 않았으나, 수정된 일정도 새 인스턴스를 생성하지 않도록 조건을 추가했습니다.
4. 반복일정 유니크키 제약조건
     - (user_id, routine_id, date) 조합이 유일하도록 제약조건을 추가해 동일 날짜에 중복된 루틴 스케줄이 등록되지 않도록 했습니다.


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
기존 로직에서 isDeleted를 참조하던 모든 부분이 정상적으로 routineStatus 기반으로 변경되었는지 리뷰 부탁드립니다.
PUT `/api/home/todo/{todoId}` → 미래 루틴 수정
GET `/api/home/todolist?date={YYYY-MM-DD}` → 루틴의 리마인드 알림 정보 포함 여부

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
schedule 테이블의 스키마가 변경되어 ddl-auto=create 설정이 필요합니다.
### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반복 일정 리마인드 알림 처리 개선 및 온보딩 리마인더 표시 추가
  * 미래 루틴 전용 수정 경로 추가

* **변경 사항**
  * 일정 삭제/표시 로직을 상태 기반(원본/수정/삭제)으로 전환하여 캘린더·목록에서 일관된 노출
  * 알람 상태가 응답에 반영되도록 개선
  * 반복 일정은 리마인드 알림만 변경 가능하다는 안내(에러 코드 추가)

* **Refactor**
  * 일정 상태 관리 정비로 충돌 검사·가시성 로직 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->