### PR TITLE
[Feat] 신고 알림 Discord Webhook 연동

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -16,6 +16,7 @@ import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.infra.discord.service.DiscordService;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,8 @@ public class ReportServiceImpl implements ReportService {
     private final ReportReasonRepository reportReasonRepository;
     private final UserRepository userRepository;
     private final TeumRequestRepository teumRequestRepository;
+
+    private final DiscordService discordService;
 
     @Override
     public void createReport(User reporter, ReportRequestDto.CreateReport request) {
@@ -60,10 +63,16 @@ public class ReportServiceImpl implements ReportService {
             throw new ReportException(ReportErrorStatus.REPORT_INVALID_TARGET_TYPE);
         }
 
-        // Report 생성
+        // Report 생성 및 저장
         Report newReport = ReportConverter.toReport(reporter, request, reason, targetUser, targetTeum);
+        Report savedReport = reportRepository.save(newReport);
 
-        // 저장
-        reportRepository.save(newReport);
+        // 디스코드 알림 발송
+        discordService.sendReportNotification(
+                savedReport.getId(),
+                savedReport.getTargetType().name(),
+                request.getTargetId(),
+                reason.getTitle()
+        );
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -71,7 +71,6 @@ public class ReportServiceImpl implements ReportService {
         discordService.sendReportNotification(
                 savedReport.getId(),
                 savedReport.getTargetType().name(),
-                request.getTargetId(),
                 reason.getTitle()
         );
     }

--- a/src/main/java/umc/teumteum/server/global/infra/discord/dto/DiscordMessageDto.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/dto/DiscordMessageDto.java
@@ -1,0 +1,29 @@
+package umc.teumteum.server.global.infra.discord.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class DiscordMessageDto {
+    private List<Embed> embeds;
+
+    @Getter
+    @Builder
+    public static class Embed {
+        private String title;
+        private String description;
+        private int color;
+        private List<Field> fields;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class Field {
+        private String name;
+        private String value;
+        private boolean inline;
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordService.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordService.java
@@ -1,0 +1,5 @@
+package umc.teumteum.server.global.infra.discord.service;
+
+public interface DiscordService {
+    void sendReportNotification(Long reportId, String targetType, Long targetId, String reasonTitle);
+}

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordService.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordService.java
@@ -1,5 +1,5 @@
 package umc.teumteum.server.global.infra.discord.service;
 
 public interface DiscordService {
-    void sendReportNotification(Long reportId, String targetType, Long targetId, String reasonTitle);
+    void sendReportNotification(Long reportId, String targetType, String reasonTitle);
 }

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
@@ -19,6 +19,8 @@ public class DiscordServiceImpl implements DiscordService {
 
     private final RestTemplate restTemplate;
 
+    private static final int DISCORD_REPORT_COLOR = 15158332;
+
     @Override
     @Async
     public void sendReportNotification(Long reportId, String targetType, Long targetId, String reasonTitle) {
@@ -31,7 +33,7 @@ public class DiscordServiceImpl implements DiscordService {
         DiscordMessageDto.Embed embed = DiscordMessageDto.Embed.builder()
                 .title("🚨 새로운 신고가 접수되었습니다")
                 .description("관리자 페이지에서 상세 내용을 확인해주세요.")
-                .color(15158332)
+                .color(DISCORD_REPORT_COLOR)
                 .fields(fields)
                 .build();
 

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
@@ -1,0 +1,48 @@
+package umc.teumteum.server.global.infra.discord.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import umc.teumteum.server.global.infra.discord.dto.DiscordMessageDto;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordServiceImpl implements DiscordService {
+
+    @Value("${discord.webhook.url}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    @Async
+    public void sendReportNotification(Long reportId, String targetType, Long targetId, String reasonTitle) {
+        List<DiscordMessageDto.Field> fields = List.of(
+                new DiscordMessageDto.Field("신고 번호", "#" + reportId, true),
+                new DiscordMessageDto.Field("대상 타입", targetType, true),
+                new DiscordMessageDto.Field("신고 사유", reasonTitle, true)
+        );
+
+        DiscordMessageDto.Embed embed = DiscordMessageDto.Embed.builder()
+                .title("🚨 새로운 신고가 접수되었습니다")
+                .description("관리자 페이지에서 상세 내용을 확인해주세요.")
+                .color(15158332)
+                .fields(fields)
+                .build();
+
+        DiscordMessageDto message = DiscordMessageDto.builder()
+                .embeds(List.of(embed))
+                .build();
+
+        try {
+            restTemplate.postForEntity(webhookUrl, message, String.class);
+        } catch (Exception e) {
+            log.error("Discord 웹훅 발송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
@@ -43,8 +43,13 @@ public class DiscordServiceImpl implements DiscordService {
 
         try {
             restTemplate.postForEntity(webhookUrl, message, String.class);
+        } catch (org.springframework.web.client.RestClientException e) {
+            // 구체적인 예외 처리 및 컨텍스트 로그
+            log.error("Discord API 호출 중 네트워크 오류 발생: reportId={}, targetType={}, error={}",
+                    reportId, targetType, e.getMessage(), e);
         } catch (Exception e) {
-            log.error("Discord 웹훅 발송 실패: {}", e.getMessage());
+            // 예기치 못한 모든 예외에 대해 스택 트레이스 포함하여 로깅
+            log.error("Discord 웹훅 발송 중 예기치 않은 오류 발생: reportId={}", reportId, e);
         }
     }
 }

--- a/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/global/infra/discord/service/DiscordServiceImpl.java
@@ -23,7 +23,7 @@ public class DiscordServiceImpl implements DiscordService {
 
     @Override
     @Async
-    public void sendReportNotification(Long reportId, String targetType, Long targetId, String reasonTitle) {
+    public void sendReportNotification(Long reportId, String targetType, String reasonTitle) {
         List<DiscordMessageDto.Field> fields = List.of(
                 new DiscordMessageDto.Field("신고 번호", "#" + reportId, true),
                 new DiscordMessageDto.Field("대상 타입", targetType, true),


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#291 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

- 신고 접수 시 Discord 실시간 알림 연동
  - `DiscordService` 및 `DiscordServiceImpl` 구현을 통한 알림 발송 로직 분리
  - 신고 ID와 신고 유형(`USER`/`TEUM_REQUEST`)을 포함한 Discord Embed 메시지 구성
- 비동기(`@Async`) 처리 적용
  - 알림 발송 실패나 지연이 실제 신고 저장 로직에 영향을 주지 않도록 비동기 처리 적용
  - `ServerApplication`에 `@EnableAsync` 추가
- Git Submodule
  - `application-dev.properties`, `application-prod.properties`에 웹훅 URL 추가
  - `application-test.properties`에 테스트용 가짜 URL을 추가하여 CI(GitHub Actions) 통과 보장

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

- 예외 처리: `DiscordServiceImpl`에서 외부 API 호출 시 발생할 수 있는 에러를 try-catch로 감싸 로깅 처리함으로써, 알림 실패가 비즈니스 로직 전체의 예외로 번지지 않도록 설계

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

- 서브모듈이 업데이트 되었습니다.
- 로컬의 신고 알림은 저랑 혜빈 님만 볼 수 있는 디코 채널에 알림이 갑니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  신고 알림 발송  |  <img width="665" height="281" alt="image" src="https://github.com/user-attachments/assets/5deb81c3-9e2f-4f59-b790-e453e01f17e1" />  |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 신고 제출 시 Discord로 자동 알림 전송 기능 추가 — 신고 번호, 대상 유형, 신고 사유를 포함한 알림이 지정된 Discord 채널로 비동기 전송됩니다. 오류 발생 시 로깅으로 처리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->