### PR TITLE
Feat : 수면패턴 수정 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -173,4 +173,17 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._ROUTINE_UPDATED, null);
     }
 
+    @Operation(
+            summary = "마이페이지 수면패턴 수정",
+            description = "수면 패턴을 수정합니다."
+    )
+    @PatchMapping(value = "/mypage/sleep-pattern", produces = "application/json")
+    public ApiResponse<Object> updateSleepPattern(
+            @RequestBody @Valid OnboardingRequestDto.SleepPatternRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        userService.updateSleepPattern(request, user);
+        return ApiResponse.of(UserSuccessStatus._SLEEP_PATTERN_UPDATED, null);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -20,6 +20,7 @@ public enum UserSuccessStatus implements BaseCode {
     _ROUTINE_DELETED(HttpStatus.OK,"USER2008","반복일정 삭제가 완료되었습니다."),
     _ROUTINE_ADDED(HttpStatus.OK,"USER2009","반복일정 등록이 완료되었습니다."),
     _ROUTINE_UPDATED(HttpStatus.OK,"USER20010","반복일정 수정이 완료되었습니다."),
+    _SLEEP_PATTERN_UPDATED(HttpStatus.OK,"USER20011","수면 패턴 수정이 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/OnboardingServiceImpl.java
@@ -324,7 +324,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
 
-    private void validateSleepPattern(LocalTime sleepTime, LocalTime wakeTime) {
+    public static void validateSleepPattern(LocalTime sleepTime, LocalTime wakeTime) {
         // sleepTime과 wakeTime 사이의 시간 차이를 분 단위로 계산 (같은 날 기준 계산)
         long minutesDifference = Duration.between(sleepTime, wakeTime).toMinutes();
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -41,4 +41,6 @@ public interface UserService {
     void saveRoutine(OnboardingRequestDto.RoutineDTO request, User user);
 
     void updateRoutine(Long routineId, OnboardingRequestDto.RoutineDTO request, User user);
+
+    void updateSleepPattern(OnboardingRequestDto.SleepPatternRequest request, User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -458,4 +458,15 @@ public class UserServiceImpl implements UserService {
         // 2-3. 충돌 여부 검증
         timeUtil.validateTimeRangeConflicts(timeRanges,UserErrorStatus.ROUTINE_TIME_CONFLICT);
     }
+
+    // 마이페이지 - 수면패턴 수정
+    @Transactional
+    @Override
+    public void updateSleepPattern(OnboardingRequestDto.SleepPatternRequest request, User user) {
+        // 1. 수면패턴 검증 (최대 23시간)
+        OnboardingServiceImpl.validateSleepPattern(request.getSleepTime(), request.getWakeTime());
+
+        // 2. 수면패턴 업데이트ㅌ
+        user.updateSleepPattern(request.getSleepTime(), request.getWakeTime());
+    }
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#272
### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 온보딩과 마이페이지에서의 수면패턴 검증 로직이 동일해 validateSleepPattern 메소드 재사용을 할 수 있도록 public static으로 변경했습니다.
- 마이페이지 수면 패턴 수정에서는 온보딩 단계의 step 검증 로직을 제외하고 업데이트 로직만 수행하도록 설계했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
PATCH `/api/users/mypage/sleep-pattern`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 개인 페이지에서 수면 패턴을 수정할 수 있는 기능이 추가되었습니다. 새로운 API 엔드포인트를 통해 수면 시간과 기상 시간을 업데이트할 수 있으며, 수정 완료 시 확인 메시지를 받을 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->