### PR TITLE
Feat: 틈 요청 전송 시 충돌 확인 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/controller/TeumController.java
@@ -260,4 +260,19 @@ public class TeumController {
 
         return ApiResponse.of(TeumSuccessStatus._TEUM_CONFLICT_CHECK_SUCCESS, response);
     }
+
+    @Operation(
+            summary = "틈 요청 간 충돌 확인",
+            description = "지정한 날짜와 시간대에 겹치는 '내가 보낸 대기 중(ACTIVE)인 틈 요청' 목록을 반환합니다."
+    )
+    @GetMapping("/request/conflicts")
+    public ApiResponse<TeumResponseDto.ConflictingRequestResponse> checkConflictingRequests(
+            @Parameter(hidden = true) @CurrentUser User user,
+            @ParameterObject @Valid @ModelAttribute TeumRequestDto.ConflictCheckRequest request
+    ) {
+        TeumResponseDto.ConflictingRequestResponse response =
+                teumService.checkConflictingRequests(user.getId(), request);
+
+        return ApiResponse.of(TeumSuccessStatus._TEUM_CONFLICT_CHECK_SUCCESS, response);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -389,7 +389,7 @@ public class TeumConverter {
                         .id(schedule.getId())
                         .title(schedule.getTitle())
                         .startTime(schedule.getStartTime().toLocalTime().format(TIME_FORMATTER))
-                        .endTime(schedule.getEndTime().toLocalTime().format(TIME_FORMATTER))
+                        .endTime(formatEndTime(schedule.getEndTime().toLocalTime()))
                         .build())
                 .toList();
 

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -399,5 +399,23 @@ public class TeumConverter {
                 .build();
     }
 
+    // 충돌 틈 요청 리스트 응답 DTO 반환
+    public TeumResponseDto.ConflictingRequestResponse toConflictingRequestResponse(List<TeumRequest> requests) {
+        List<TeumResponseDto.ConflictingRequest> conflictDtos = requests.stream()
+                .map(req -> TeumResponseDto.ConflictingRequest.builder()
+                        .id(req.getId())
+                        .receiverNickname(req.getTeumResponses().getFirst().getReceiverUser().getNickname())
+                        .title(req.getTitle())
+                        .description(req.getDescription())
+                        .startTime(req.getStartTime().format(TIME_FORMATTER))
+                        .endTime(req.getEndTime().format(TIME_FORMATTER))
+                        .build())
+                .toList();
+
+        return TeumResponseDto.ConflictingRequestResponse.builder()
+                .hasConflict(!conflictDtos.isEmpty())
+                .conflictingRequests(conflictDtos)
+                .build();
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -404,11 +404,12 @@ public class TeumConverter {
         List<TeumResponseDto.ConflictingRequest> conflictDtos = requests.stream()
                 .map(req -> TeumResponseDto.ConflictingRequest.builder()
                         .id(req.getId())
-                        .receiverNickname(req.getTeumResponses().getFirst().getReceiverUser().getNickname())
+                        .receiverNickname(req.getTeumResponses().get(0).getReceiverUser().getNickname())
                         .title(req.getTitle())
                         .description(req.getDescription())
                         .startTime(req.getStartTime().format(TIME_FORMATTER))
-                        .endTime(req.getEndTime().format(TIME_FORMATTER))
+                        // [수정] 종료 시간 포맷팅 시 별도 메서드 사용
+                        .endTime(formatEndTime(req.getEndTime()))
                         .build())
                 .toList();
 
@@ -416,6 +417,15 @@ public class TeumConverter {
                 .hasConflict(!conflictDtos.isEmpty())
                 .conflictingRequests(conflictDtos)
                 .build();
+    }
+
+    // 종료 시간 포맷팅 헬퍼 메서드
+    // 00:00 -> 24:00
+    private String formatEndTime(LocalTime time) {
+        if (time.equals(LocalTime.MIDNIGHT)) {
+            return "24:00";
+        }
+        return time.format(TIME_FORMATTER);
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -299,5 +299,44 @@ public class TeumResponseDto {
         private String endTime;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "ConflictingRequestResponse : 틈 요청 충돌 응답을 감싸는 DTO")
+    public static class ConflictingRequestResponse {
+
+        @Schema(description = "충돌 여부 (true: 겹치는 틈 요청 있음, false: 없음)", example = "true")
+        private boolean hasConflict;
+
+        @Schema(description = "겹치는 틈 요청 목록 (충돌이 없으면 빈 리스트 반환)")
+        private List<ConflictingRequest> conflictingRequests;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "ConflictingRequest : 개별 충돌 요청 정보 DTO")
+    public static class ConflictingRequest {
+
+        @Schema(description = "틈 요청 ID", example = "5")
+        private Long id;
+
+        @Schema(description = "수신자 닉네임 (누구에게 보낸 요청인지)", example = "디자이너 수박")
+        private String receiverNickname;
+
+        @Schema(description = "틈 요청 제목", example = "디자인 회의")
+        private String title;
+
+        @Schema(description = "틈 요청 설명(멘트)", example = "이번 주 스프린트 UI 점검해요")
+        private String description;
+
+        @Schema(description = "시작 시간 (HH:mm)", example = "15:20")
+        private String startTime;
+
+        @Schema(description = "종료 시간 (HH:mm)", example = "16:10")
+        private String endTime;
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -61,16 +61,20 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
         JOIN FETCH tr.teumResponses tr_res
         JOIN FETCH tr_res.receiverUser
         WHERE tr.user.id = :userId
-          AND tr.status = :status  
+          AND tr.status = :status
           AND tr.date = :date
-          AND (tr.startTime < :checkEnd AND tr.endTime > :checkStart)
+          AND (
+              (tr.startTime < :checkEnd OR :checkEnd = :midnight)
+              AND (tr.endTime > :checkStart OR tr.endTime = :midnight)
+          )
     """)
     List<TeumRequest> findConflictingRequests(
             @Param("userId") Long userId,
             @Param("date") LocalDate date,
             @Param("checkStart") LocalTime checkStart,
             @Param("checkEnd") LocalTime checkEnd,
-            @Param("status") RequestStatus status
+            @Param("status") RequestStatus status,
+            @Param("midnight") LocalTime midnight
     );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumRequestRepository.java
@@ -4,9 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.entity.enums.RequestStatus;
 import umc.teumteum.server.domain.user.entity.User;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> {
@@ -47,5 +49,28 @@ public interface TeumRequestRepository extends JpaRepository<TeumRequest, Long> 
     );
 
     List<TeumRequest> findByDate(LocalDate date);
+
+    /**
+     * 충돌 스케줄 조회 조건:
+     * 1. 내가 보낸 요청일 것
+     * 2. ACTIVE 상태일 것
+     * 3. 시간이 겹칠 것 (등호 제외: 접하는 시간 허용)
+     */
+    @Query("""
+        SELECT DISTINCT tr FROM TeumRequest tr
+        JOIN FETCH tr.teumResponses tr_res
+        JOIN FETCH tr_res.receiverUser
+        WHERE tr.user.id = :userId
+          AND tr.status = :status  
+          AND tr.date = :date
+          AND (tr.startTime < :checkEnd AND tr.endTime > :checkStart)
+    """)
+    List<TeumRequest> findConflictingRequests(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date,
+            @Param("checkStart") LocalTime checkStart,
+            @Param("checkEnd") LocalTime checkEnd,
+            @Param("status") RequestStatus status
+    );
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumService.java
@@ -42,4 +42,5 @@ public interface TeumService {
 
     TeumResponseDto.ConflictingScheduleResponse checkConflictingSchedules(Long userId, TeumRequestDto.ConflictCheckRequest request);
 
+    TeumResponseDto.ConflictingRequestResponse checkConflictingRequests(Long userId, TeumRequestDto.ConflictCheckRequest request);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -606,6 +606,30 @@ public class TeumServiceImpl implements TeumService {
         return teumConverter.toConflictingScheduleResponse(conflicts);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public TeumResponseDto.ConflictingRequestResponse checkConflictingRequests(Long userId, TeumRequestDto.ConflictCheckRequest request) {
+        // 사용자 검증
+        validateUserExists(userId);
+
+        // 시간 순서 검증 (Start < End)
+        if (!request.getStartTime().isBefore(request.getEndTime())) {
+            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        }
+
+        // 겹치는 요청 조회 (ACTIVE 상태인 요청만)
+        List<TeumRequest> conflicts = teumRequestRepository.findConflictingRequests(
+                userId,
+                request.getDate(),
+                request.getStartTime(),
+                request.getEndTime(),
+                RequestStatus.ACTIVE
+        );
+
+        // 변환 및 반환
+        return teumConverter.toConflictingRequestResponse(conflicts);
+    }
+
 
     // 사용자가 해당 요청의 요청자 또는 응답자인지 여부
     private boolean isParticipant(TeumRequest req, Long userId) {

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -609,24 +609,21 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional(readOnly = true)
     public TeumResponseDto.ConflictingRequestResponse checkConflictingRequests(Long userId, TeumRequestDto.ConflictCheckRequest request) {
-        // 사용자 검증
         validateUserExists(userId);
 
-        // 시간 순서 검증 (Start < End)
-        if (!request.getStartTime().isBefore(request.getEndTime())) {
-            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
-        }
+        // 시간 순서 검증
+        validateTimeOrder(request.getStartTime(), request.getEndTime());
 
-        // 겹치는 요청 조회 (ACTIVE 상태인 요청만)
+        // 겹치는 요청 조회
         List<TeumRequest> conflicts = teumRequestRepository.findConflictingRequests(
                 userId,
                 request.getDate(),
                 request.getStartTime(),
-                request.getEndTime(),
-                RequestStatus.ACTIVE
+                request.getEndTime(), // 00:00 그대로 전달
+                RequestStatus.ACTIVE,
+                LocalTime.MIDNIGHT
         );
 
-        // 변환 및 반환
         return teumConverter.toConflictingRequestResponse(conflicts);
     }
 
@@ -759,6 +756,14 @@ public class TeumServiceImpl implements TeumService {
         LocalTime end = endTime.equals("00:00") ? LocalTime.MAX : LocalTime.parse(endTime);
 
         if (!start.isBefore(end)) {
+            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        }
+    }
+
+    private void validateTimeOrder(LocalTime startTime, LocalTime endTime) {
+        LocalTime effectiveEnd = endTime.equals(LocalTime.MIDNIGHT) ? LocalTime.MAX : endTime;
+
+        if (!startTime.isBefore(effectiveEnd)) {
             throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
         }
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -583,16 +583,19 @@ public class TeumServiceImpl implements TeumService {
     @Transactional(readOnly = true)
     public TeumResponseDto.ConflictingScheduleResponse checkConflictingSchedules(Long userId, TeumRequestDto.ConflictCheckRequest request) {
         validateUserExists(userId);
+        validateTimeOrder(request.getStartTime(), request.getEndTime());
 
-        if (!request.getStartTime().isBefore(request.getEndTime())) {
-            throw new GeneralException(TeumErrorStatus.INVALID_TEUM_TIME);
+        LocalDateTime checkStart = request.getDate().atTime(request.getStartTime());
+
+        // 종료 시간이 00:00이면 다음 날 00:00으로 설정
+        LocalDateTime checkEnd;
+        if (request.getEndTime().equals(LocalTime.MIDNIGHT)) {
+            checkEnd = request.getDate().plusDays(1).atStartOfDay();
+        } else {
+            checkEnd = request.getDate().atTime(request.getEndTime());
         }
 
-        // 입력받은 시간(LocalTime)을 날짜(LocalDate)와 합쳐 LocalDateTime으로 변환
-        LocalDateTime checkStart = request.getDate().atTime(request.getStartTime());
-        LocalDateTime checkEnd = request.getDate().atTime(request.getEndTime());
-
-        // Repository 조회
+        // Repository 조회 (기존 유지)
         List<Schedule> conflicts = scheduleRepository.findConflictingSchedules(
                 userId,
                 request.getDate(),
@@ -602,7 +605,6 @@ public class TeumServiceImpl implements TeumService {
                 RoutineStatus.DELETED
         );
 
-        // Converter를 통해 DTO 변환 후 반환
         return teumConverter.toConflictingScheduleResponse(conflicts);
     }
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 틈 요청 전송 시 충돌 확인 API (`GET /api/teums/request/conflicts`)를 구현
  - 충돌 기준: 시간이 완전히 겹치는 경우만 충돌로 간주 (맞물리는 경우는 충돌 아님)
  - 조회 대상: `ACTIVE` 상태인 요청만 조회하며, 취소하거나 마감된 요청은 반영 X

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 수신자 닉네임 반환시 `JOIN FETCH` 적용
- 리포지토리 쿼리에서 `ACTIVE` 문자열을 하드코딩하지 않고 파라미터로 받음

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|겹치는 틈 요청 반환|<img width="1173" height="559" alt="image" src="https://github.com/user-attachments/assets/a856779c-3f50-4c41-9892-297ed55877d6" />|
|시간 예외 처리|<img width="1162" height="303" alt="image" src="https://github.com/user-attachments/assets/349a56a3-26fd-470f-b8e0-9624582c2252" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 요청 간 시간 충돌 확인 기능 추가: 특정 날짜·시간대의 활성 요청들 사이에 겹치는 요청이 있는지 확인할 수 있습니다.
  * 충돌 결과는 충돌 여부(hasConflict)와 충돌 항목 목록(요청자, 제목, 설명, 시작/종료 시간 포함)으로 제공됩니다.
  * 종료 시간이 자정인 경우 "24:00"로 표기되는 등 시간 경계 처리를 반영합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->