### PR TITLE
Feat: 반복일정 수정 삭제 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -52,6 +52,9 @@ public class ScheduleConverter {
 
     // RemindAlarm 리스트 -> ScheduleReminder
     public static List<ScheduleReminder> remindAlarmToScheduleReminders(Schedule schedule, List<RemindAlarm> remindAlarm, AlarmStatus alarmStatus) {
+        if(remindAlarm == null || remindAlarm.isEmpty()){
+            return List.of();
+        }
         return remindAlarm.stream()
                 .map(item -> ScheduleReminder.builder()
                     .schedule(schedule)

--- a/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/home/converter/ScheduleConverter.java
@@ -50,6 +50,17 @@ public class ScheduleConverter {
                 .toList();
     }
 
+    // RemindAlarm 리스트 -> ScheduleReminder
+    public static List<ScheduleReminder> remindAlarmToScheduleReminders(Schedule schedule, List<RemindAlarm> remindAlarm, AlarmStatus alarmStatus) {
+        return remindAlarm.stream()
+                .map(item -> ScheduleReminder.builder()
+                    .schedule(schedule)
+                    .reminderTime(item.getMinutesBefore())
+                    .alarmStatus(alarmStatus)
+                    .build())
+                .toList();
+    }
+
     // Schedule -> TodoInfoResponseDTO
     public HomeResponseDto.TodoInfoDto toTodoInfoResponse(Schedule schedule, List<ScheduleReminder> reminders, List<String> profileUrls) {
 
@@ -111,8 +122,8 @@ public class ScheduleConverter {
                 .toList();
     }
 
-    // Routine -> Schedule(isDeleted = true)
-    public Schedule toDeleteRoutine(Routine routine,LocalDate date){
+    // Routine -> Schedule
+    public static Schedule routineToSchedule(Routine routine, LocalDate date, RoutineStatus routineStatus) {
         return Schedule.builder()
                 .user(routine.getUser())
                 .routine(routine)
@@ -125,7 +136,7 @@ public class ScheduleConverter {
                 .includeTeum(false)
                 .type(ScheduleType.ROUTINE)
                 .status(ScheduleStatus.ACTIVE)
-                .routineStatus(RoutineStatus.DELETED)
+                .routineStatus(routineStatus)
                 .build();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -104,6 +104,18 @@ public class Schedule extends BaseEntity {
         this.includeTeum = dto.getIncludeTeum();
     }
 
+    public void updateFromRoutine(Routine routine) {
+        // 1. startTime, endTime 변환
+        LocalDateTime newStartTime = LocalDateTime.of(this.getDate(),routine.getStartTime());
+        LocalDateTime newEndTime = LocalDateTime.of(this.getDate(),routine.getEndTime());
+
+        // 2. 필드 업데이트
+        this.title = routine.getTitle();
+        this.description = routine.getDescription();
+        this.startTime = newStartTime;
+        this.endTime = newEndTime;
+    }
+
     public void cancel() {
         this.status = ScheduleStatus.CANCELLED;
     }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -129,4 +129,9 @@ public class Schedule extends BaseEntity {
         this.routineStatus = routineStatus;
     }
 
+    // 루틴 설정
+    public void setRoutine(Routine routine) {
+        this.routine = routine;
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -327,4 +327,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("select s from Schedule s where s.routine = :routine and s.date >= :date")
     List<Schedule> findByRoutineAndDateGreaterThanEqual(Routine routine, LocalDate date);
 
+    // 루틴Id로 스케줄 조회
+    List<Schedule> findByRoutineId(Long routineId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -321,4 +321,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("userIds") Collection<Long> userIds
     );
 
+    /**
+     * 오늘 이후의 루틴 검색 (오늘 & 미래)
+     */
+    @Query("select s from Schedule s where s.routine = :routine and s.date >= :date")
+    List<Schedule> findByRoutineAndDateGreaterThanEqual(Routine routine, LocalDate date);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -336,7 +336,7 @@ public class HomeServiceImpl implements HomeService {
         Routine routine = routineRepository.findById(routineId)
                 .orElseThrow(() -> new HomeException(HomeErrorStatus._ROUTINE_NOT_FOUND));
 
-        Schedule deletedSchedule = scheduleConverter.toDeleteRoutine(routine,date);
+        Schedule deletedSchedule = scheduleConverter.routineToSchedule(routine,date,RoutineStatus.DELETED);
         scheduleRepository.save(deletedSchedule);
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -5,11 +5,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import umc.teumteum.server.domain.home.dto.response.HomeResponseDto;
-import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDto;
@@ -22,7 +19,6 @@ import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
-import java.time.LocalDate;
 import java.util.List;
 
 
@@ -144,7 +140,7 @@ public class UserController {
     )
     @DeleteMapping(value = "/mypage/routines/{routineId}", produces = "application/json")
     public ApiResponse<Object> deleteRoutine(
-            @Parameter(name= "routineId", description = "삭제할 routine Id", example = "123") @PathVariable("routineId") Long routineId
+            @Parameter(name= "routineId", description = "삭제할 Routine Id", example = "123") @PathVariable("routineId") Long routineId
     ){
         userService.deleteRoutine(routineId);
         return ApiResponse.of(UserSuccessStatus._ROUTINE_DELETED, null);
@@ -161,6 +157,20 @@ public class UserController {
     ){
         userService.saveRoutine(request, user);
         return ApiResponse.of(UserSuccessStatus._ROUTINE_ADDED,null);
+    }
+
+    @Operation(
+            summary = "마이페이지 반복일정 수정",
+            description = "특정 반복일정을 수정합니다."
+    )
+    @PatchMapping(value = "/mypage/routines/{routineId}", produces = "application/json")
+    public ApiResponse<Object> updateRoutine(
+            @Parameter(name= "routineId", description = "수정할 Routine Id", example = "123") @PathVariable("routineId") Long routineId,
+            @RequestBody @Valid OnboardingRequestDto.RoutineDTO request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        userService.updateRoutine(routineId, request, user);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_UPDATED, null);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -138,4 +138,16 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._ROUTINE_LOADED,response);
     }
 
+    @Operation(
+            summary = "마이페이지 반복일정 삭제",
+            description = "특정 반복일정을 삭제합니다."
+    )
+    @DeleteMapping(value = "/routines/{routineId}", produces = "application/json")
+    public ApiResponse<Object> deleteRoutine(
+            @Parameter(name= "routineId", description = "삭제할 routine Id", example = "123") @PathVariable("routineId") Long routineId
+    ){
+        userService.deleteRoutine(routineId);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_DELETED, null);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -116,7 +116,7 @@ public class UserController {
             summary = "마이페이지 알림 설정 수정",
             description = "오늘의 일정, 리마인드 알림, 팔로워, 틈 요청에 대해 알림 여부를 수정합니다."
     )
-    @PatchMapping(value = "/alarm", produces = "application/json")
+    @PatchMapping(value = "/mypage/alarm", produces = "application/json")
     public ApiResponse<Object> updateAlarm(
             @RequestBody @Valid UserRequestDto.NotificationSettingRequest request,
             @CurrentUser @Parameter(hidden = true) User user
@@ -129,7 +129,7 @@ public class UserController {
             summary = "마이페이지 반복일정 조회",
             description = "요일별 반복일정을 조회합니다. query string으로 요일을 입력해주세요."
     )
-    @GetMapping(value = "/routines", produces = "application/json")
+    @GetMapping(value = "/mypage/routines", produces = "application/json")
     public ApiResponse<List<UserResponseDTO.RoutineDTO>> getRoutines(
             @Parameter(name = "weekday",description = "조회할 요일", example = "MONDAY") @RequestParam("weekday") Weekday weekday,
             @CurrentUser @Parameter(hidden = true) User user
@@ -142,12 +142,25 @@ public class UserController {
             summary = "마이페이지 반복일정 삭제",
             description = "특정 반복일정을 삭제합니다."
     )
-    @DeleteMapping(value = "/routines/{routineId}", produces = "application/json")
+    @DeleteMapping(value = "/mypage/routines/{routineId}", produces = "application/json")
     public ApiResponse<Object> deleteRoutine(
             @Parameter(name= "routineId", description = "삭제할 routine Id", example = "123") @PathVariable("routineId") Long routineId
     ){
         userService.deleteRoutine(routineId);
         return ApiResponse.of(UserSuccessStatus._ROUTINE_DELETED, null);
+    }
+
+    @Operation(
+            summary = "마이페이지 반복일정 추가",
+            description = "새로운 반복일정을 등록합니다."
+    )
+    @PostMapping(value = "/mypage/routines", produces = "application/json")
+    public ApiResponse<Object> saveRoutine(
+            @RequestBody @Valid OnboardingRequestDto.RoutineDTO request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        userService.saveRoutine(request, user);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_ADDED,null);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -5,19 +5,24 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.home.dto.response.HomeResponseDto;
+import umc.teumteum.server.domain.home.exception.status.HomeSuccessStatus;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.domain.user.exception.status.UserSuccessStatus;
 import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.annotation.CurrentUser;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
@@ -118,6 +123,19 @@ public class UserController {
     ) {
         userService.updateAlarm(request, user);
         return ApiResponse.of(UserSuccessStatus._ALARM_STATE_UPDATED, null);
+    }
+
+    @Operation(
+            summary = "마이페이지 반복일정 조회",
+            description = "요일별 반복일정을 조회합니다. query string으로 요일을 입력해주세요."
+    )
+    @GetMapping(value = "/routines", produces = "application/json")
+    public ApiResponse<List<UserResponseDTO.RoutineDTO>> getRoutines(
+            @Parameter(name = "weekday",description = "조회할 요일", example = "MONDAY") @RequestParam("weekday") Weekday weekday,
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        List<UserResponseDTO.RoutineDTO> response = userService.getRoutines(weekday, user);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_LOADED,response);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
 
@@ -32,5 +33,16 @@ public class UserConverter {
             .job(user.getJob())
             .build();
 
+    }
+
+    // routine -> UserResponseDTO.RoutineDTO
+    public static UserResponseDTO.RoutineDTO toRoutineDTO(Routine routine) {
+        return UserResponseDTO.RoutineDTO.builder()
+                .title(routine.getTitle())
+                .description(routine.getDescription())
+                .weekday(routine.getWeekday())
+                .startTime(routine.getStartTime())
+                .endTime(routine.getEndTime())
+                .build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -38,6 +38,7 @@ public class UserConverter {
     // routine -> UserResponseDTO.RoutineDTO
     public static UserResponseDTO.RoutineDTO toRoutineDTO(Routine routine) {
         return UserResponseDTO.RoutineDTO.builder()
+                .routineId(routine.getId())
                 .title(routine.getTitle())
                 .description(routine.getDescription())
                 .weekday(routine.getWeekday())

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -35,6 +35,9 @@ public class UserResponseDTO {
   @AllArgsConstructor
   public static class RoutineDTO {
 
+    @Schema(description = "반복일정 ID", example = "1")
+    private Long routineId;
+
     @Schema(description = "제목", example = "매주 산책")
     private String title;
 

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -1,9 +1,16 @@
 package umc.teumteum.server.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
+
+import java.time.LocalTime;
+import java.util.List;
 
 public class UserResponseDTO {
 
@@ -21,5 +28,28 @@ public class UserResponseDTO {
     private String job;
 
 
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class RoutineDTO {
+
+    @Schema(description = "제목", example = "매주 산책")
+    private String title;
+
+    @Schema(description = "상세 내용", example = "한강에서 산책")
+    private String description;
+
+    @Schema(description = "반복 요일", example = "WEDNESDAY")
+    private Weekday weekday;
+
+    @JsonFormat(pattern = "HH:mm")
+    @Schema(description = "시작 시간 (HH:mm 형식)", example = "13:00")
+    private LocalTime startTime;
+
+    @JsonFormat(pattern = "HH:mm")
+    @Schema(description = "종료 시간 (HH:mm 형식)", example = "00:00")
+    private LocalTime endTime;
   }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
@@ -46,12 +46,6 @@ public class Routine extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
-    /*
-        양방향 연관관계
-    */
-    @OneToMany(mappedBy = "routine", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<Schedule> schedules = new ArrayList<>();
-
     public void updateField(OnboardingRequestDto.RoutineDTO request) {
         this.title = request.getTitle();
         this.description = request.getDescription();

--- a/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.global.common.BaseEntity;
 
@@ -50,4 +51,12 @@ public class Routine extends BaseEntity {
     */
     @OneToMany(mappedBy = "routine", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Schedule> schedules = new ArrayList<>();
+
+    public void updateField(OnboardingRequestDto.RoutineDTO request) {
+        this.title = request.getTitle();
+        this.description = request.getDescription();
+        this.weekday = request.getWeekday();
+        this.startTime = request.getStartTime();
+        this.endTime = request.getEndTime();
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
@@ -5,10 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.global.common.BaseEntity;
 
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -41,4 +44,10 @@ public class Routine extends BaseEntity {
 
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
+
+    /*
+        양방향 연관관계
+    */
+    @OneToMany(mappedBy = "routine", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Schedule> schedules = new ArrayList<>();
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/Routine.java
@@ -46,11 +46,16 @@ public class Routine extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
-    public void updateField(OnboardingRequestDto.RoutineDTO request) {
-        this.title = request.getTitle();
-        this.description = request.getDescription();
-        this.weekday = request.getWeekday();
-        this.startTime = request.getStartTime();
-        this.endTime = request.getEndTime();
+    public void updateField(String title,
+                            String description,
+                            Weekday weekday,
+                            LocalTime startTime,
+                            LocalTime endTime){
+
+        this.title = title;
+        this.description = description;
+        this.weekday = weekday;
+        this.startTime = startTime;
+        this.endTime = endTime;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -13,6 +13,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     CANNOT_DELETE_DEFAULT_IMAGE(HttpStatus.BAD_REQUEST,"USER4000","기본 프로필 이미지는 삭제할 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041","사용자의 알림 설정 정보를 찾을 수 없습니다."),
+    ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND,"USER4042","사용자의 반복일정 정보를 찾을 수 없습니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -16,6 +16,7 @@ public enum UserSuccessStatus implements BaseCode {
     _PROFILE_IMAGE_DELETED(HttpStatus.OK,"USER2004","프로필 이미지 삭제가 완료되었습니다."),
     _PROFILE_UPDATED(HttpStatus.OK,"USER2005","개인정보 수정이 완료되었습니다."),
     _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2006","사용자의 알림 설정 변경이 완료되었습니다."),
+    _ROUTINE_LOADED(HttpStatus.OK,"USER2007","반복일정 조회가 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -17,6 +17,7 @@ public enum UserSuccessStatus implements BaseCode {
     _PROFILE_UPDATED(HttpStatus.OK,"USER2005","개인정보 수정이 완료되었습니다."),
     _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2006","사용자의 알림 설정 변경이 완료되었습니다."),
     _ROUTINE_LOADED(HttpStatus.OK,"USER2007","반복일정 조회가 완료되었습니다."),
+    _ROUTINE_DELETED(HttpStatus.OK,"USER2008","반복일정 삭제가 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -19,6 +19,7 @@ public enum UserSuccessStatus implements BaseCode {
     _ROUTINE_LOADED(HttpStatus.OK,"USER2007","반복일정 조회가 완료되었습니다."),
     _ROUTINE_DELETED(HttpStatus.OK,"USER2008","반복일정 삭제가 완료되었습니다."),
     _ROUTINE_ADDED(HttpStatus.OK,"USER2009","반복일정 등록이 완료되었습니다."),
+    _ROUTINE_UPDATED(HttpStatus.OK,"USER20010","반복일정 수정이 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -18,6 +18,7 @@ public enum UserSuccessStatus implements BaseCode {
     _ALARM_STATE_UPDATED(HttpStatus.OK,"USER2006","사용자의 알림 설정 변경이 완료되었습니다."),
     _ROUTINE_LOADED(HttpStatus.OK,"USER2007","반복일정 조회가 완료되었습니다."),
     _ROUTINE_DELETED(HttpStatus.OK,"USER2008","반복일정 삭제가 완료되었습니다."),
+    _ROUTINE_ADDED(HttpStatus.OK,"USER2009","반복일정 등록이 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,4 +33,6 @@ public interface UserService {
     void deleteProfileImage(User user);
 
     void updateAlarm(UserRequestDto.NotificationSettingRequest request, User user);
+
+    List<UserResponseDTO.RoutineDTO> getRoutines(Weekday weekday, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -39,4 +39,6 @@ public interface UserService {
     void deleteRoutine(Long routineId);
 
     void saveRoutine(OnboardingRequestDto.RoutineDTO request, User user);
+
+    void updateRoutine(Long routineId, OnboardingRequestDto.RoutineDTO request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -37,4 +37,6 @@ public interface UserService {
     List<UserResponseDTO.RoutineDTO> getRoutines(Weekday weekday, User user);
 
     void deleteRoutine(Long routineId);
+
+    void saveRoutine(OnboardingRequestDto.RoutineDTO request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -35,4 +35,6 @@ public interface UserService {
     void updateAlarm(UserRequestDto.NotificationSettingRequest request, User user);
 
     List<UserResponseDTO.RoutineDTO> getRoutines(Weekday weekday, User user);
+
+    void deleteRoutine(Long routineId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +17,14 @@ import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.NotificationSetting;
+import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.domain.user.entity.enums.Weekday;
 import umc.teumteum.server.domain.user.exception.UserException;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
@@ -43,6 +47,8 @@ public class UserServiceImpl implements UserService {
 
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
+    @Autowired
+    private RoutineRepository routineRepository;
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -262,5 +268,22 @@ public class UserServiceImpl implements UserService {
                 request.getRemindAlarm(),
                 request.getTeum(), request.getFollow()
         );
+    }
+
+    // 마이페이지 - 반복일정 조회
+    @Override
+    public List<UserResponseDTO.RoutineDTO> getRoutines(Weekday weekday, User user) {
+        // 1. 유저 조회
+        User existingUser = userRepository.findById(user.getId())
+                .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
+
+        // 2. 요일별 반복일정 조회
+        List<Routine> routines = routineRepository.findByUserAndWeekday(existingUser, weekday);
+
+
+        // 3. 응답 변환
+        return routines.stream()
+                .map(UserConverter::toRoutineDTO)
+                .toList();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -4,10 +4,18 @@ import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
+import umc.teumteum.server.domain.home.converter.ScheduleConverter;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.ScheduleReminder;
+import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
+import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.user.converter.OnboardingConverter;
 import umc.teumteum.server.domain.user.converter.UserConverter;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
@@ -16,23 +24,31 @@ import umc.teumteum.server.domain.user.dto.UserRequestDto;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.NotificationSetting;
+import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.domain.user.exception.OnboardingException;
 import umc.teumteum.server.domain.user.exception.UserException;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
+import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.dto.TimeRange;
 import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
+import umc.teumteum.server.global.util.TimeUtil;
 
 import static umc.teumteum.server.domain.user.util.ImageConstants.ALLOWED_IMAGE_TYPES;
 import static umc.teumteum.server.domain.user.util.ImageConstants.DEFAULT_IMAGE;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +63,10 @@ public class UserServiceImpl implements UserService {
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
     private final RoutineRepository routineRepository;
+    private final TimeUtil timeUtil;
+    private final ScheduleRepository scheduleRepository;
+    private final RemindAlarmRepository remindAlarmRepository;
+    private final ScheduleReminderRepository scheduleReminderRepository;
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -278,7 +298,6 @@ public class UserServiceImpl implements UserService {
         // 2. 요일별 반복일정 조회
         List<Routine> routines = routineRepository.findByUserAndWeekday(existingUser, weekday);
 
-
         // 3. 응답 변환
         return routines.stream()
                 .map(UserConverter::toRoutineDTO)
@@ -296,4 +315,82 @@ public class UserServiceImpl implements UserService {
         // 2. 루틴 삭제
         routineRepository.delete(routine);
     }
+
+    // 마이페이지 - 반복일정 등록
+    @Transactional
+    @Override
+    public void saveRoutine(OnboardingRequestDto.RoutineDTO request, User user) {
+
+        // 1. 단일 일정 내에서 시작 & 종료시간 확인
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+
+        validateRoutineTimeRange(startTime, endTime);
+
+        // 2. 기존 존재하는 루틴과 충돌이 없는지 여부 검토
+        List<Routine> existingRoutines = routineRepository.findByUserAndWeekday(user, request.getWeekday());
+        validateExistingRoutineConflicts(request, existingRoutines);
+
+        // 3. 저장
+        Routine routine = OnboardingConverter.toRoutine(request, user);
+        routineRepository.save(routine);
+
+        // 4. 해당 날짜가 오늘이라면 스케줄 테이블에 삽입
+        Weekday todayWeekday = Weekday.from(LocalDate.now().getDayOfWeek());
+        LocalDate today = LocalDate.now();
+
+        if(request.getWeekday().equals(todayWeekday)){
+            Schedule schedule = ScheduleConverter.routineToSchedule(routine,today, RoutineStatus.ORIGINAL);
+            Schedule savedSchedule = scheduleRepository.save(schedule);
+
+            // 4-1. 리마인드 알림 조회
+            List<RemindAlarm> remindAlarms = remindAlarmRepository.findAllByUser(user);
+
+            // 4-2. 스케줄 리마인드 생성
+            List<ScheduleReminder> scheduleReminder = ScheduleConverter.remindAlarmToScheduleReminders(savedSchedule, remindAlarms, AlarmStatus.ACTIVE);
+
+            // 4-3. 저장
+            scheduleReminderRepository.saveAll(scheduleReminder);
+        }
+    }
+
+    // 단일 일정 내에서 시작 & 종료시간 확인
+    private void validateRoutineTimeRange(LocalTime startTime, LocalTime endTime) {
+        // 1. 종료시간 00:00의 경우 무조건 허용 (=다음날 자정에 종료를 의미)
+        if (endTime.equals(LocalTime.MIDNIGHT)) {
+            return;
+        }
+
+        // 2. 기본 유효성 검증 (시작시간 < 종료시간)
+        if (!startTime.isBefore(endTime)) {
+            // ex) 13:00~03:00, 10:00~10:00 등이 해당
+            throw new OnboardingException(UserErrorStatus.INVALID_TIME_RANGE);
+        }
+    }
+
+    // 기존 루틴들과의 시간 충돌 여부 검사
+    private void validateExistingRoutineConflicts(
+            OnboardingRequestDto.RoutineDTO newRoutineRequest,
+            List<Routine> existingRoutines
+    ){
+        // 1. 기존 루틴이 없으면 검증 통과
+        if(existingRoutines.isEmpty()){
+            return;
+        }
+
+        // 2. 기존 루틴들과 새 루틴을 모두 TimeRange 리스트로 변환
+        List<TimeRange> timeRanges = new ArrayList<>();
+
+        // 2-1. 기존 루틴들을 TimeRange로 변환하여 추가 (Routine::toTimeRange 필요)
+        existingRoutines.stream()
+                .map(TimeRange::from)
+                .forEach(timeRanges::add);
+
+        // 2-2. 새로 등록한 루틴 TimeRange로 변환 후 추가
+        timeRanges.add(TimeRange.from(newRoutineRequest));
+
+        // 2-3. 충돌 여부 검증
+        timeUtil.validateTimeRangeConflicts(timeRanges,UserErrorStatus.ROUTINE_TIME_CONFLICT);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -4,7 +4,6 @@ import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -354,6 +353,48 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    // 마이페이지 -  반복일정 수정
+    @Transactional
+    @Override
+    public void updateRoutine(Long routineId, OnboardingRequestDto.RoutineDTO request, User user) {
+        // 1. 루틴 존재 여부 확인
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new UserException(UserErrorStatus.ROUTINE_NOT_FOUND));
+
+        // 2. 단일 일정 내에서 시작 & 종료시간 확인
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+        validateRoutineTimeRange(startTime, endTime);
+
+        // 3. 기존 루틴들과의 시간 충돌 여부 검사
+        // 3-1. 요일과 유저로 루틴 조회
+        List<Routine> existingRoutines = routineRepository.findByUserAndWeekday(user, request.getWeekday());
+
+        // 3-2. 현재 수정 중인 루틴 (ID 일치)을 제외하고 필터링
+        List<Routine> routinesToCheck = existingRoutines.stream()
+                .filter(r -> !r.getId().equals(routineId))
+                .collect(Collectors.toList());
+
+        validateExistingRoutineConflicts(request, routinesToCheck);
+
+        // 4. 반복일정 필드 수정
+        routine.updateField(request);
+
+        // 5. 해당 날짜가 오늘이라면 오늘 이후의 스케줄 수정
+        Weekday todayWeekday = Weekday.from(LocalDate.now().getDayOfWeek());
+        LocalDate today = LocalDate.now();
+
+        if(request.getWeekday().equals(todayWeekday)){
+            // 5-1. 오늘 이후의 루틴 ID가 같은 스케줄 조회
+            List<Schedule> scheduleList = scheduleRepository.findByRoutineAndDateGreaterThanEqual(routine, today);
+
+            // 5-2. 기존 스케줄에서 필드 수정
+            scheduleList.forEach(schedule -> {
+                schedule.updateFromRoutine(routine);
+            });
+        }
+    }
+
     // 단일 일정 내에서 시작 & 종료시간 확인
     private void validateRoutineTimeRange(LocalTime startTime, LocalTime endTime) {
         // 1. 종료시간 00:00의 경우 무조건 허용 (=다음날 자정에 종료를 의미)
@@ -392,5 +433,4 @@ public class UserServiceImpl implements UserService {
         // 2-3. 충돌 여부 검증
         timeUtil.validateTimeRangeConflicts(timeRanges,UserErrorStatus.ROUTINE_TIME_CONFLICT);
     }
-
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -397,7 +397,13 @@ public class UserServiceImpl implements UserService {
         validateExistingRoutineConflicts(request, routinesToCheck);
 
         // 4. 반복일정 필드 수정
-        routine.updateField(request);
+        routine.updateField(
+                request.getTitle(),
+                request.getDescription(),
+                request.getWeekday(),
+                request.getStartTime(),
+                request.getEndTime()
+        );
 
         // 5. 해당 날짜가 오늘이라면 오늘 이후의 스케줄 수정
         Weekday todayWeekday = Weekday.from(LocalDate.now().getDayOfWeek());

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -4,7 +4,6 @@ import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,8 +46,7 @@ public class UserServiceImpl implements UserService {
 
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
-    @Autowired
-    private RoutineRepository routineRepository;
+    private final RoutineRepository routineRepository;
 
     @Override
     public List<UserSearchResponseDto> searchUsersByKeyword(String keyword, Long userId) {
@@ -285,5 +283,17 @@ public class UserServiceImpl implements UserService {
         return routines.stream()
                 .map(UserConverter::toRoutineDTO)
                 .toList();
+    }
+
+    // 마이페이지 - 반복일정 삭제
+    @Transactional
+    @Override
+    public void deleteRoutine(Long routineId) {
+        // 1. 루틴 존재 여부 확인
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new UserException(UserErrorStatus.ROUTINE_NOT_FOUND));
+
+        // 2. 루틴 삭제
+        routineRepository.delete(routine);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -311,7 +311,26 @@ public class UserServiceImpl implements UserService {
         Routine routine = routineRepository.findById(routineId)
                 .orElseThrow(() -> new UserException(UserErrorStatus.ROUTINE_NOT_FOUND));
 
-        // 2. 루틴 삭제
+        // 2. 오늘 & 미래 스케줄 조회
+        LocalDate today = LocalDate.now();
+        List<Schedule> schedules = scheduleRepository.findByRoutineAndDateGreaterThanEqual(routine, today);
+
+        // 3. 스케줄 리마인드 삭제
+        for (Schedule schedule : schedules) {
+            scheduleReminderRepository.deleteByScheduleId(schedule.getId());
+        }
+
+        // 4. 스케줄 삭제
+        scheduleRepository.deleteAll(schedules);
+
+        // 5. 과거 스케줄의 연관관계 제거
+        List<Schedule> pastSchedules = scheduleRepository.findByRoutineId(routineId);
+        pastSchedules.forEach(s -> {
+            s.setRoutine(null);
+        });
+        scheduleRepository.saveAll(pastSchedules);
+
+        // 6. 루틴 삭제
         routineRepository.delete(routine);
     }
 

--- a/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
+++ b/src/main/java/umc/teumteum/server/global/dto/TimeRange.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.global.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
+import umc.teumteum.server.domain.user.entity.Routine;
 
 import java.time.LocalTime;
 
@@ -14,6 +15,11 @@ public class TimeRange {
 
     // RoutineDTO에서 TimeRange로 변환
     public static TimeRange from(OnboardingRequestDto.RoutineDTO routine) {
+        return new TimeRange(routine.getStartTime(), routine.getEndTime());
+    }
+
+    // Routine에서 TimeRange로 변환
+    public static TimeRange from(Routine routine) {
         return new TimeRange(routine.getStartTime(), routine.getEndTime());
     }
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#267
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 반복일정 조회
query string으로 요일을 받아 해당 요일의 반복일정을 조회합니다.
- 반복일정 추가
기존의 반복일정과 충돌 검사 & 단일 일정 내에서 시작 종료 시간 검증 이후 반복일정을 저장하고 해당 루틴이 오늘 요일이라면 스케줄 테이블에 데이터를 추가합니다.
- 반복일정 수정
반복일정 수정 시, 반복일정 추가와 로직과 동일하게 진행됩니다. 추가로 미래에 수정된 루틴의 정보도 수정하도록 추가했습니다.
- 반복일정 삭제
반복일정 삭제시 오늘&미래의 반복일정은 삭제하고, 과거의 반복일정은 연관관계를 제거한 후 보존되도록 설계했습니다.


온보딩의 서비스 로직을 검토하니 마이페이지에서는 별도로 기존의 루틴을 조회하는 로직이 필요하고 인자로 주고받는 DTO의 차이가 있어 코드를 참고하고 새롭게 마이페이지용 로직을 재설계했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
GET `/api/users/routines?weekday={weekday}`
DELETE `/api/users/mypage/routines/{routineId}`
POST `/api/users/mypage/routines`
GET `/api/users/mypage/routines`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X
### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MyPage에서 반복일정 관리 추가(조회, 생성, 수정, 삭제) 및 요일별 조회 지원
  * 반복일정 DTO 및 변환 지원으로 클라이언트에 반복일정 정보 제공
  * 반복일정 생성/수정 시 오늘 일정 자동 생성·업데이트 및 알림 생성

* **Bug Fixes**
  * 반복일정 삭제 시 오늘 이후 스케줄과 알림을 정리하여 일관성 유지

* **Other**
  * 반복일정 관련 성공/오류 상태 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->