### PR TITLE
Feat: 틈 요청 취소 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -237,12 +237,12 @@ public class TeumController {
             description = "요청자가 본인의 틈 요청을 취소합니다. 취소된 요청은 더 이상 응답할 수 없습니다."
     )
     @PatchMapping("/request/{requestId}/cancel")
-    public ApiResponse<TeumResponseDto.ScheduledTeumCancel> cancelTeumRequest(
-            @PathVariable("requestId") Long requestId,
-            @CurrentUser @Parameter(hidden = true) User user
+    public ApiResponse<Long> cancelTeumRequest( // 반환 타입 변경: DTO -> Long
+                                                @PathVariable("requestId") Long requestId,
+                                                @CurrentUser @Parameter(hidden = true) User user
     ) {
-        TeumResponseDto.ScheduledTeumCancel result = teumService.cancelTeumRequest(requestId, user.getId());
-        return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CANCELLED, result);
+        Long cancelledId = teumService.cancelTeumRequest(requestId, user.getId());
+        return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CANCELLED, cancelledId);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -232,5 +232,19 @@ public class TeumController {
         return ApiResponse.of(TeumSuccessStatus._SHARED_LIST_LOADED, result);
     }
 
+    @Operation(
+            summary = "틈 요청 취소",
+            description = "요청자가 본인의 틈 요청을 취소합니다. 취소된 요청은 더 이상 응답할 수 없습니다."
+    )
+    @PatchMapping("/request/{requestId}/cancel")
+    public ApiResponse<TeumResponseDto.ScheduledTeumCancel> cancelTeumRequest(
+            @PathVariable("requestId") Long requestId,
+            @CurrentUser @Parameter(hidden = true) User user
+    ) {
+        TeumResponseDto.ScheduledTeumCancel result = teumService.cancelTeumRequest(requestId, user.getId());
+        return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CANCELLED, result);
+    }
+
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -237,7 +237,7 @@ public class TeumController {
             description = "요청자가 본인의 틈 요청을 취소합니다. 취소된 요청은 더 이상 응답할 수 없습니다."
     )
     @PatchMapping("/request/{requestId}/cancel")
-    public ApiResponse<Long> cancelTeumRequest( // 반환 타입 변경: DTO -> Long
+    public ApiResponse<Long> cancelTeumRequest(
                                                 @PathVariable("requestId") Long requestId,
                                                 @CurrentUser @Parameter(hidden = true) User user
     ) {

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/TeumRequest.java
@@ -75,4 +75,6 @@ public class TeumRequest extends BaseEntity {
     public void markAsClosed() {
         this.status = RequestStatus.CLOSED;
     }
+
+    public void markAsCanceled() { this.status = RequestStatus.CANCELED; }
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/RequestStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/RequestStatus.java
@@ -3,4 +3,5 @@ package umc.teumteum.server.domain.teum.entity.enums;
 public enum RequestStatus {
     ACTIVE,    // 진행 중
     CLOSED,    // 자동 마감 (시간 지남)
+    CANCELED,  // 취소
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
@@ -4,6 +4,7 @@ public enum ResponseStatus {
     PENDING,    // 수신자가 응답을 하지 않음
     ACCEPTED,   // 수신자가 요청을 수락
     REJECTED,   // 수신자가 요청을 거절
-    RESEND,   // 수신자가 시간대 바꿔 재요청
-    LEFT        // 수신자가 요청을 수락했다가 취소함
+    RESEND,     // 수신자가 시간대 바꿔 재요청
+    LEFT,       // 수신자가 요청을 수락했다가 취소함
+    CANCELED_BY_REQUESTER  // 송신자가 요청을 취소하여 응답 무효
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
@@ -20,7 +20,7 @@ public enum TeumSuccessStatus implements BaseCode {
     _SCHEDULED_CALENDAR_LOADED(HttpStatus.OK, "TEUM2007", "약속된 틈 달력 정보가 조회되었습니다."),
     _SCHEDULED_LIST_LOADED(HttpStatus.OK, "TEUM2008", "지정한 날짜의 약속된 틈 목록이 조회되었습니다."),
     _SCHEDULED_DETAIL_LOADED(HttpStatus.OK, "TEUM2009", "약속된 틈 상세 정보가 조회되었습니다."),
-    _SCHEDULED_CANCELLED(HttpStatus.OK, "TEUM2010", "약속된 틈이 성공적으로 취소되었습니다.."),
+    _SCHEDULED_CANCELLED(HttpStatus.OK, "TEUM2010", "약속된 틈이 성공적으로 취소되었습니다."),
     _AVAILABLE_TIME_LOADED(HttpStatus.OK, "TEUM2011", "공통 가능한 시간대가 조회되었습니다."),
     _SHARED_TIME_LOADED(HttpStatus.OK, "TEUM2012", "함께한 빈틈 시간 정보가 조회되었습니다."),
     _SHARED_LIST_LOADED(HttpStatus.OK, "TEUM2013", "함께한 틈 목록이 조회되었습니다."),

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
@@ -24,7 +24,8 @@ public enum TeumSuccessStatus implements BaseCode {
     _AVAILABLE_TIME_LOADED(HttpStatus.OK, "TEUM2011", "공통 가능한 시간대가 조회되었습니다."),
     _SHARED_TIME_LOADED(HttpStatus.OK, "TEUM2012", "함께한 빈틈 시간 정보가 조회되었습니다."),
     _SHARED_LIST_LOADED(HttpStatus.OK, "TEUM2013", "함께한 틈 목록이 조회되었습니다."),
-    _TEUM_READ_SUCCESS(HttpStatus.OK, "TEUM2014", "틈 요청이 읽음 처리되었습니다.");
+    _TEUM_READ_SUCCESS(HttpStatus.OK, "TEUM2014", "틈 요청이 읽음 처리되었습니다."),
+    _TEUM_REQUEST_CANCELLED(HttpStatus.OK, "TEUM2015", "틈 요청이 취소되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -37,4 +37,6 @@ public interface TeumService {
     PagingResponseDto<TeumResponseDto.SharedTeumList> getSharedTeums(Long loginUserId, Long targetUserId, int page, int size);
 
     List<TeumResponseDto.TeumRequestDetail> getTeumRequestsByDate(Long userId, String date);
+
+    TeumResponseDto.ScheduledTeumCancel cancelTeumRequest(Long requestId, Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -38,5 +38,5 @@ public interface TeumService {
 
     List<TeumResponseDto.TeumRequestDetail> getTeumRequestsByDate(Long userId, String date);
 
-    TeumResponseDto.ScheduledTeumCancel cancelTeumRequest(Long requestId, Long userId);
+    Long cancelTeumRequest(Long requestId, Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -552,7 +552,8 @@ public class TeumServiceImpl implements TeumService {
     }
 
     @Override
-    public TeumResponseDto.ScheduledTeumCancel cancelTeumRequest(Long requestId, Long userId) {
+    @Transactional
+    public Long cancelTeumRequest(Long requestId, Long userId) {
         TeumRequest request = teumRequestRepository.findById(requestId)
                 .orElseThrow(() -> new GeneralException(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND));
 
@@ -576,9 +577,7 @@ public class TeumServiceImpl implements TeumService {
             }
         }
 
-        return TeumResponseDto.ScheduledTeumCancel.builder()
-                .cancelledUserIds(List.of(userId))
-                .build();
+        return requestId;
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -551,6 +551,36 @@ public class TeumServiceImpl implements TeumService {
                 .toList();
     }
 
+    @Override
+    public TeumResponseDto.ScheduledTeumCancel cancelTeumRequest(Long requestId, Long userId) {
+        TeumRequest request = teumRequestRepository.findById(requestId)
+                .orElseThrow(() -> new GeneralException(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND));
+
+        // 요청자 본인만 취소 가능
+        if (!request.getUser().getId().equals(userId)) {
+            throw new GeneralException(TeumErrorStatus.USER_NOT_ELIGIBLE);
+        }
+
+        // 이미 종료되었거나 취소된 요청은 중복 취소 불가
+        if (request.getStatus() != RequestStatus.ACTIVE) {
+            throw new GeneralException(TeumErrorStatus.REQUEST_ALREADY_CLOSED);
+        }
+
+        // 요청 상태를 CANCELED로 변경
+        request.markAsCanceled();
+
+        // 연결된 응답을 모두 비활성화 처리 (응답 불가하도록)
+        for (TeumResponse response : request.getTeumResponses()) { //
+            if (response.getStatus() == ResponseStatus.PENDING) {
+                response.changeStatus(ResponseStatus.CANCELED_BY_REQUESTER);
+            }
+        }
+
+        return TeumResponseDto.ScheduledTeumCancel.builder()
+                .cancelledUserIds(List.of(userId))
+                .build();
+    }
+
 
     // 사용자가 해당 요청의 요청자 또는 응답자인지 여부
     private boolean isParticipant(TeumRequest req, Long userId) {
@@ -574,7 +604,8 @@ public class TeumServiceImpl implements TeumService {
 
         // 응답자가 모두 거절 또는 취소한 경우
         boolean allResponsesCancelled = request.getTeumResponses().stream()
-                .allMatch(r -> r.getStatus() == ResponseStatus.REJECTED || r.getStatus() == ResponseStatus.LEFT);
+                .allMatch(r -> r.getStatus() == ResponseStatus.REJECTED || r.getStatus() == ResponseStatus.LEFT ||
+                        r.getStatus() == ResponseStatus.CANCELED_BY_REQUESTER);
 
         // 최종 취소 판단 조건
         return hasNoPending && (allSchedulesCancelled || (hasNoSchedules && allResponsesCancelled));

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -554,8 +554,7 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional
     public Long cancelTeumRequest(Long requestId, Long userId) {
-        TeumRequest request = teumRequestRepository.findById(requestId)
-                .orElseThrow(() -> new GeneralException(TeumErrorStatus.TEUM_REQUEST_NOT_FOUND));
+        TeumRequest request = findActiveRequestOrThrow(requestId);
 
         // 요청자 본인만 취소 가능
         if (!request.getUser().getId().equals(userId)) {
@@ -571,7 +570,7 @@ public class TeumServiceImpl implements TeumService {
         request.markAsCanceled();
 
         // 연결된 응답을 모두 비활성화 처리 (응답 불가하도록)
-        for (TeumResponse response : request.getTeumResponses()) { //
+        for (TeumResponse response : request.getTeumResponses()) {
             if (response.getStatus() == ResponseStatus.PENDING) {
                 response.changeStatus(ResponseStatus.CANCELED_BY_REQUESTER);
             }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#260 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 수신자가 수락되지 않은 틈 요청을 취소할 수 있도록 합니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 틈 요청 status에 CANCELED, 틈 응답 status에 CANCELED_BY_REQUESTER가 추가되었습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 틈 요청 취소 API | <img width="1161" height="241" alt="image" src="https://github.com/user-attachments/assets/22962b6c-228b-4dd4-a1e5-8af270571124" /> |
| 틈 응답 | <img width="1607" height="162" alt="image" src="https://github.com/user-attachments/assets/95525125-3563-442b-a324-c1747dca89d9" /> |
| 틈 요청 | <img width="646" height="113" alt="image" src="https://github.com/user-attachments/assets/d6c45fd3-e576-4a9d-8236-aa5335b6fa7d" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 틈 요청 취소 기능 추가: 요청자가 활성 상태의 틈 요청을 취소할 수 있습니다.
  * 요청 취소 시 해당 요청에 속한 모든 대기 중인 응답이 자동으로 취소 상태로 전환됩니다.
  * 취소 관련 상태값 및 취소 성공 안내 메시지 추가로 사용자 피드백이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->