### PR TITLE
Fix : 위시 투두 등록 수면패턴 유효성 검정 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/HomeServiceImpl.java
@@ -569,11 +569,15 @@ public class HomeServiceImpl implements HomeService {
             throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
         }
 
-        // 3 중복 스케줄 체크 -> 스케줄 중복 검사
+        // 3. 중복 검사
         LocalDate date = dto.getStartTime().toLocalDate();
         LocalDateTime startTime = dto.getStartTime();
         LocalDateTime endTime = dto.getEndTime();
 
+        // 3-1. 수면시간 충돌 체크
+        conflictValidator.validateWish(user, startTime, endTime);
+
+        // 3-2. 중복 스케줄 체크 -> 스케줄 중복 검사
         boolean hasConflict = scheduleRepository.existsConflictSchedule(
                 user.getId(), date, startTime, endTime
         );

--- a/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
+++ b/src/main/java/umc/teumteum/server/global/validator/ConflictValidator.java
@@ -63,6 +63,21 @@ public class ConflictValidator {
         checkWithSleepPattern(user,date,startTime,endTime);
     }
 
+    /**
+     * Wish 투두 등록시 중복 검증 로직
+     * - 수면패턴과 충돌 여부 검사
+     */
+    public void validateWish(User user, LocalDateTime startTime, LocalDateTime endTime) {
+        LocalDate startDate = startTime.toLocalDate();
+        LocalDate endDate = endTime.toLocalDate();
+
+        checkWithSleepPattern(user,startDate,startTime,endTime);
+
+        // 일정이 날짜를 넘기는 경우, 종료 날짜 기준 수면 패턴 검사
+        if(!startDate.equals(endDate)){
+            checkWithSleepPattern(user,endDate,startTime,endTime);
+        }
+    }
 
     // 내부 충돌 검사 메서드들
     private void checkWithSchedules(User user, LocalDateTime requestStart, LocalDateTime requestEnd) {


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#287 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
위시 투두 등록시 수면패턴 유효성 검증을 추가했습니다.
ConflictValidator 클래스에 validateWish 메소드를 추가해서 수면패턴과 충돌 여부를 검사하도록 로직을 구분했습니다.


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
POST `/api/wishes/{wishId}/assign`
수면패턴과 충돌시 등록되지 않는지

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 할 일 할당 시 수면 시간 겹침 검증 단계가 추가되었습니다.
  * 기존 일정 충돌 검사 전에 수면 패턴 검증이 먼저 수행되도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->