### PR TITLE
Feat: 겹치는 일정 반환 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.enums.RoutineStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleStatus;
 import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
@@ -23,16 +24,16 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserIdAndIncludeTeumIsTrue(Long userId);
 
     @Query("""
-    SELECT s FROM Schedule s
-    WHERE s.user.id = :userId
-      AND s.status IN (:statuses)
-      AND s.endTime >= :startOfDay
-      AND s.startTime < :endOfDay
-""")
+        SELECT s FROM Schedule s
+        WHERE s.user.id = :userId
+          AND s.status IN (:statuses)
+          AND s.endTime > :checkStart
+          AND s.startTime < :checkEnd
+    """)
     List<Schedule> findOverlappingSchedules(
             @Param("userId") Long userId,
-            @Param("startOfDay") LocalDateTime startOfDay,
-            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("checkStart") LocalDateTime checkStart,
+            @Param("checkEnd") LocalDateTime checkEnd,
             @Param("statuses") Collection<ScheduleStatus> statuses
     );
 
@@ -319,6 +320,30 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("date") LocalDate date,
             @Param("type") ScheduleType type,
             @Param("userIds") Collection<Long> userIds
+    );
+
+    /**
+     * 충돌 스케줄 조회 조건:
+     * 1. ACTIVE 상태일 것
+     * 2. RoutineStatus가 DELETED가 아닐 것
+     * 3. 시간이 겹칠 것 (등호 제외: 접하는 시간 허용)
+     */
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.status = :status
+      AND s.routineStatus <> :routineStatus
+      AND s.date = :date
+      AND s.startTime < :checkEnd
+      AND s.endTime > :checkStart
+""")
+    List<Schedule> findConflictingSchedules(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("checkStart") LocalDateTime checkStart,
+            @Param("checkEnd") LocalDateTime checkEnd,
+            @Param("status") ScheduleStatus status,        // 추가됨
+            @Param("routineStatus") RoutineStatus routineStatus // 추가됨
     );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import umc.teumteum.server.domain.teum.dto.TeumRequestDto;
@@ -245,6 +246,18 @@ public class TeumController {
         return ApiResponse.of(TeumSuccessStatus._TEUM_REQUEST_CANCELLED, cancelledId);
     }
 
+    @Operation(
+            summary = "일정 충돌 확인",
+            description = "지정한 날짜와 시간대에 겹치는 사용자의 기존 스케줄 목록을 반환합니다. 겹치는 일정이 없으면 빈 리스트를 반환합니다."
+    )
+    @GetMapping("/conflicts")
+    public ApiResponse<TeumResponseDto.ConflictingScheduleResponse> checkConflictingSchedules(
+            @Parameter(hidden = true) @CurrentUser User user,
+            @ParameterObject @Valid @ModelAttribute TeumRequestDto.ConflictCheckRequest request
+    ) {
+        TeumResponseDto.ConflictingScheduleResponse response =
+                teumService.checkConflictingSchedules(user.getId(), request);
 
-
+        return ApiResponse.of(TeumSuccessStatus._TEUM_CONFLICT_CHECK_SUCCESS, response);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 public class TeumConverter {
 
     private final TimeUtil timeUtil;
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public TeumRequest toTeumRequest(TeumRequestDto.TeumRequest dto, User sender) {
         return TeumRequest.builder()
@@ -387,9 +388,8 @@ public class TeumConverter {
                 .map(schedule -> TeumResponseDto.ConflictingSchedule.builder()
                         .id(schedule.getId())
                         .title(schedule.getTitle())
-                        // "HH:mm" 포맷으로 변환 (초 단위 제거)
-                        .startTime(schedule.getStartTime().toLocalTime().toString().substring(0, 5))
-                        .endTime(schedule.getEndTime().toLocalTime().toString().substring(0, 5))
+                        .startTime(schedule.getStartTime().toLocalTime().format(TIME_FORMATTER))
+                        .endTime(schedule.getEndTime().toLocalTime().format(TIME_FORMATTER))
                         .build())
                 .toList();
 

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -381,5 +381,23 @@ public class TeumConverter {
                 .build();
     }
 
+    // 충돌 스케줄 리스트 응답 DTO 반환
+    public TeumResponseDto.ConflictingScheduleResponse toConflictingScheduleResponse(List<Schedule> schedules) {
+        List<TeumResponseDto.ConflictingSchedule> conflictDtos = schedules.stream()
+                .map(schedule -> TeumResponseDto.ConflictingSchedule.builder()
+                        .id(schedule.getId())
+                        .title(schedule.getTitle())
+                        // "HH:mm" 포맷으로 변환 (초 단위 제거)
+                        .startTime(schedule.getStartTime().toLocalTime().toString().substring(0, 5))
+                        .endTime(schedule.getEndTime().toLocalTime().toString().substring(0, 5))
+                        .build())
+                .toList();
+
+        return TeumResponseDto.ConflictingScheduleResponse.builder()
+                .hasConflict(!conflictDtos.isEmpty())
+                .conflictingSchedules(conflictDtos)
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumRequestDto.java
@@ -7,7 +7,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public class TeumRequestDto {
@@ -87,6 +91,28 @@ public class TeumRequestDto {
 
         @Schema(description = "응답 상태", example = "ACCEPTED", allowableValues = {"ACCEPTED", "REJECTED"})
         private String status;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "일정 충돌 확인 요청 DTO")
+    public static class ConflictCheckRequest {
+
+        @Schema(description = "확인할 날짜 (YYYY-MM-DD)", example = "2025-05-20", type = "string")
+        @NotNull(message = "날짜는 필수입니다.")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        private LocalDate date;
+
+        @Schema(description = "시작 시간 (HH:mm)", example = "14:00", type = "string")
+        @NotNull(message = "시작 시간은 필수입니다.")
+        @DateTimeFormat(pattern = "HH:mm")
+        private LocalTime startTime;
+
+        @Schema(description = "종료 시간 (HH:mm)", example = "16:00", type = "string")
+        @NotNull(message = "종료 시간은 필수입니다.")
+        @DateTimeFormat(pattern = "HH:mm")
+        private LocalTime endTime;
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -267,5 +267,37 @@ public class TeumResponseDto {
         private Long id;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConflictingScheduleResponse {
+
+        @Schema(description = "충돌 여부 (true: 겹치는 일정 있음, false: 없음)", example = "true")
+        private boolean hasConflict;
+
+        @Schema(description = "겹치는 스케줄 목록 (충돌이 없으면 빈 리스트 반환)")
+        private List<ConflictingSchedule> conflictingSchedules;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConflictingSchedule {
+
+        @Schema(description = "스케줄 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "스케줄 제목", example = "팀 회의")
+        private String title;
+
+        @Schema(description = "시작 시간 (HH:mm)", example = "14:00")
+        private String startTime;
+
+        @Schema(description = "종료 시간 (HH:mm)", example = "16:00")
+        private String endTime;
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/exception/status/TeumSuccessStatus.java
@@ -25,7 +25,9 @@ public enum TeumSuccessStatus implements BaseCode {
     _SHARED_TIME_LOADED(HttpStatus.OK, "TEUM2012", "함께한 빈틈 시간 정보가 조회되었습니다."),
     _SHARED_LIST_LOADED(HttpStatus.OK, "TEUM2013", "함께한 틈 목록이 조회되었습니다."),
     _TEUM_READ_SUCCESS(HttpStatus.OK, "TEUM2014", "틈 요청이 읽음 처리되었습니다."),
-    _TEUM_REQUEST_CANCELLED(HttpStatus.OK, "TEUM2015", "틈 요청이 취소되었습니다.");
+    _TEUM_REQUEST_CANCELLED(HttpStatus.OK, "TEUM2015", "틈 요청이 취소되었습니다."),
+    _TEUM_CONFLICT_CHECK_SUCCESS(HttpStatus.OK, "TEUM2016", "일정 충돌 확인에 성공했습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -39,4 +39,7 @@ public interface TeumService {
     List<TeumResponseDto.TeumRequestDetail> getTeumRequestsByDate(Long userId, String date);
 
     Long cancelTeumRequest(Long requestId, Long userId);
+
+    TeumResponseDto.ConflictingScheduleResponse checkConflictingSchedules(Long userId, TeumRequestDto.ConflictCheckRequest request);
+
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -582,6 +582,12 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional(readOnly = true)
     public TeumResponseDto.ConflictingScheduleResponse checkConflictingSchedules(Long userId, TeumRequestDto.ConflictCheckRequest request) {
+        validateUserExists(userId);
+
+        if (!request.getStartTime().isBefore(request.getEndTime())) {
+            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        }
+
         // 입력받은 시간(LocalTime)을 날짜(LocalDate)와 합쳐 LocalDateTime으로 변환
         LocalDateTime checkStart = request.getDate().atTime(request.getStartTime());
         LocalDateTime checkEnd = request.getDate().atTime(request.getEndTime());

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -579,6 +579,27 @@ public class TeumServiceImpl implements TeumService {
         return requestId;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public TeumResponseDto.ConflictingScheduleResponse checkConflictingSchedules(Long userId, TeumRequestDto.ConflictCheckRequest request) {
+        // 입력받은 시간(LocalTime)을 날짜(LocalDate)와 합쳐 LocalDateTime으로 변환
+        LocalDateTime checkStart = request.getDate().atTime(request.getStartTime());
+        LocalDateTime checkEnd = request.getDate().atTime(request.getEndTime());
+
+        // Repository 조회
+        List<Schedule> conflicts = scheduleRepository.findConflictingSchedules(
+                userId,
+                request.getDate(),
+                checkStart,
+                checkEnd,
+                ScheduleStatus.ACTIVE,
+                RoutineStatus.DELETED
+        );
+
+        // Converter를 통해 DTO 변환 후 반환
+        return teumConverter.toConflictingScheduleResponse(conflicts);
+    }
+
 
     // 사용자가 해당 요청의 요청자 또는 응답자인지 여부
     private boolean isParticipant(TeumRequest req, Long userId) {

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -31,7 +31,7 @@ public class ConflictValidator {
     /**
      * 단일 사용자에 대한 Teum 시간 중복 검증 로직
      * - 사용자가 일정 생성 또는 Teum 응답을 시도할 때 호출
-     * - 일정, 반복 일정, 수면 시간과 겹침 여부를 검사
+     * - 일정, 반복 일정과 겹침 여부를 검사
      */
     public void validateTeum(User user, LocalDate date, LocalTime startTime, LocalTime endTime) {
         LocalDateTime startDateTime = LocalDateTime.of(date, startTime);
@@ -39,7 +39,6 @@ public class ConflictValidator {
 
         checkWithSchedules(user, startDateTime, endDateTime);
         checkWithRoutines(user, date, startDateTime, endDateTime);
-        checkWithSleepPattern(user, date, startDateTime, endDateTime);
     }
 
     /**


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#269 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
틈 요청에 대한 응답 생성 전, 해당 시간에 겹치는 기존 스케줄을 확인하는 API를 구현했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
1. 스케줄 겹침 조회 쿼리
2. 컨트롤러 파라미터 처리
3. DTO 스키마 설

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
- 테스트 케이스 검증 완료:
  - 정상적으로 겹치는 일정 (Active, 포함/걸침 등) -> 조회됨 (O)
  - 삭제된 루틴 (Deleted) -> 조회 안 됨 (X)
  - 취소된 일정 (Cancelled) -> 조회 안 됨 (X)
  - 시간 경계 (딱 붙은 일정) -> 조회 안 됨 (X)

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|겹치는 일정 반환 API |<img width="1167" height="753" alt="image" src="https://github.com/user-attachments/assets/76dc97f7-3166-4abb-ba3b-64dc7e14e7af" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 일정 충돌 확인 API가 추가되었습니다. 사용자가 지정한 날짜·시간 범위와 겹치는 활성 일정들을 조회해 충돌 여부(hasConflict)와 충돌 일정(id, 제목, 시작/종료 시각)을 반환합니다.
  * 요청 DTO(날짜/시작/종료 시간) 및 응답 DTO(충돌 여부·충돌 목록), 성공 상태 코드가 추가되었습니다.
* **문서/설명**
  * 일정 검증 주석에서 "수면 시간" 관련 언급이 제거되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->