### PR TITLE
Feat : 알림 수정 설정 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -107,4 +107,17 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_DELETED, null);
     }
 
+    @Operation(
+            summary = "마이페이지 알림 설정 수정",
+            description = "오늘의 일정, 리마인드 알림, 팔로워, 틈 요청에 대해 알림 여부를 수정합니다."
+    )
+    @PatchMapping(value = "/alarm", produces = "application/json")
+    public ApiResponse<Object> updateAlarm(
+            @RequestBody @Valid UserRequestDto.NotificationSettingRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ) {
+        userService.updateAlarm(request, user);
+        return ApiResponse.of(UserSuccessStatus._ALARM_STATE_UPDATED, null);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserRequestDto.java
@@ -33,4 +33,28 @@ public class UserRequestDto {
         @Schema(description = "빈틈 시간 공개 여부", example = "true")
         private Boolean timePublic;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "마이페이지 - 알림 설정 수정")
+    public static class NotificationSettingRequest {
+
+        @NotNull
+        @Schema(description = "오늘의 일정 - 오전 9시 투두 일림 여부", example = "true")
+        private Boolean todayTodo;
+
+        @NotNull
+        @Schema(description = "리마인드 알림 - 투두에 등록한 리마인드 알림 여부", example = "true")
+        private Boolean remindAlarm;
+
+        @NotNull
+        @Schema(description = "새로운 팔로워 - 나를 팔로우한 새로운 친구가 있을 때", example = "true")
+        private Boolean follow;
+
+        @NotNull
+        @Schema(description = "틈 요청 - 맞팔로우한 사용자의 틈 요청 알림", example = "true")
+        private Boolean teum;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/NotificationSetting.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/NotificationSetting.java
@@ -38,4 +38,11 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     @Column(name = "follow", nullable = false)
     private Boolean follow = true;
+
+    public void update(Boolean todayTodo, Boolean remindAlarm, Boolean follow, Boolean teum) {
+        this.todayTodo = todayTodo;
+        this.remindAlarm = remindAlarm;
+        this.follow = follow;
+        this.teum = teum;
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -12,6 +12,7 @@ public enum UserErrorStatus implements BaseErrorCode {
 
     CANNOT_DELETE_DEFAULT_IMAGE(HttpStatus.BAD_REQUEST,"USER4000","기본 프로필 이미지는 삭제할 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041","사용자의 알림 설정 정보를 찾을 수 없습니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -14,6 +14,7 @@ public enum UserSuccessStatus implements BaseCode {
     _USER_PRESIGNED_URL_ISSUED(HttpStatus.OK,"USER2002","프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
     _PROFILE_IMAGE_UPDATED(HttpStatus.OK,"USER2003","프로필 이미지 수정이 완료되었습니다."),
     _PROFILE_IMAGE_DELETED(HttpStatus.OK,"USER2004","프로필 이미지 삭제가 완료되었습니다."),
+    _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2005","사용자의 알림 설정 변경이 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -14,11 +14,9 @@ public enum UserSuccessStatus implements BaseCode {
     _USER_PRESIGNED_URL_ISSUED(HttpStatus.OK,"USER2002","프로필 이미지 업로드용 Presigned URL 발급이 완료되었습니다."),
     _PROFILE_IMAGE_UPDATED(HttpStatus.OK,"USER2003","프로필 이미지 수정이 완료되었습니다."),
     _PROFILE_IMAGE_DELETED(HttpStatus.OK,"USER2004","프로필 이미지 삭제가 완료되었습니다."),
-    _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2005","사용자의 알림 설정 변경이 완료되었습니다."),
-
-
-
     _PROFILE_UPDATED(HttpStatus.OK,"USER2005","개인정보 수정이 완료되었습니다."),
+    _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2006","사용자의 알림 설정 변경이 완료되었습니다."),
+
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
@@ -2,6 +2,10 @@ package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.teumteum.server.domain.user.entity.NotificationSetting;
+import umc.teumteum.server.domain.user.entity.User;
+
+import java.util.Optional;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+    Optional<NotificationSetting> findByUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
@@ -1,0 +1,7 @@
+package umc.teumteum.server.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.teumteum.server.domain.user.entity.NotificationSetting;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+}

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -30,4 +30,6 @@ public interface UserService {
     void saveProfileImage(HttpServletRequest httpServletRequest, OnboardingRequestDto.ProfileImageRequest request, User user);
 
     void deleteProfileImage(User user);
+
+    void updateAlarm(UserRequestDto.NotificationSettingRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -249,4 +249,18 @@ public class UserServiceImpl implements UserService {
         // 3. DB 저장 키 교체 (S3 Key -> default)
         user.updateProfileImageName(DEFAULT_IMAGE);
     }
+
+    // 마이페이지 - 알림 설졍 변경
+    @Transactional
+    @Override
+    public void updateAlarm(UserRequestDto.NotificationSettingRequest request, User user) {
+        NotificationSetting setting = notificationSettingRepository.findByUser(user)
+                .orElseThrow(() -> new UserException(UserErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        setting.update(
+                request.getTodayTodo(),
+                request.getRemindAlarm(),
+                request.getTeum(), request.getFollow()
+        );
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -15,10 +15,12 @@ import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
+import umc.teumteum.server.domain.user.entity.NotificationSetting;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.exception.UserException;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
+import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
@@ -35,6 +37,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserConverter userConverter;
     private final UserRepository userRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
     private final S3Util s3Util;
     private final JwtProvider jwtProvider;
 
@@ -70,6 +73,7 @@ public class UserServiceImpl implements UserService {
 
         return userRepository.findBySocialTypeAndSocialId(socialType, socialId)
                 .orElseGet(() -> {
+                    // 1. User 생성
                     User newUser = User.builder()
                             .socialType(socialType)
                             .socialId(socialId)
@@ -77,7 +81,19 @@ public class UserServiceImpl implements UserService {
                             .build()
                             ;
 
-                    return userRepository.save(newUser);
+                    User savedUser = userRepository.save(newUser);
+
+                    // 2. NotificationSetting 생성
+                    NotificationSetting notificationSetting = NotificationSetting.builder()
+                            .user(savedUser)
+                            .teum(true)
+                            .follow(true)
+                            .todayTodo(true)
+                            .remindAlarm(true)
+                            .build();
+                    notificationSettingRepository.save(notificationSetting);
+
+                    return savedUser;
                 });
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -250,7 +250,7 @@ public class UserServiceImpl implements UserService {
         user.updateProfileImageName(DEFAULT_IMAGE);
     }
 
-    // 마이페이지 - 알림 설졍 변경
+    // 마이페이지 - 알림 설정 변경
     @Transactional
     @Override
     public void updateAlarm(UserRequestDto.NotificationSettingRequest request, User user) {

--- a/src/test/java/umc/teumteum/server/unit/user/service/UserServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/UserServiceTest.java
@@ -1,0 +1,100 @@
+package umc.teumteum.server.unit.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.user.entity.NotificationSetting;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.domain.user.service.UserServiceImpl;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserServiceImpl - User 관련 단위 테스트")
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationSettingRepository notificationSettingRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private OAuthUserInfo userInfo;
+
+    @BeforeEach
+    void setUp() {
+        userInfo = OAuthUserInfo.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("1234567890")
+                .email("teumteum@kakao.com")
+                .build();
+    }
+
+    // 회원 가입 시 알림 설정 생성 테스트
+    @Test
+    @DisplayName("사용자 생성 시 알림 설정이 기본값으로 저장되는지 확인")
+    void findOrCreateUser_createNotificationSetting(){
+        // given
+        when(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO,"1234567890"))
+                .thenReturn(Optional.empty());
+
+        // when
+        User result = userService.findOrCreateUser(userInfo);
+
+        // then
+        ArgumentCaptor<NotificationSetting> captor = ArgumentCaptor.forClass(NotificationSetting.class);
+        verify(notificationSettingRepository).save(captor.capture());
+
+        NotificationSetting savedSetting = captor.getValue();
+
+        // 저장된 NotificationSetting의 user가 result인지 확인
+        assertThat(savedSetting.getUser()).isEqualTo(result);
+
+        // 기본값 확인
+        assertThat(savedSetting.getFollow()).isTrue();
+        assertThat(savedSetting.getTeum()).isTrue();
+        assertThat(savedSetting.getRemindAlarm()).isTrue();
+        assertThat(savedSetting.getTodayTodo()).isTrue();
+    }
+
+    @Test
+    @DisplayName("findOrCreateUser 호출 시 기존 사용자면 NotificationSetting 생성하지 않음")
+    void findOrCreateUser_existingUser() {
+        // given: 이미 존재하는 사용자
+        User existingUser = User.builder()
+                .id(1L)
+                .email("teumteum@kakao.com")
+                .socialType(SocialType.KAKAO)
+                .socialId("1234567890")
+                .build();
+
+        when(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, "1234567890"))
+                .thenReturn(Optional.of(existingUser));
+
+        // when
+        User result = userService.findOrCreateUser(userInfo);
+
+        // then
+        assertThat(result).isEqualTo(existingUser);
+
+        // NotificationSettingRepository.save는 호출되지 않아야 함
+        verify(notificationSettingRepository, times(0)).save(org.mockito.ArgumentMatchers.any(NotificationSetting.class));
+    }
+
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#265
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 기존 소셜로그인 시 신규 회원이라면 유저를 생성하는 로직에 NotificationSetting을 기본값으로 생성하는 로직을 추가하였습니다. 
- 소셜로그인 api를 테스트해 볼 수 없어 테스트코드를 통해 검증하였습니다. 
   - 신규 회원 생성시  NotificatonSetting 생성 확인
   - 기존 회원 로그인 시 NotificationSetting 생성되지 않음 검증
- 알림 설정 수정 API는 오늘의 일정, 리마인드 알림, 틈요청, 팔로우의 4개 필드를 boolean으로 받아 처리합니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
PATCH `api/users/alarm`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자가 오늘의 할일, 알림 리마인더, 팔로우, 팀 알림을 개별적으로 설정·수정할 수 있는 알림 설정 기능 및 관련 API 추가
  * 신규 회원 가입 시 기본 알림 설정이 자동으로 생성됨
* **Tests**
  * 알림 설정 기본값 생성과 기존 사용자 처리에 대한 단위 테스트 추가
* **Success / Error 메시지**
  * 알림 설정 변경 완료 및 설정 미존재에 대한 명확한 응답 상태 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->