### PR TITLE
Feat: 팔로우 API 분산 락 적용

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         uses: supercharge/redis-github-action@1.7.0
         with:
           redis-version: ${{ secrets.REDIS_TEST_VERSION }}
-          redis-remove-container: true
+#          redis-remove-container: true
           redis-password: ${{ secrets.REDIS_TEST_PASSWORD }}
 
       - name: Verify Config folders

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
 
 	// S3
 	implementation platform('software.amazon.awssdk:bom:2.25.10')

--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -4,19 +4,28 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import umc.teumteum.server.domain.friend.dto.FriendRequestDto;
 import umc.teumteum.server.domain.friend.dto.FriendResponseDto;
 import umc.teumteum.server.domain.friend.exception.status.FriendSuccessStatus;
+import umc.teumteum.server.domain.friend.service.FriendLockService;
+import umc.teumteum.server.domain.friend.service.FriendLockServiceImpl;
 import umc.teumteum.server.domain.friend.service.FriendService;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 import umc.teumteum.server.global.dto.PagingResponseDto;
-
-import java.util.List;
 
 @Validated
 @Tag(name = "Friend", description = "친구 관련 API")
@@ -26,6 +35,7 @@ import java.util.List;
 public class FriendController {
 
     private final FriendService friendService;
+    private final FriendLockService friendLockService;
 
     @Operation(
             summary = "유저 팔로우",
@@ -37,7 +47,7 @@ public class FriendController {
             @Parameter(name = "userId", description = "팔로우할 대상 유저의 ID", example = "1")
             @PathVariable("userId") Long targetUserId
     ) {
-        friendService.follow(loginUser, targetUserId);
+        friendLockService.followWithLock(loginUser, targetUserId);
         return ApiResponse.of(FriendSuccessStatus._FOLLOW_SUCCESS, null);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendLockService.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendLockService.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.friend.service;
+
+import umc.teumteum.server.domain.user.entity.User;
+
+public interface FriendLockService {
+    void followWithLock(User loginUser, Long targetUserId);
+}

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendLockServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendLockServiceImpl.java
@@ -1,0 +1,27 @@
+package umc.teumteum.server.domain.friend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.util.RedissonLockUtil;
+
+@Service
+@RequiredArgsConstructor
+public class FriendLockServiceImpl implements FriendLockService {
+
+    private final RedissonLockUtil redissonLockUtil;
+    private final FriendService friendService;
+
+    // 팔로우 요청 시 Redisson 락을 걸고 follow 로직 실행
+    @Override
+    public void followWithLock(User loginUser, Long targetUserId) {
+        String lockKey = createLockKey(loginUser.getId(), targetUserId);
+        redissonLockUtil.executeWithLock(lockKey,
+                () -> friendService.follow(loginUser, targetUserId)
+        );
+    }
+
+    private String createLockKey(Long loginUserId, Long targetUserId) {
+        return String.format("FOLLOW_LOCK:%d:%d", loginUserId, targetUserId);
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -1,5 +1,15 @@
 package umc.teumteum.server.domain.friend.service;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,17 +33,6 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.util.S3Util;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 @Service
 @RequiredArgsConstructor
 public class FriendServiceImpl implements FriendService {
@@ -54,7 +53,9 @@ public class FriendServiceImpl implements FriendService {
             EnumSet.of(ScheduleStatus.ACTIVE, ScheduleStatus.COMPLETED);
 
     private String toProfileUrl(User user) {
-        if (user == null || user.getProfileImageName() == null) return null;
+        if (user == null || user.getProfileImageName() == null) {
+            return null;
+        }
         return s3Util.toPresignedUrl("profile/" + user.getProfileImageName(), Duration.ofMinutes(30));
     }
 
@@ -78,9 +79,7 @@ public class FriendServiceImpl implements FriendService {
 
         // 5. 알림 전송
         notificationUseCases.notifyFollow(loginUser, targetUser, friend.getId());
-
     }
-
 
     @Override
     @Transactional
@@ -102,7 +101,8 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     @Transactional(readOnly = true)
-    public PagingResponseDto<FriendResponseDto.MutualFriend> getMutualFriends(User loginUser, Long excludeUserId, int page, int size) {
+    public PagingResponseDto<FriendResponseDto.MutualFriend> getMutualFriends(User loginUser, Long excludeUserId,
+                                                                              int page, int size) {
         // 1. 자기 자신을 제외하는지 확인
         validateNotSelf(loginUser.getId(), excludeUserId);
 
@@ -114,18 +114,19 @@ public class FriendServiceImpl implements FriendService {
                 Sort.by(Sort.Order.asc("following.nickname")));
 
         // 4. 맞팔로우 관계 조회 (특정 사용자 제외)
-        Slice<Friend> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(loginUser, excludeUser, pageable);
+        Slice<Friend> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(loginUser, excludeUser,
+                pageable);
 
         // 5. 맞팔로우한 상대방들에 대한 S3 프리사인드 URL 생성 및 Dto 변환
         List<FriendResponseDto.MutualFriend> mutualFriendList = mutualFriendsSlice.getContent()
                 .stream()
                 .map(friend -> {
                     User targetUser = friend.getFollowing();
-                    String profileImageUrl = s3Util.toPresignedUrl("profile/" + targetUser.getProfileImageName(), Duration.ofMinutes(30));
+                    String profileImageUrl = s3Util.toPresignedUrl("profile/" + targetUser.getProfileImageName(),
+                            Duration.ofMinutes(30));
                     return FriendConverter.toMutualFriendDto(targetUser, profileImageUrl);
                 })
-                .collect(Collectors.toList())
-                ;
+                .collect(Collectors.toList());
 
         // 6. PagingResponseDto 생성
         return new PagingResponseDto<>(mutualFriendList, mutualFriendsSlice.hasNext());
@@ -266,7 +267,8 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FriendResponseDto.FriendPublicTodo> getDailyPublicTodos(Long loginUserId, Long targetUserId, String date) {
+    public List<FriendResponseDto.FriendPublicTodo> getDailyPublicTodos(Long loginUserId, Long targetUserId,
+                                                                        String date) {
         validateNotSelf(loginUserId, targetUserId);
         validateUserExists(targetUserId);
 
@@ -299,10 +301,12 @@ public class FriendServiceImpl implements FriendService {
         LocalDate end = ym.atEndOfMonth();
 
         // TODO/WISH/AI 일정 (status: ACTIVE)
-        List<LocalDate> generalDates = scheduleRepository.findPublicActiveTodos(targetUserId, GENERAL_SCHEDULE_TYPES, start, end);
+        List<LocalDate> generalDates = scheduleRepository.findPublicActiveTodos(targetUserId, GENERAL_SCHEDULE_TYPES,
+                start, end);
 
         // TEUM 일정 (status: ACTIVE, COMPLETED)
-        List<LocalDate> teumDates = scheduleRepository.findPublicTeumDates(targetUserId, TEUM_VALID_STATUSES, start, end);
+        List<LocalDate> teumDates = scheduleRepository.findPublicTeumDates(targetUserId, TEUM_VALID_STATUSES, start,
+                end);
 
         List<LocalDate> allDates = Stream.concat(generalDates.stream(), teumDates.stream())
                 .distinct()
@@ -314,9 +318,7 @@ public class FriendServiceImpl implements FriendService {
 
 
     /**
-     * 주어진 ID에 해당하는 User를 조회합니다.
-     * - User 객체 자체가 필요한 경우에 사용합니다.
-     * - 존재하지 않으면 예외를 던집니다.
+     * 주어진 ID에 해당하는 User를 조회합니다. - User 객체 자체가 필요한 경우에 사용합니다. - 존재하지 않으면 예외를 던집니다.
      */
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
@@ -324,9 +326,7 @@ public class FriendServiceImpl implements FriendService {
     }
 
     /**
-     * 주어진 ID에 해당하는 User가 존재하는지만 확인합니다.
-     * - 객체 자체가 필요하지 않고, 존재 여부만 확인할 때 사용합니다.
-     * - 존재하지 않으면 예외를 던집니다.
+     * 주어진 ID에 해당하는 User가 존재하는지만 확인합니다. - 객체 자체가 필요하지 않고, 존재 여부만 확인할 때 사용합니다. - 존재하지 않으면 예외를 던집니다.
      */
     private void validateUserExists(Long userId) {
         if (!userRepository.existsById(userId)) {

--- a/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
@@ -14,6 +14,9 @@ public enum ErrorStatus implements BaseErrorCode {
   _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
   _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+  // 동시성 관련
+  LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "COMMON4091", "요청이 처리 중입니다. 잠시 후 다시 시도해주세요."),
+
 
   // 인증 관련
   MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4101", "잘못 구성된 JWT 형식입니다."),
@@ -29,6 +32,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
   // 회원 관련
   INVALID_USER(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 유저입니다."),
+
+
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package umc.teumteum.server.global.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,5 +72,14 @@ public class RedisConfig {
   @Bean
   public RedisTemplate<String, String> profileImageRedisTemplate() {
     return createRedisTemplate(createConnectionFactory(4));
+  }
+
+  @Bean
+  public RedissonClient redissonClient() {
+    Config config = new Config();
+    config.useSingleServer()
+            .setAddress("redis://" + host + ":" + port)
+            .setPassword(password);
+    return Redisson.create(config);
   }
 }

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.global.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -77,9 +78,13 @@ public class RedisConfig {
   @Bean
   public RedissonClient redissonClient() {
     Config config = new Config();
-    config.useSingleServer()
-            .setAddress("redis://" + host + ":" + port)
-            .setPassword(password);
+    SingleServerConfig serverConfig = config.useSingleServer()
+            .setAddress("redis://" + host + ":" + port);
+
+    if(password != null && !password.isEmpty()) {
+      serverConfig.setPassword(password);
+    }
+
     return Redisson.create(config);
   }
 }

--- a/src/main/java/umc/teumteum/server/global/util/RedissonLockUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/RedissonLockUtil.java
@@ -15,7 +15,6 @@ public class RedissonLockUtil {
     private final RedissonClient redissonClient;
 
     private static final long DEFAULT_WAIT_TIME = 3;  // 락 대기 시간
-    private static final long DEFAULT_LEASE_TIME = 5;  // 락 점유 시간
     private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;  // 시간 단위 (초)
 
     // 락 획득&해제 및 action 실행
@@ -32,7 +31,7 @@ public class RedissonLockUtil {
     public RLock acquireLock(String key) {
         RLock lock = redissonClient.getLock(key);
         try {
-            boolean isLocked = lock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
+            boolean isLocked = lock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_TIME_UNIT);
             if (!isLocked) {
                 throw new GlobalHandler(ErrorStatus.LOCK_ACQUISITION_FAILED);
             }

--- a/src/main/java/umc/teumteum/server/global/util/RedissonLockUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/RedissonLockUtil.java
@@ -1,0 +1,52 @@
+package umc.teumteum.server.global.util;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.exception.handler.GlobalHandler;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonLockUtil {
+
+    private final RedissonClient redissonClient;
+
+    private static final long DEFAULT_WAIT_TIME = 3;  // 락 대기 시간
+    private static final long DEFAULT_LEASE_TIME = 5;  // 락 점유 시간
+    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;  // 시간 단위 (초)
+
+    // 락 획득&해제 및 action 실행
+    public void executeWithLock(String key, Runnable action) {
+        RLock lock = acquireLock(key);
+        try {
+            action.run();
+        } finally {
+            releaseLock(lock);
+        }
+    }
+
+    // key로 락을 획득
+    public RLock acquireLock(String key) {
+        RLock lock = redissonClient.getLock(key);
+        try {
+            boolean isLocked = lock.tryLock(DEFAULT_WAIT_TIME, DEFAULT_LEASE_TIME, DEFAULT_TIME_UNIT);
+            if (!isLocked) {
+                throw new GlobalHandler(ErrorStatus.LOCK_ACQUISITION_FAILED);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GlobalHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+        return lock;
+    }
+
+    // 현재 스레드가 보유한 락 해제
+    public void releaseLock(RLock lock) {
+        if (lock != null && lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
+    }
+}

--- a/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
+++ b/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
@@ -1,0 +1,114 @@
+package umc.teumteum.server.integration.friend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import umc.teumteum.server.domain.friend.exception.FriendException;
+import umc.teumteum.server.domain.friend.repository.FriendRepository;
+import umc.teumteum.server.domain.friend.service.FriendLockService;
+import umc.teumteum.server.domain.notification.service.NotificationUseCases;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.UserStep;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.exception.handler.GlobalHandler;
+import umc.teumteum.server.global.util.S3Util;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("FriendLockService 관련 통합 테스트")
+public class FriendLockServiceTest {
+
+    @Autowired
+    private FriendLockService friendLockService;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @MockBean
+    private NotificationUseCases notificationUseCases;
+
+    @MockBean
+    private S3Util s3Util;
+
+    private User loginUser;
+    private User targetUser;
+
+    @BeforeEach
+    void setUp() {
+        friendRepository.deleteAll();
+        userRepository.deleteAll();
+        redissonClient.getKeys().flushall();
+
+        loginUser = userRepository.save(
+                User.builder()
+                        .email("teumteum@kakao.com")
+                        .socialId(UUID.randomUUID().toString())
+                        .socialType(SocialType.KAKAO)
+                        .step(UserStep.ONBOARDING)
+                        .build()
+        );
+        targetUser = userRepository.save(
+                User.builder()
+                        .email("teumteum2@kakao.com")
+                        .socialId(UUID.randomUUID().toString())
+                        .socialType(SocialType.KAKAO)
+                        .step(UserStep.ONBOARDING)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("follow 여러 번 요청 시 한 번만 성공 - Redisson 분산 락으로 동시성 제어")
+    void followFriend_ConcurrencyControl() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    friendLockService.followWithLock(loginUser, targetUser.getId());
+                    successCount.incrementAndGet();
+                } catch (FriendException | GlobalHandler e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        long totalSaved = friendRepository.count();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount-1);
+        assertThat(totalSaved).isEqualTo(1);
+    }
+}

--- a/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
+++ b/src/test/java/umc/teumteum/server/unit/global/scheduler/DailyTodoReminderSchedulerTest.java
@@ -91,7 +91,7 @@ public class DailyTodoReminderSchedulerTest {
             .isPublic(true)
             .includeTeum(false)
             .status(ScheduleStatus.ACTIVE)
-            .isDeleted(false)
+//            .isDeleted(false)
             .build();
         schedules.add(schedule);
       }

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -35,7 +35,7 @@ import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.TimeUtil;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("OnboardingService 테스트")
+@DisplayName("OnboardingService 관련 단위 테스트")
 class OnboardingServiceTest {
 
     @InjectMocks


### PR DESCRIPTION
### 👀 관련 이슈
#259

### ✨ 작업한 내용
- `Redisson` 클라이언트 추가
- `RedissonLockUtil` - 락 획득/해제 & 분산 락 적용한 서비스 코드 실행 (추후 다른 API 활용 고려)
- `FriendLockServiceImpl` - 키 생성 및 RedissonLockUtil을 활용하여 기존 follow 로직 실행
- `FriendLockServiceTest` - 동시성 제어 관련 테스트 코드


### 🌀 PR Point
X


### 🍰 참고사항
- 스케줄 엔티티 변경이 되었으나 기존 `DailyTodoReminderSchedulerTest`에는 반영되지 않으며 빌드가 되지 않는 문제
-> `.isDeleted(false)` 부분 주석 처리

- 추가한 `FriendLockServiceTest`로 인해 CI 환경에서 테스트가 실패하는 문제
  -> CI에 사용된 Action에 오류 존재
  -> `redis-remove-container: true` 옵션이 의도대로 동작하지 않음
        `의도`: `docker run --rm redis:7`
        `실제`: `docker run redis:7 --rm`
        (Redis에 존재하지 않는 --rm 옵션으로 인한 에러 -> 종료)
  -> 해당 옵션 주석 처리

  ※ 버전 업하며 수정되었다고 기술되어 있으나, 실제 테스트 결과 및 최근 이슈를 참고하면 여전히 해결되지 않은 것으로 보임
  [CHANGELOG](https://github.com/supercharge/redis-github-action/blob/main/CHANGELOG.md) / [ISSUE](https://github.com/supercharge/redis-github-action/issues/26) (인도형님이 PR올리긴함)


### 📷 스크린샷 또는 GIF
X


### 🤯 개발 회고
#### ※ FriendLockServiceImpl로 별도로 분리한 이유
기존 `FriendServiceImpl`의 `follow()` 로직에는 `@Transactional`이 적용되어 있기 때문에 별도로 분리하지 않으면
`스레드1 락 획득 -> 스레드1 팔로우 로직 수행 -> 스레드1 락 해제 -> 스레드2 락 획득 -> ...` 같은 순서로 진행
-> 스레드1의 변경사항이 DB에 커밋되지 않은 채 스레드2가 실행
-> 동시성 해결 X
-> 별도로 분리


#### ※ FriendLockServiceImpl에는 @Transactional / FriendServiceImpl에는 @Transactional(propagation = Propagation.REQUIRES_NEW)을 적용한다면?
`FriendLockServiceImpl`과 `FriendServiceImpl`이 각각 별도의 트랜잭션을 가지는 경우
-> 테스트 코드 실행 결과, 후행 스레드들은 `락 타임아웃 예외`가 발생
-> 이론상으로는, `FriendServiceImpl`의 트랜잭션 종료, DB에 반영 / 후행 스레드들이 락을 얻어 `중복 팔로우 예외`가 발생해야 함
-> 외부 트랜잭션의 존재로 인해 DB 커넥션 풀이 부족하여 대기하던 과정에서 후행 스레드들의 `락 타임아웃 예외`가 발생z
<br>

(아래 사항들을 인지하고 있으나, 궁금증으로 진행)
- 일반적으로 락의 획득/해제는 트랜잭션 바깥에서 함
- `FriendLockServiceImpl`에는 DB작업이 없어서 트랜잭션이 불필요함


### 🏷️ 참고자료
- https://an-jjin.tistory.com/219
- https://osslab.s-core.co.kr/232035f5-1294-8088-9213-cca3bab1b165
- https://ming412.tistory.com/298
- https://velog.io/@ohzzi/Redis%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EC%97%AC-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0
- https://velog.io/@kim_table_next/Spring-%EB%8F%99%EC%8B%9C%EC%84%B1-%EC%A0%9C%EC%96%B4-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-%EC%9E%91%EC%84%B1%ED%95%98%EA%B8%B0Redisson-H2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 친구 팔로우 동작에 분산 잠금 기반 동시성 제어 추가 — 중복 팔로우 방지

* **개선 사항**
  * Redisson을 이용한 Redis 분산 잠금 통합으로 안정성 향상
  * Redisson 클라이언트 설정 추가

* **버그 수정 / 기타**
  * 잠금 획득 실패 시 사용자 안내 메시지 추가(요청 처리 중 안내)

* **테스트**
  * 동시성 시나리오를 검증하는 통합 테스트 추가

* **CI**
  * Redis 시작 워크플로우에서 컨테이너 자동 제거 설정 비활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->