### PR TITLE
Feat : 마이페이지 - 프로필 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -3,8 +3,10 @@ package umc.teumteum.server.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -49,5 +51,16 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._USER_FOUND, response);
     }
 
-
+    @Operation(
+            summary = "마이페이지 프로필 수정",
+            description = "사용자의 닉네임, 직업 분야, 빈틈 시간 공개 여부를 수정합니다."
+    )
+    @PatchMapping(value = "/mypage/profile", produces = "application/json")
+    public ApiResponse<Void> updateProfile(
+            @Valid @RequestBody UserRequestDto.ProfileRequest request,
+            @Parameter(hidden = true) @CurrentUser User user
+    ){
+        userService.updateProfile(request, user);
+        return ApiResponse.of(UserSuccessStatus._PROFILE_UPDATED,null);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
@@ -1,0 +1,36 @@
+package umc.teumteum.server.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserRequestDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "마이페이지 - 개인정보 수정")
+    public static class ProfileRequest {
+
+        @NotBlank(message = "닉네임은 필수 입력입니다")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다")
+        @Pattern(regexp = "^[a-zA-Z가-힣]*$", message = "닉네임은 영어와 한글만 가능합니다")
+        @Schema(description = "사용자 닉네임 (최대 10자, 영어&한글만, 중복 불가)", example = "틈틈")
+        private String nickname;
+
+        @NotBlank(message = "분야/직종은 필수 입력입니다")
+        @Size(max = 10, message = "분야/직종은 최대 10자까지 가능합니다")
+        @Schema(description = "사용자의 분야/직종 (최대 10자)", example = "개발자")
+        private String jobField;
+
+        @NotNull
+        @Schema(description = "빈틈 시간 공개 여부", example = "true")
+        private Boolean timePublic;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
@@ -29,7 +29,7 @@ public class UserRequestDto {
         @Schema(description = "사용자의 분야/직종 (최대 10자)", example = "개발자")
         private String jobField;
 
-        @NotNull
+        @NotNull(message = "빈틈 시간 공개 여부는 필수 입력입니다")
         @Schema(description = "빈틈 시간 공개 여부", example = "true")
         private Boolean timePublic;
     }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -81,6 +81,10 @@ public class User extends BaseEntity {
     @Column(name = "inactive_at")
     private LocalDateTime inactiveAt;
 
+    @Builder.Default
+    @Column(name = "time_public")
+    private Boolean timePublic = true;
+
 
     /*
         양방향 연관관계
@@ -143,5 +147,11 @@ public class User extends BaseEntity {
     public void clearSleepPattern() {
         this.sleepTime = null;
         this.wakeTime = null;
+    }
+
+    public void updateProfile(String nickname, String jobField, Boolean timePublic) {
+        this.nickname = nickname;
+        this.job = jobField;
+        this.timePublic = timePublic;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -13,6 +13,10 @@ public enum UserSuccessStatus implements BaseCode {
     _USER_FOUND(HttpStatus.OK, "USER2001", "사용자 조회 성공"),
 
 
+
+    _PROFILE_UPDATED(HttpStatus.OK,"USER2005","개인정보 수정이 완료되었습니다."),
+
+
     // 사용자 온보딩
     AGREEMENT_SAVED(HttpStatus.OK, "ONBOARDING2001", "약관 동의가 완료되었습니다."),
     NICKNAME_JOB_SAVED(HttpStatus.OK, "ONBOARDING2002", "닉네임과 분야/직종 등록이 완료되었습니다."),

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package umc.teumteum.server.domain.user.service;
 
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
@@ -18,4 +19,6 @@ public interface UserService {
     Optional<User> findUser(Long userId);
 
     UserResponseDTO.MyPageDTO getMyPage(User user);
+
+    void updateProfile(UserRequestDto.ProfileRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -107,9 +107,8 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
 
         // 2. 닉네임 수정 시, 닉네임 중복 검증
-        if (existingUser.getNickname() != null &&
-            !existingUser.getNickname().equals(request.getNickname()) &&
-            userRepository.existsByNickname(request.getNickname())) {
+        if (!Objects.equals(existingUser.getNickname(), request.getNickname()) &&
+                userRepository.existsByNickname(request.getNickname())) {
             throw new UserException(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
         }
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -6,10 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.user.converter.UserConverter;
+import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.exception.UserException;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.util.S3Util;
 
@@ -93,5 +96,28 @@ public class UserServiceImpl implements UserService {
     public UserResponseDTO.MyPageDTO getMyPage(User user) {
         String profileImageUrl = s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
         return UserConverter.toMyPageDTO(user, profileImageUrl);
+    }
+
+    // 마이페이지 - 개인정보 수정
+    @Transactional
+    @Override
+    public void updateProfile(UserRequestDto.ProfileRequest request, User user) {
+        // 1. 유저 조회
+        User existingUser = userRepository.findById(user.getId())
+                .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
+
+        // 2. 닉네임 수정 시, 닉네임 중복 검증
+        if (existingUser.getNickname() != null &&
+            !existingUser.getNickname().equals(request.getNickname()) &&
+            userRepository.existsByNickname(request.getNickname())) {
+            throw new UserException(UserErrorStatus.NICKNAME_ALREADY_EXISTS);
+        }
+
+        // 3. 프로필 수정
+        existingUser.updateProfile(
+                request.getNickname(),
+                request.getJobField(),
+                request.getTimePublic()
+        );
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#257 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
마이페이지에서 개인정보(닉네임, 직종분야, 빈틈시간 공개 여부)를 변경하기 위한 API입니다.
기존 유저 엔티티에 빈틈시간 공개 여부를 나타내기 위한 필드가 존재하지 않아 time_public 칼럼을 추가하고 default는 true로 설정하였습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
PATCH `/api/users/mypage/profile`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 프로필 업데이트 기능 추가: 닉네임, 직무 분야, 자유시간 공개 여부 수정 가능.
  * 입력 유효성 검사 적용(닉네임 길이·문자 제한, 직무 길이, 공개 여부 필수).
  * 닉네임 중복 검사로 중복 방지.
  * 자유시간 공개 여부의 기본값이 존재하며, 수정 시 적용됨.
  * 수정 성공 시 관련 성공 응답 반환.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->