### PR TITLE
[Feat] 틈 요청 충돌 확인 API 응답 데이터 확장

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -401,17 +401,24 @@ public class TeumConverter {
     }
 
     // 충돌 틈 요청 리스트 응답 DTO 반환
-    public TeumResponseDto.ConflictingRequestResponse toConflictingRequestResponse(List<TeumRequest> requests) {
+    public TeumResponseDto.ConflictingRequestResponse toConflictingRequestResponse(
+            List<TeumRequest> requests,
+            Map<Long, String> profileUrlMap // 각 유저 ID별 프로필 URL 맵 추가
+    ) {
         List<TeumResponseDto.ConflictingRequest> conflictDtos = requests.stream()
-                .map(req -> TeumResponseDto.ConflictingRequest.builder()
-                        .id(req.getId())
-                        .receiverNickname(maskedNickName(req.getTeumResponses().get(0).getReceiverUser()))
-                        .title(req.getTitle())
-                        .description(req.getDescription())
-                        .startTime(req.getStartTime().format(TIME_FORMATTER))
-                        // [수정] 종료 시간 포맷팅 시 별도 메서드 사용
-                        .endTime(formatEndTime(req.getEndTime()))
-                        .build())
+                .map(req -> {
+                    User receiver = req.getTeumResponses().get(0).getReceiverUser(); // 수신자 추출
+
+                    return TeumResponseDto.ConflictingRequest.builder()
+                            .id(req.getId())
+                            .receiverNickname(maskedNickName(receiver)) // 닉네임 유지
+                            .receiverProfileImageUrl(profileUrlMap.get(receiver.getId())) // 프로필 이미지 추가
+                            .title(req.getTitle())
+                            .description(req.getDescription())
+                            .startTime(req.getStartTime().format(TIME_FORMATTER))
+                            .endTime(formatEndTime(req.getEndTime()))
+                            .build();
+                })
                 .toList();
 
         return TeumResponseDto.ConflictingRequestResponse.builder()

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -326,6 +326,9 @@ public class TeumResponseDto {
         @Schema(description = "수신자 닉네임 (누구에게 보낸 요청인지)", example = "디자이너 수박")
         private String receiverNickname;
 
+        @Schema(description = "수신자 프로필 이미지 URL", example = "https://example.com")
+        private String receiverProfileImageUrl;
+
         @Schema(description = "틈 요청 제목", example = "디자인 회의")
         private String title;
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -653,7 +653,16 @@ public class TeumServiceImpl implements TeumService {
                 LocalTime.MIDNIGHT
         );
 
-        return teumConverter.toConflictingRequestResponse(conflicts);
+        Map<Long, String> profileUrlMap = conflicts.stream()
+                .map(req -> req.getTeumResponses().get(0).getReceiverUser()) // 수신자 추출
+                .distinct()
+                .collect(Collectors.toMap(
+                        User::getId,
+                        this::toProfileUrl, // S3 Presigned URL 생성
+                        (existing, replacement) -> existing
+                ));
+
+        return teumConverter.toConflictingRequestResponse(conflicts, profileUrlMap);
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -654,11 +654,12 @@ public class TeumServiceImpl implements TeumService {
         );
 
         Map<Long, String> profileUrlMap = conflicts.stream()
-                .map(req -> req.getTeumResponses().get(0).getReceiverUser()) // 수신자 추출
-                .distinct()
+                .flatMap(req -> req.getTeumResponses().stream()) // 모든 응답 스트림으로 평탄화
+                .map(TeumResponse::getReceiverUser)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toMap(
                         User::getId,
-                        this::toProfileUrl, // S3 Presigned URL 생성
+                        this::toProfileUrl,
                         (existing, replacement) -> existing
                 ));
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#296 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 틈 요청 충돌 확인 API에서 프로필 이미지를 응답에 추가함

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

- `ConflictingRequest` DTO에 수신자 프로필 이미지(`receiverProfileImageUrl`) 필드 추가
- `TeumConverter`에서 `profileUrlMap`을 통해 이미지 URL 매핑 로직 구현
- `TeumServiceImpl`에서 충돌 대상자들의 Presigned URL 생성 로직 추가

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 충돌하는 팀 요청 목록에 요청 수신자의 프로필 이미지가 함께 표시됩니다.
  * 기존 수신자 닉네임 표기는 유지되며, 요청별 제목·설명·시간 정보와 함께 프로필 이미지로 식별이 더 쉬워집니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->