### PR TITLE
Feat : 프로필 이미지 수정 API

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -68,4 +68,17 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._USER_PRESIGNED_URL_ISSUED, response);
     }
 
+    @Operation(
+            summary = "마이페이지 프로필 이미지 수정",
+            description = ""
+    )
+    @PostMapping(value = "/mypage/prefile-image", produces = "application/json")
+    public ApiResponse<Object> saveProfileImageKey(
+                HttpServletRequest httpServletRequest,
+                @RequestBody @Valid OnboardingRequestDto.ProfileImageRequest request,
+                @CurrentUser @Parameter(hidden = true) User user
+    ) {
+            userService.saveProfileImage(httpServletRequest, request, user);
+            return ApiResponse.of(UserSuccessStatus._USER_PROFILE_IMAGE_UPDATED, null);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -3,8 +3,12 @@ package umc.teumteum.server.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -49,5 +53,19 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._USER_FOUND, response);
     }
 
+    @Operation(
+            summary = "마이페이지 프로필 수정용 Presigned URL 발급",
+            description = "프로필 수정 과정에서 프로필 이미지를 S3에 직접 업로드할 수 있는 Presigned URL을 발급합니다."
+    )
+    @PostMapping(value = "/mypage/prefile-image/presigned-url", produces = "application/json")
+    public ApiResponse<OnboardingResponseDto.ProfileImagePresignedUrlResponse> getPresignedImagePresignedUrl(
+        HttpServletRequest httpServletRequest,
+        @RequestBody @Valid OnboardingRequestDto.ProfileImagePresignedUrlRequest request,
+        @CurrentUser @Parameter(hidden = true) User user
+    ){
+        OnboardingResponseDto.ProfileImagePresignedUrlResponse response =
+                userService.generateProfileImagePresignedUrl(httpServletRequest, request, user);
+        return ApiResponse.of(UserSuccessStatus._USER_PRESIGNED_URL_ISSUED, response);
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
             summary = "마이페이지 프로필 수정용 Presigned URL 발급",
             description = "프로필 수정 과정에서 프로필 이미지를 S3에 직접 업로드할 수 있는 Presigned URL을 발급합니다."
     )
-    @PostMapping(value = "/mypage/prefile-image/presigned-url", produces = "application/json")
+    @PostMapping(value = "/mypage/profile-image/presigned-url", produces = "application/json")
     public ApiResponse<OnboardingResponseDto.ProfileImagePresignedUrlResponse> getPresignedImagePresignedUrl(
         HttpServletRequest httpServletRequest,
         @RequestBody @Valid OnboardingRequestDto.ProfileImagePresignedUrlRequest request,
@@ -72,7 +72,7 @@ public class UserController {
             summary = "마이페이지 프로필 이미지 수정",
             description = "Presigned URL로 업로드된 새 프로필 이미지를 등록합니다. 기존 프로필 이미지는 삭제되고, 새 이미지 파일명이 저장됩니다."
     )
-    @PostMapping(value = "/mypage/prefile-image", produces = "application/json")
+    @PostMapping(value = "/mypage/profile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
                 HttpServletRequest httpServletRequest,
                 @RequestBody @Valid OnboardingRequestDto.ProfileImageRequest request,
@@ -86,7 +86,7 @@ public class UserController {
             summary = "마이페이지 프로필 이미지 삭제",
             description = "기존 프로필 이미지를 삭제 후, default 이미지로 수정합니다."
     )
-    @DeleteMapping(value = "/mypage/prefile-image", produces = "application/json")
+    @DeleteMapping(value = "/mypage/profile-image", produces = "application/json")
     public ApiResponse<Object> deleteProfileImage(
             HttpServletRequest httpServletRequest,
             @CurrentUser @Parameter(hidden = true) User user

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -88,10 +88,9 @@ public class UserController {
     )
     @DeleteMapping(value = "/mypage/profile-image", produces = "application/json")
     public ApiResponse<Object> deleteProfileImage(
-            HttpServletRequest httpServletRequest,
             @CurrentUser @Parameter(hidden = true) User user
     ) {
-        userService.deleteProfileImage(httpServletRequest, user);
+        userService.deleteProfileImage(user);
         return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_DELETED, null);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
 
     @Operation(
             summary = "마이페이지 프로필 이미지 수정",
-            description = ""
+            description = "Presigned URL로 업로드된 새 프로필 이미지를 등록합니다. 기존 프로필 이미지는 삭제되고, 새 이미지 파일명이 저장됩니다."
     )
     @PostMapping(value = "/mypage/prefile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
@@ -79,6 +79,20 @@ public class UserController {
                 @CurrentUser @Parameter(hidden = true) User user
     ) {
             userService.saveProfileImage(httpServletRequest, request, user);
-            return ApiResponse.of(UserSuccessStatus._USER_PROFILE_IMAGE_UPDATED, null);
+            return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_UPDATED, null);
     }
+
+    @Operation(
+            summary = "마이페이지 프로필 이미지 삭제",
+            description = "기존 프로필 이미지를 삭제 후, default 이미지로 수정합니다."
+    )
+    @DeleteMapping(value = "/mypage/prefile-image", produces = "application/json")
+    public ApiResponse<Object> deleteProfileImage(
+            HttpServletRequest httpServletRequest,
+            @CurrentUser @Parameter(hidden = true) User user
+    ) {
+        userService.deleteProfileImage(httpServletRequest, user);
+        return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_DELETED, null);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -10,6 +10,7 @@ import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
 @AllArgsConstructor
 public enum UserErrorStatus implements BaseErrorCode {
 
+    CANNOT_DELETE_DEFAULT_IMAGE(HttpStatus.BAD_REQUEST,"USER4000","기본 프로필 이미지는 삭제할 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다."),
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -12,7 +12,8 @@ public enum UserSuccessStatus implements BaseCode {
 
     _USER_FOUND(HttpStatus.OK, "USER2001", "사용자 조회 성공"),
     _USER_PRESIGNED_URL_ISSUED(HttpStatus.OK,"USER2002","프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
-    _USER_PROFILE_IMAGE_UPDATED(HttpStatus.OK,"USER2003","프로필 이미지 수정이 완료되었습니다."),
+    _PROFILE_IMAGE_UPDATED(HttpStatus.OK,"USER2003","프로필 이미지 수정이 완료되었습니다."),
+    _PROFILE_IMAGE_DELETED(HttpStatus.OK,"USER2004","프로필 이미지 삭제가 완료되었습니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -11,6 +11,7 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 public enum UserSuccessStatus implements BaseCode {
 
     _USER_FOUND(HttpStatus.OK, "USER2001", "사용자 조회 성공"),
+    _USER_PRESIGNED_URL_ISSUED(HttpStatus.OK,"USER2002","프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -12,6 +12,7 @@ public enum UserSuccessStatus implements BaseCode {
 
     _USER_FOUND(HttpStatus.OK, "USER2001", "사용자 조회 성공"),
     _USER_PRESIGNED_URL_ISSUED(HttpStatus.OK,"USER2002","프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
+    _USER_PROFILE_IMAGE_UPDATED(HttpStatus.OK,"USER2003","프로필 이미지 수정이 완료되었습니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -35,6 +35,8 @@ import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static umc.teumteum.server.domain.user.util.ImageConstants.ALLOWED_IMAGE_TYPES;
+
 @Service
 @RequiredArgsConstructor
 public class OnboardingServiceImpl implements OnboardingService {
@@ -54,10 +56,6 @@ public class OnboardingServiceImpl implements OnboardingService {
 
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
-
-    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
-            "image/jpeg", "image/png", "image/webp", "image/svg+xml"
-    );
 
     private static final Set<Integer> ALLOWED_REMIND_ALARM_VALUES = Set.of(1, 3, 5, 10, 30);
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -23,4 +23,6 @@ public interface UserService {
     UserResponseDTO.MyPageDTO getMyPage(User user);
 
     OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user);
+
+    void saveProfileImage(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImageRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -1,6 +1,9 @@
 package umc.teumteum.server.domain.user.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -18,4 +21,6 @@ public interface UserService {
     Optional<User> findUser(Long userId);
 
     UserResponseDTO.MyPageDTO getMyPage(User user);
+
+    OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -25,4 +25,6 @@ public interface UserService {
     OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user);
 
     void saveProfileImage(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImageRequest request, User user);
+
+    void deleteProfileImage(HttpServletRequest httpServletRequest, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -26,5 +26,5 @@ public interface UserService {
 
     void saveProfileImage(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImageRequest request, User user);
 
-    void deleteProfileImage(HttpServletRequest httpServletRequest, User user);
+    void deleteProfileImage(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -154,4 +154,42 @@ public class UserServiceImpl implements UserService {
         return String.format("PROFILE_IMAGE_FILE_NAME:%s:%s", userId, sessionId);
     }
 
+    // 마이페이지 - 프로필 이미지 수정
+    @Transactional
+    @Override
+    public void saveProfileImage(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImageRequest request, User user) {
+
+        // 1. Redis 조회하여 비교
+        String userId = user.getId().toString();
+        String sessionId = jwtProvider.getSessionIdFromToken(jwtProvider.resolveToken(httpServletRequest));
+        String imageFileKey = getProfileImageKey(userId, sessionId);
+
+        // 2. 검증
+        try{
+            String storedImageFileName = profileImageRedisTemplate.opsForValue().get(imageFileKey);
+
+            // 2-1. TTL 만료
+            if(storedImageFileName == null){
+                throw new UserException(UserErrorStatus.EXPIRED_UPLOAD_SESSION);
+            }
+
+            // 2-2. 요청 파일명 != Redis 파일명
+            if (!Objects.equals(storedImageFileName, request.getFileName())) {
+                throw new UserException(UserErrorStatus.INVALID_IMAGE_NAME);
+            }
+
+            // 2-3. 기존 객체 삭제
+            String oldFileName = user.getProfileImageName();
+
+            if(oldFileName != null && !oldFileName.isEmpty() && !oldFileName.equals("default.svg")){
+                s3Util.deleteObject("profile/" + oldFileName);
+            }
+
+            // 2-4. DB 저장 키 수정 (사용자 프로필 이미지 이름 업데이트)
+            user.updateProfileImageName(request.getFileName());
+        } finally {
+            // 3. Redis 키 삭제
+            profileImageRedisTemplate.delete(imageFileKey);
+        }
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -197,7 +197,7 @@ public class UserServiceImpl implements UserService {
     // 마이페이지 - 프로필 이미지 삭제
     @Transactional
     @Override
-    public void deleteProfileImage(HttpServletRequest httpServletRequest, User user) {
+    public void deleteProfileImage(User user) {
 
         String oldFileName = user.getProfileImageName();
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
 
 import static umc.teumteum.server.domain.user.util.ImageConstants.ALLOWED_IMAGE_TYPES;
+import static umc.teumteum.server.domain.user.util.ImageConstants.DEFAULT_IMAGE;
 
 import java.time.Duration;
 import java.util.*;
@@ -39,8 +40,6 @@ public class UserServiceImpl implements UserService {
 
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
-
-    private static final String DEFAULT_IMAGE = "default.svg";
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -24,7 +24,6 @@ import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
 import java.util.*;
-
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
@@ -40,6 +39,8 @@ public class UserServiceImpl implements UserService {
     private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
             "image/jpeg", "image/png", "image/webp", "image/svg+xml"
     );
+
+    private static final String DEFAULT_IMAGE = "default.svg";
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -181,7 +182,7 @@ public class UserServiceImpl implements UserService {
             // 2-3. 기존 객체 삭제
             String oldFileName = user.getProfileImageName();
 
-            if(oldFileName != null && !oldFileName.isEmpty() && !oldFileName.equals("default.svg")){
+            if(oldFileName != null && !oldFileName.isEmpty() && !oldFileName.equals(DEFAULT_IMAGE)){
                 s3Util.deleteObject("profile/" + oldFileName);
             }
 
@@ -190,6 +191,27 @@ public class UserServiceImpl implements UserService {
         } finally {
             // 3. Redis 키 삭제
             profileImageRedisTemplate.delete(imageFileKey);
+        }
+    }
+
+    // 마이페이지 - 프로필 이미지 삭제
+    @Transactional
+    @Override
+    public void deleteProfileImage(HttpServletRequest httpServletRequest, User user) {
+
+        String oldFileName = user.getProfileImageName();
+
+        // 1. default 이미지 삭제 예외처리
+        if(oldFileName == null || oldFileName.equals(DEFAULT_IMAGE)){
+            throw new UserException(UserErrorStatus.CANNOT_DELETE_DEFAULT_IMAGE);
+        }
+
+        // 2. 기존 객체 삭제
+        try{
+            s3Util.deleteObject("profile/" + oldFileName);
+        }  finally {
+            // 3. DB 저장 키 교체 (S3 Key -> default)
+            user.updateProfileImageName(DEFAULT_IMAGE);
         }
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -22,6 +22,8 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
 
+import static umc.teumteum.server.domain.user.util.ImageConstants.ALLOWED_IMAGE_TYPES;
+
 import java.time.Duration;
 import java.util.*;
 @Service
@@ -35,10 +37,6 @@ public class UserServiceImpl implements UserService {
 
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
-
-    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
-            "image/jpeg", "image/png", "image/webp", "image/svg+xml"
-    );
 
     private static final String DEFAULT_IMAGE = "default.svg";
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -1,16 +1,25 @@
 package umc.teumteum.server.domain.user.service;
 
+import jakarta.annotation.Resource;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.converter.OnboardingConverter;
 import umc.teumteum.server.domain.user.converter.UserConverter;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.exception.UserException;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
@@ -23,6 +32,14 @@ public class UserServiceImpl implements UserService {
     private final UserConverter userConverter;
     private final UserRepository userRepository;
     private final S3Util s3Util;
+    private final JwtProvider jwtProvider;
+
+    @Resource(name = "profileImageRedisTemplate")
+    private RedisTemplate<String, String> profileImageRedisTemplate;
+
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp", "image/svg+xml"
+    );
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -94,4 +111,47 @@ public class UserServiceImpl implements UserService {
         String profileImageUrl = s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
         return UserConverter.toMyPageDTO(user, profileImageUrl);
     }
+
+    // 프로필 이미지 업로드, Presigned URL 발급
+    @Override
+    public OnboardingResponseDto.ProfileImagePresignedUrlResponse generateProfileImagePresignedUrl(
+            HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImagePresignedUrlRequest request, User user) {
+
+        // 1. content-type 검증
+        String contentType = request.getContentType().toLowerCase();
+        if(!ALLOWED_IMAGE_TYPES.contains(contentType)){
+            throw new UserException(UserErrorStatus.UNSUPPORTED_IMAGE_FORMAT);
+        }
+
+        // 2. 확장자 추출
+        String extension = contentType.substring(contentType.lastIndexOf("/") + 1);
+        // svg+xml의 경우 svg로 변환
+        if ("svg+xml".equals(extension)) {
+            extension = "svg";
+        }
+
+        // 3. 파일명 생성
+        String fileName = UUID.randomUUID() + "." + extension;
+
+        // 4. S3 Key 구성 (profile/{fileName})
+        String key = "profile/" + fileName;
+
+        // 5. Presigned URL 발급
+        String presignedUrl = s3Util.toUploadPresignedUrl(key, contentType, Duration.ofMinutes(30));
+
+        // 6. S3 업로드 예정인 파일이름 redis에 저장
+        String userId = user.getId().toString();
+        String sessionId = jwtProvider.getSessionIdFromToken(jwtProvider.resolveToken(httpServletRequest));
+        String imageFileKey = getProfileImageKey(userId, sessionId);
+        profileImageRedisTemplate.opsForValue().set(imageFileKey, fileName, Duration.ofMinutes(30));
+
+        // 7. 응답 반환
+        return OnboardingConverter.toProfileImagePresignedUrlResponse(presignedUrl, fileName);
+    }
+
+    // 프로필 이미지 키 get
+    private String getProfileImageKey(String userId, String sessionId) {
+        return String.format("PROFILE_IMAGE_FILE_NAME:%s:%s", userId, sessionId);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -207,11 +207,9 @@ public class UserServiceImpl implements UserService {
         }
 
         // 2. 기존 객체 삭제
-        try{
-            s3Util.deleteObject("profile/" + oldFileName);
-        }  finally {
-            // 3. DB 저장 키 교체 (S3 Key -> default)
-            user.updateProfileImageName(DEFAULT_IMAGE);
-        }
+        s3Util.deleteObject("profile/" + oldFileName);
+
+        // 3. DB 저장 키 교체 (S3 Key -> default)
+        user.updateProfileImageName(DEFAULT_IMAGE);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/util/ImageConstants.java
+++ b/src/main/java/umc/teumteum/server/domain/user/util/ImageConstants.java
@@ -1,0 +1,13 @@
+package umc.teumteum.server.domain.user.util;
+
+import java.util.Set;
+
+public class ImageConstants {
+    // 아미지 형식
+    public static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/webp", "image/svg+xml"
+    );
+
+    // 기본 이미지
+    public static final String DEFAULT_IMAGE = "default.svg";
+}

--- a/src/main/java/umc/teumteum/server/domain/user/util/ImageConstants.java
+++ b/src/main/java/umc/teumteum/server/domain/user/util/ImageConstants.java
@@ -2,7 +2,7 @@ package umc.teumteum.server.domain.user.util;
 
 import java.util.Set;
 
-public class ImageConstants {
+public final class ImageConstants {
     // 아미지 형식
     public static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
             "image/jpeg", "image/png", "image/webp", "image/svg+xml"


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#245

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
기존 온보딩에서 사용하던 프로필 이미지 업로드 방식과 동일한 구조를 유지했습니다. 다만, 온보딩 로직은 온보딩 단계 검증 과정이 포함되어 있어 그대로 재사용하기는 제약이 있어 마이페이지 전용 API와 서비스 로직을 새로 설계했습니다.
DTO와 에러코드, coverter는 온보딩에서 사용하던 것을 그대로 재활용하되 서비스 로직에서는 온보딩 단계 검증 로직을 제외하고 기존 프로필 이미지를 제거한 뒤 새로운 이미지를 등록하는 과정을 추가했습니다.
또한, 업로드된 이미지는 단순히 삭제하고 기본 이미지로 되돌리고자 하는 경우 DELETE `/api/users/mypage/profile-image` API를 통해 등록된 이미지만 삭제할 수 있도록 구현했습니다.

[기본 흐름]
presigned-url 발급 → S3업로드 → 등록

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
POST `/api/users/mypage/prefile-image/presigned-url`
POST `/api/users/mypage/profile-image`
DELETE `/api/users/mypage/profile-image`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 업로드용 Presigned URL 발급 — 안전하게 직접 업로드 시작 가능.
  * 프로필 이미지 등록/수정 — 업로드 완료 후 프로필에 즉시 반영.
  * 프로필 이미지 삭제 — 기본 이미지는 삭제 불가로 보호됨.
  * 업로드 세션(유효성) 관리 추가 — 임시 업로드 키 검증으로 무결성·보안 강화.
  * 업로드 관련 성공/오류 응답 메시지 추가/명확화 — 처리 상태가 더 분명해짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->