### PR TITLE
Feat : 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/fcm/repository/FcmTokenRepository.java
@@ -4,6 +4,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import umc.teumteum.server.domain.fcm.entity.FcmToken;
 import umc.teumteum.server.domain.user.entity.User;
@@ -18,4 +19,8 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
   @Query("SELECT t FROM FcmToken t WHERE t.isActive = true AND t.user IN :users")
   List<FcmToken> findActiveTokensByUsers(@Param("users") List<User> users);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM FcmToken t WHERE t.user.id = :userId")
+  void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/repository/BlockRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/BlockRepository.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.friend.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.friend.entity.Block;
@@ -20,4 +21,9 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     // 목록 조회: 내가 차단한 목록을 페이징(Slice)으로 조회
     @Query("SELECT b FROM Block b JOIN FETCH b.blocked WHERE b.blocker.id = :blockerId")
     Slice<Block> findByBlockerId(@Param("blockerId") Long blockerId, Pageable pageable);
+
+    // 삭제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Block b WHERE b.blocker.id = :userId or b.blocked.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
@@ -36,4 +36,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             "WHERE (f.follower = :user1 AND f.following = :user2) " +
             "OR (f.follower = :user2 AND f.following = :user1)")
     void deleteFriendshipsBetween(@Param("user1") User user1, @Param("user2") User user2);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Friend f WHERE f.follower.id = :userId OR f.following.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
+++ b/src/main/java/umc/teumteum/server/domain/home/entity/Schedule.java
@@ -91,7 +91,7 @@ public class Schedule extends BaseEntity {
     /*
         양방향 연관관계
     */
-    @OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ScheduleReminder> scheduleReminders = new ArrayList<>();
 
     public void updateField(HomeRequestDto.TodoRequestDto dto) {

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleReminderRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleReminderRepository.java
@@ -1,6 +1,9 @@
 package umc.teumteum.server.domain.home.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 
 import java.util.List;
@@ -9,4 +12,8 @@ public interface ScheduleReminderRepository extends JpaRepository<ScheduleRemind
     List<ScheduleReminder> findByScheduleId(Long scheduleId);
     void deleteByScheduleId(Long scheduleId);
     List<ScheduleReminder> findByScheduleIdIn(List<Long> scheduleIds);
+
+    @Modifying(clearAutomatically = true,flushAutomatically = true)
+    @Query("DELETE FROM ScheduleReminder sr WHERE sr.schedule.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -354,4 +354,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     // 루틴Id로 스케줄 조회
     List<Schedule> findByRoutineId(Long routineId);
+
+    // userId로 스케줄 조회
+    List<Schedule> findByUserId(Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -355,6 +355,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 루틴Id로 스케줄 조회
     List<Schedule> findByRoutineId(Long routineId);
 
-    // userId로 스케줄 조회
-    List<Schedule> findByUserId(Long userId);
+    @Modifying(clearAutomatically = true,flushAutomatically = true)
+    @Query("DELETE FROM Schedule s WHERE s.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishCategoryRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishCategoryRepository.java
@@ -1,7 +1,13 @@
 package umc.teumteum.server.domain.home.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.mapping.WishCategory;
 
 public interface WishCategoryRepository extends JpaRepository<WishCategory, Long> {
+    @Modifying(clearAutomatically = true,flushAutomatically = true)
+    @Query("DELETE FROM WishCategory wc WHERE wc.wish.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -38,4 +38,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
         "WHERE w.user = :user AND LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
     List<Wish> findByUserAndCategoryLike(User user, String categoryName);
 
+    // userId로 조회
+    List<Wish> findByUserId(Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/WishRepository.java
@@ -3,7 +3,9 @@ package umc.teumteum.server.domain.home.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.home.entity.Wish;
 import umc.teumteum.server.domain.home.entity.enums.EstimatedDuration;
 import umc.teumteum.server.domain.user.entity.User;
@@ -38,6 +40,7 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
         "WHERE w.user = :user AND LOWER(c.name) LIKE LOWER(CONCAT('%', :categoryName, '%'))")
     List<Wish> findByUserAndCategoryLike(User user, String categoryName);
 
-    // userId로 조회
-    List<Wish> findByUserId(Long userId);
+    @Modifying(clearAutomatically = true,flushAutomatically = true)
+    @Query("DELETE FROM Wish w WHERE w.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/repository/NotificationRepository.java
@@ -3,9 +3,16 @@ package umc.teumteum.server.domain.notification.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.notification.entity.Notification;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
   Slice<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("DELETE FROM Notification n WHERE n.user.id = :userId")
+  void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -34,7 +34,7 @@ public class TeumConverter {
 
     private final TimeUtil timeUtil;
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-
+    private static final String WITHDRAWN_USER_NICKNAME = "탈퇴한 사용자";
     public TeumRequest toTeumRequest(TeumRequestDto.TeumRequest dto, User sender) {
         return TeumRequest.builder()
                 .title(dto.getTitle())
@@ -431,8 +431,11 @@ public class TeumConverter {
 
     // 회원 익명화 헬퍼 메서드
     private String maskedNickName(User user){
+        if(user == null){
+            return WITHDRAWN_USER_NICKNAME;
+        }
         if(user.getStatus() == UserStatus.INACTIVE){
-            return "탈퇴한 사용자";
+            return WITHDRAWN_USER_NICKNAME;
         }
         return user.getNickname();
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -13,6 +13,7 @@ import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.exception.status.TeumErrorStatus;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.global.exception.GeneralException;
 import umc.teumteum.server.global.util.TimeUtil;
 
@@ -92,7 +93,7 @@ public class TeumConverter {
                 .receiverCount(request.getTeumResponses().size())
                 .senderUser(ParticipantDto.builder()
                         .userId(sender.getId())
-                        .nickname(sender.getNickname())
+                        .nickname(maskedNickName(sender))
                         .profileImageUrl(senderProfileImageUrl)
                         .build())
                 .date(request.getDate().toString())
@@ -271,7 +272,7 @@ public class TeumConverter {
                 .participants(relatedSchedules.stream()
                         .map(s -> {
                             var u = s.getUser();
-                            return new ParticipantDto(u.getId(), u.getNickname(), profileUrlByUserId.get(u.getId()));
+                            return new ParticipantDto(u.getId(), maskedNickName(u), profileUrlByUserId.get(u.getId()));
                         })
                         .collect(Collectors.toList()))
                 .build();
@@ -377,7 +378,7 @@ public class TeumConverter {
     private ParticipantDto toParticipantDto(User user, String profileImageUrl) {
         return ParticipantDto.builder()
                 .userId(user.getId())
-                .nickname(user.getNickname())
+                .nickname(maskedNickName(user))
                 .profileImageUrl(profileImageUrl)
                 .build();
     }
@@ -404,7 +405,7 @@ public class TeumConverter {
         List<TeumResponseDto.ConflictingRequest> conflictDtos = requests.stream()
                 .map(req -> TeumResponseDto.ConflictingRequest.builder()
                         .id(req.getId())
-                        .receiverNickname(req.getTeumResponses().get(0).getReceiverUser().getNickname())
+                        .receiverNickname(maskedNickName(req.getTeumResponses().get(0).getReceiverUser()))
                         .title(req.getTitle())
                         .description(req.getDescription())
                         .startTime(req.getStartTime().format(TIME_FORMATTER))
@@ -426,6 +427,14 @@ public class TeumConverter {
             return "24:00";
         }
         return time.format(TIME_FORMATTER);
+    }
+
+    // 회원 익명화 헬퍼 메서드
+    private String maskedNickName(User user){
+        if(user.getStatus() == UserStatus.INACTIVE){
+            return "탈퇴한 사용자";
+        }
+        return user.getNickname();
     }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -82,7 +82,7 @@ public class TeumServiceImpl implements TeumService {
         User receiver = getUserOrThrow(dto.getReceiverUserId());
 
         // 수신자가 ACTIVE 유저인지 검증
-        validActiveUser(receiver.getId());
+        validActiveUser(receiver);
 
         // 차단 관계 검증 (요청자 <-> 수신자)
         validateBlockRelationship(user, receiver);
@@ -122,7 +122,7 @@ public class TeumServiceImpl implements TeumService {
     @Transactional
     public Long createResendRequest(Long parentRequestId, TeumRequestDto.TeumResend dto, User user) {
       // 재요청자 ACTIVE 검증
-      validActiveUser(user.getId());
+      validActiveUser(user);
 
       // 원본 요청 확인 및 권한 검증
         TeumRequest parent = findActiveRequestOrThrow(parentRequestId);
@@ -141,7 +141,7 @@ public class TeumServiceImpl implements TeumService {
         validateStartTimeNotPast(date, startTime);
 
         User originalSender = parent.getUser();  // 부모 요청의 작성자 → 이번 재요청의 수신자
-        validActiveUser(originalSender.getId()); // 기존 요청자가 ACTIVE인지 검증
+        validActiveUser(originalSender); // 기존 요청자가 ACTIVE인지 검증
 
         // 차단 관계 검증 (재요청자 <-> 기존 요청자)
         validateBlockRelationship(user, originalSender);
@@ -711,11 +711,8 @@ public class TeumServiceImpl implements TeumService {
     /**
      * 사용자가 INACTIVE인 경우 USER_NOT_FOUND 에러를 발생시킵니다.
      */
-    private void validActiveUser(Long userId) {
-        User u = userRepository.findById(userId)
-                .orElseThrow(()-> new GlobalHandler(UserErrorStatus.USER_NOT_FOUND));
-
-        if(u.getStatus() == UserStatus.INACTIVE){
+    private void validActiveUser(User user) {
+        if(user.getStatus() == UserStatus.INACTIVE){
             throw new GlobalHandler(UserErrorStatus.USER_DELETED);
         }
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -26,6 +26,7 @@ import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
 import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
@@ -80,6 +81,9 @@ public class TeumServiceImpl implements TeumService {
         // 수신자 조회 (단일 사용자)
         User receiver = getUserOrThrow(dto.getReceiverUserId());
 
+        // 수신자가 ACTIVE 유저인지 검증
+        validActiveUser(receiver.getId());
+
         // 차단 관계 검증 (요청자 <-> 수신자)
         validateBlockRelationship(user, receiver);
 
@@ -117,7 +121,10 @@ public class TeumServiceImpl implements TeumService {
     @Override
     @Transactional
     public Long createResendRequest(Long parentRequestId, TeumRequestDto.TeumResend dto, User user) {
-        // 원본 요청 확인 및 권한 검증
+      // 재요청자 ACTIVE 검증
+      validActiveUser(user.getId());
+
+      // 원본 요청 확인 및 권한 검증
         TeumRequest parent = findActiveRequestOrThrow(parentRequestId);
         validateResendableRequest(parent);
         validateResender(parent, user.getId());
@@ -134,6 +141,7 @@ public class TeumServiceImpl implements TeumService {
         validateStartTimeNotPast(date, startTime);
 
         User originalSender = parent.getUser();  // 부모 요청의 작성자 → 이번 재요청의 수신자
+        validActiveUser(originalSender.getId()); // 기존 요청자가 ACTIVE인지 검증
 
         // 차단 관계 검증 (재요청자 <-> 기존 요청자)
         validateBlockRelationship(user, originalSender);
@@ -697,6 +705,18 @@ public class TeumServiceImpl implements TeumService {
     private void validateUserExists(Long userId) {
         if (!userRepository.existsById(userId)) {
             throw new GlobalHandler(UserErrorStatus.USER_NOT_FOUND);
+        }
+    }
+
+    /**
+     * 사용자가 INACTIVE인 경우 USER_NOT_FOUND 에러를 발생시킵니다.
+     */
+    private void validActiveUser(Long userId) {
+        User u = userRepository.findById(userId)
+                .orElseThrow(()-> new GlobalHandler(UserErrorStatus.USER_NOT_FOUND));
+
+        if(u.getStatus() == UserStatus.INACTIVE){
+            throw new GlobalHandler(UserErrorStatus.USER_DELETED);
         }
     }
 

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.auth.service.AuthService;
 import umc.teumteum.server.domain.user.dto.OnboardingRequestDto;
 import umc.teumteum.server.domain.user.dto.OnboardingResponseDto;
 import umc.teumteum.server.domain.user.dto.UserRequestDto;
@@ -29,6 +30,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final AuthService authService;
 
     @Operation(
             summary = "닉네임 사용자 검색",
@@ -217,8 +219,10 @@ public class UserController {
     )
     @DeleteMapping(value = "/mypage", produces = "application/json")
     public ApiResponse<Object> deleteUser(
+            HttpServletRequest httpServletRequest,
             @CurrentUser @Parameter(hidden = true) User user
     ){
+        authService.logout(httpServletRequest, user);
         userService.deleteUser(user);
         return ApiResponse.of(UserSuccessStatus._USER_DELETED, null);
     }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -199,7 +199,7 @@ public class UserController {
     }
 
     @Operation(
-            summary = "마페이지 리마인드 알림 수정",
+            summary = "마이페이지 리마인드 알림 수정",
             description = "마이페이지에서 리마인드 알림을 수정합니다. 등록하려는 정보가 없을 경우 빈배열로 호출합니다."
     )
     @PatchMapping(value = "/mypage/reminders", produces = "application/json")
@@ -209,5 +209,17 @@ public class UserController {
     ){
         userService.updateReminders(request, user);
         return ApiResponse.of(UserSuccessStatus._REMIND_ALARM_UPDATED, null);
+    }
+
+    @Operation(
+            summary = "마이페이지 회원 탈퇴",
+            description = "마이페이지에서 회원을 탈퇴합니다."
+    )
+    @DeleteMapping(value = "/mypage", produces = "application/json")
+    public ApiResponse<Object> deleteUser(
+            @CurrentUser @Parameter(hidden = true) User user
+    ){
+        userService.deleteUser(user);
+        return ApiResponse.of(UserSuccessStatus._USER_DELETED, null);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -16,6 +16,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -157,5 +159,24 @@ public class User extends BaseEntity {
         this.nickname = nickname;
         this.job = jobField;
         this.timePublic = timePublic;
+    }
+
+    // 회원 탈퇴
+    public void withdraw(){
+        this.status = UserStatus.INACTIVE;
+        this.inactiveAt = LocalDateTime.now();
+
+        String token = UUID.randomUUID().toString();
+
+        this.socialId = "deleted-" + this.id + "-" + token;
+        this.email = "deleted-" + this.id + "-" + token + "@deleted.local";
+
+        this.nickname = "탈퇴회원-" + this.id + "-" + token.substring(0, 8);
+        this.sleepTime = null;
+        this.wakeTime = null;
+        this.job = null;
+        this.timePublic = false;
+
+        this.profileImageName = DEFAULT_PROFILE_IMAGE;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserErrorStatus.java
@@ -14,6 +14,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4040", "존재하지 않는 사용자입니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041","사용자의 알림 설정 정보를 찾을 수 없습니다."),
     ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND,"USER4042","사용자의 반복일정 정보를 찾을 수 없습니다."),
+    USER_DELETED(HttpStatus.NOT_FOUND,"USER4043","탈퇴한 사용자입니다."),
 
 
     // 사용자 온보딩

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -23,6 +23,7 @@ public enum UserSuccessStatus implements BaseCode {
     _SLEEP_PATTERN_UPDATED(HttpStatus.OK,"USER20011","수면 패턴 수정이 완료되었습니다."),
     _REMIND_ALARM_LOADED(HttpStatus.OK,"USER20012","리마인드 알림 설정 조회가 완료되었습니다."),
     _REMIND_ALARM_UPDATED(HttpStatus.OK,"USER20013","리마인드 알림 설정 수정이 완료되었습니다."),
+    _USER_DELETED(HttpStatus.OK,"USER20014","회원 탈퇴가 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/AgreementRepository.java
@@ -1,6 +1,9 @@
 package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.user.entity.Agreement;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -10,4 +13,8 @@ public interface AgreementRepository extends JpaRepository<Agreement, Long> {
     Optional<Agreement> findByUser(User user);
 
     boolean existsByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Agreement a WHERE a.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/NotificationSettingRepository.java
@@ -1,6 +1,9 @@
 package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.user.entity.NotificationSetting;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -8,4 +11,8 @@ import java.util.Optional;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
     Optional<NotificationSetting> findByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM NotificationSetting ns WHERE ns.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RemindAlarmRepository.java
@@ -1,16 +1,21 @@
 package umc.teumteum.server.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.user.entity.RemindAlarm;
 import umc.teumteum.server.domain.user.entity.User;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 public interface RemindAlarmRepository extends JpaRepository<RemindAlarm, Long> {
-    Optional<RemindAlarm> findByUser(User user);
     List<RemindAlarm> findAllByUser(User user);
     boolean existsByUser(User user);
     void deleteByUserAndMinutesBeforeIn(User user, Collection<Integer> minutesBeforeList);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RemindAlarm ra WHERE ra.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/RoutineRepository.java
@@ -22,4 +22,8 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     @Query("select r from Routine r where r.weekday = :weekday")
     List<Routine> findByWeekday(@Param("weekday") Weekday weekday);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Routine r WHERE r.user.id = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -47,4 +47,6 @@ public interface UserService {
     UserResponseDTO.RemindAlarmList getReminders(User user);
 
     void updateReminders(OnboardingRequestDto.RemindAlarmList request, User user);
+
+    void deleteUser(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -555,7 +555,10 @@ public class UserServiceImpl implements UserService {
         // 1. 유저 관련 데이터 삭제
         userDataCleaner.clean(u.getId());
 
-        // 2. 유저 익명화
+        // 2. 프로필 이미지 삭제
+        deleteProfileImage(user);
+
+        // 3. 유저 익명화
         u.withdraw();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -558,7 +558,7 @@ public class UserServiceImpl implements UserService {
         userDataCleaner.clean(u.getId());
 
         // 2. 프로필 이미지 삭제
-        deleteUserImage(user);
+        deleteUserImage(u);
 
         // 3. 유저 익명화
         u.withdraw();

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -543,4 +543,17 @@ public class UserServiceImpl implements UserService {
             remindAlarmJdbcRepository.batchInsertRemindAlarms(alarmsToAdd);
         }
     }
+
+    // 회원탈퇴
+    @Transactional
+    @Override
+    public void deleteUser(User user) {
+        User u = userRepository.findById(user.getId())
+                .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
+
+        // 1. 유저 관련 데이터 삭제
+
+        // 2. 유저 익명화
+        user.withdraw();
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,7 @@ import umc.teumteum.server.global.jwt.JwtProvider;
 import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.global.util.TimeUtil;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
@@ -565,7 +567,6 @@ public class UserServiceImpl implements UserService {
     /**
      * 유저 프로필 삭제 헬퍼 메서드
      */
-    @Transactional
     public void deleteUserImage(User user) {
 
         String oldFileName = user.getProfileImageName();
@@ -576,7 +577,11 @@ public class UserServiceImpl implements UserService {
         }
 
         // 2. 기존 객체 삭제
-        s3Util.deleteObject("profile/" + oldFileName);
+        try{
+            s3Util.deleteObject("profile/" + oldFileName);
+        } catch(Exception e){
+            log.warn("S3 profile delete failed. userId={}, file={}", user.getId(), oldFileName, e);
+        }
 
         // 3. DB 저장 키 교체 (S3 Key -> default)
         user.updateProfileImageName(DEFAULT_IMAGE);

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -556,9 +556,29 @@ public class UserServiceImpl implements UserService {
         userDataCleaner.clean(u.getId());
 
         // 2. 프로필 이미지 삭제
-        deleteProfileImage(user);
+        deleteUserImage(user);
 
         // 3. 유저 익명화
         u.withdraw();
+    }
+
+    /**
+     * 유저 프로필 삭제 헬퍼 메서드
+     */
+    @Transactional
+    public void deleteUserImage(User user) {
+
+        String oldFileName = user.getProfileImageName();
+
+        // 1. default 이미지 -> 삭제하지 않고 통과
+        if(oldFileName == null || oldFileName.equals(DEFAULT_IMAGE)){
+            return;
+        }
+
+        // 2. 기존 객체 삭제
+        s3Util.deleteObject("profile/" + oldFileName);
+
+        // 3. DB 저장 키 교체 (S3 Key -> default)
+        user.updateProfileImageName(DEFAULT_IMAGE);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -53,6 +53,7 @@ import umc.teumteum.server.domain.user.repository.RemindAlarmJdbcRepository;
 import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
 import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.domain.user.util.UserDataCleaner;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.dto.TimeRange;
 import umc.teumteum.server.global.jwt.JwtProvider;
@@ -68,16 +69,16 @@ public class UserServiceImpl implements UserService {
     private final NotificationSettingRepository notificationSettingRepository;
     private final S3Util s3Util;
     private final JwtProvider jwtProvider;
-
-    @Resource(name = "profileImageRedisTemplate")
-    private RedisTemplate<String, String> profileImageRedisTemplate;
-
     private final RoutineRepository routineRepository;
     private final TimeUtil timeUtil;
     private final ScheduleRepository scheduleRepository;
     private final RemindAlarmRepository remindAlarmRepository;
     private final ScheduleReminderRepository scheduleReminderRepository;
     private final RemindAlarmJdbcRepository remindAlarmJdbcRepository;
+    private final UserDataCleaner userDataCleaner;
+
+    @Resource(name = "profileImageRedisTemplate")
+    private RedisTemplate<String, String> profileImageRedisTemplate;
 
     private static final Set<Integer> ALLOWED_REMIND_ALARM_VALUES = Set.of(1, 3, 5, 10, 30);
 
@@ -552,8 +553,10 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
 
         // 1. 유저 관련 데이터 삭제
+        userDataCleaner.clean(u.getId());
 
         // 2. 유저 익명화
-        user.withdraw();
+        u.withdraw();
+        userRepository.save(u);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -557,6 +557,5 @@ public class UserServiceImpl implements UserService {
 
         // 2. 유저 익명화
         u.withdraw();
-        userRepository.save(u);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/util/UserDataCleaner.java
+++ b/src/main/java/umc/teumteum/server/domain/user/util/UserDataCleaner.java
@@ -8,9 +8,12 @@ import umc.teumteum.server.domain.friend.repository.BlockRepository;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.home.repository.WishCategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.notification.repository.NotificationRepository;
+import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.AgreementRepository;
 import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
 import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
@@ -22,8 +25,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserDataCleaner {
     private final ScheduleRepository scheduleRepository;
-    private final WishRepository wishRepository;
+    private final ScheduleReminderRepository scheduleReminderRepository;
 
+    private final WishRepository wishRepository;
+    private final WishCategoryRepository wishCategoryRepository;
     private final BlockRepository blockRepository;
     private final FriendRepository friendRepository;
 
@@ -38,15 +43,11 @@ public class UserDataCleaner {
     @Transactional
     public void clean(Long userId) {
         // 1. 스케줄 & 스케줄 리마인드
-        List<Schedule> schedules = scheduleRepository.findByUserId(userId);
-        if(!schedules.isEmpty()){
-            scheduleRepository.deleteAll(schedules);
-        }
-        // 2. 위시
-        List<Wish> wishes = wishRepository.findByUserId(userId);
-        if(!wishes.isEmpty()){
-            wishRepository.deleteAll(wishes);
-        }
+        scheduleReminderRepository.deleteAllByUserId(userId);
+        scheduleRepository.deleteAllByUserId(userId);
+        // 2. 위시 & 위시카테고리
+        wishCategoryRepository.deleteAllByUserId(userId);
+        wishRepository.deleteAllByUserId(userId);
         // 3. 차단
         blockRepository.deleteAllByUserId(userId);
         // 4. 친구

--- a/src/main/java/umc/teumteum/server/domain/user/util/UserDataCleaner.java
+++ b/src/main/java/umc/teumteum/server/domain/user/util/UserDataCleaner.java
@@ -1,0 +1,67 @@
+package umc.teumteum.server.domain.user.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.fcm.repository.FcmTokenRepository;
+import umc.teumteum.server.domain.friend.repository.BlockRepository;
+import umc.teumteum.server.domain.friend.repository.FriendRepository;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.Wish;
+import umc.teumteum.server.domain.home.repository.ScheduleRepository;
+import umc.teumteum.server.domain.home.repository.WishRepository;
+import umc.teumteum.server.domain.notification.repository.NotificationRepository;
+import umc.teumteum.server.domain.user.repository.AgreementRepository;
+import umc.teumteum.server.domain.user.repository.NotificationSettingRepository;
+import umc.teumteum.server.domain.user.repository.RemindAlarmRepository;
+import umc.teumteum.server.domain.user.repository.RoutineRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserDataCleaner {
+    private final ScheduleRepository scheduleRepository;
+    private final WishRepository wishRepository;
+
+    private final BlockRepository blockRepository;
+    private final FriendRepository friendRepository;
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final RoutineRepository routineRepository;
+    private final RemindAlarmRepository remindAlarmRepository;
+    private final AgreementRepository agreementRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+
+    @Transactional
+    public void clean(Long userId) {
+        // 1. 스케줄 & 스케줄 리마인드
+        List<Schedule> schedules = scheduleRepository.findByUserId(userId);
+        if(!schedules.isEmpty()){
+            scheduleRepository.deleteAll(schedules);
+        }
+        // 2. 위시
+        List<Wish> wishes = wishRepository.findByUserId(userId);
+        if(!wishes.isEmpty()){
+            wishRepository.deleteAll(wishes);
+        }
+        // 3. 차단
+        blockRepository.deleteAllByUserId(userId);
+        // 4. 친구
+        friendRepository.deleteAllByUserId(userId);
+        // 5. 알림
+        notificationRepository.deleteAllByUserId(userId);
+        // 6. 알림 설정
+        notificationSettingRepository.deleteAllByUserId(userId);
+        // 7. 루틴
+        routineRepository.deleteAllByUserId(userId);
+        // 8. 리마인드 알림
+        remindAlarmRepository.deleteAllByUserId(userId);
+        // 9. 동의
+        agreementRepository.deleteAllByUserId(userId);
+        // 10. fcm 토큰
+        fcmTokenRepository.deleteAllByUserId(userId);
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#286 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
회원 탈퇴는 로그아웃 → 관련 데이터 삭제 → 유저 익명화의 3단계로 처리됩니다.
- 회원 탈퇴 시 유저 관련 활동 데이터 삭제
  - 스케줄, 위시, 루틴, 리마인드 알림, 친구/차단, 알림, FCM 토큰 등 관련 데이터 삭제
- 유저 익명화 처리
  - status를 INACTIVE로 변경
  - 개인정보 삭제 후 기본 프로필 이미지로 변경
- 탈퇴 후 틈(Teum) 도메인 후속 처리
  - 틈 요청/재요청 생성 시 수신자가 INACTIVE인 경우 생성 불가
  - 관련 조회 응답에서 탈퇴 유저 닉네임 마스킹 처리


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
DELETE `users/mypage`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴 API(마이페이지 삭제) 및 자동 로그아웃 처리 추가
  * 회원 삭제 서비스와 전용 데이터 정리 컴포넌트(UserDataCleaner) 도입
  * 사용자 관련 데이터 일괄 삭제 기능(여러 엔티티 대상) 추가

* **동작 변경 / 안정성**
  * 탈퇴(비활성) 사용자 익명화(닉네임 등) 적용
  * 비활성 사용자 요청 차단 검증 추가
  * 일정 하위 알림의 고아 엔티티 자동 제거 활성화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->