### PR TITLE
[Feat] 신고 접수 시 틈 요청 숨김 처리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
@@ -15,6 +15,7 @@ public enum ReportErrorStatus implements BaseErrorCode {
     REPORT_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT4003", "자기 자신은 신고할 수 없습니다."),
     REPORT_OTHER_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REPORT4004", "기타 사유 선택 시, 구체적인 내용을 입력해야 합니다."),
     REPORT_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "REPORT4005", "지원하지 않는 신고 대상입니다."),
+    REPORT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "REPORT4006", "대기 중인 요청만 신고할 수 있습니다."),
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -13,7 +13,10 @@ import umc.teumteum.server.domain.report.exception.status.ReportErrorStatus;
 import umc.teumteum.server.domain.report.repository.ReportReasonRepository;
 import umc.teumteum.server.domain.report.repository.ReportRepository;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.entity.TeumResponse;
+import umc.teumteum.server.domain.teum.entity.enums.ResponseStatus;
 import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.infra.discord.service.DiscordService;
@@ -27,6 +30,7 @@ public class ReportServiceImpl implements ReportService {
     private final ReportReasonRepository reportReasonRepository;
     private final UserRepository userRepository;
     private final TeumRequestRepository teumRequestRepository;
+    private final TeumResponseRepository teumResponseRepository;
 
     private final DiscordService discordService;
 
@@ -59,6 +63,9 @@ public class ReportServiceImpl implements ReportService {
         } else if (request.getTargetType() == TargetType.TEUM_REQUEST) {
             targetTeum = teumRequestRepository.findById(request.getTargetId())
                     .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
+
+            // 신고자의 응답 상태를 REPORTED로 변경
+            handleTeumRequestReport(reporter, targetTeum);
         } else {
             throw new ReportException(ReportErrorStatus.REPORT_INVALID_TARGET_TYPE);
         }
@@ -73,5 +80,16 @@ public class ReportServiceImpl implements ReportService {
                 savedReport.getTargetType().name(),
                 reason.getTitle()
         );
+    }
+
+    /**
+     * 틈 요청 신고 시 신고자의 홈에서 숨기기 위한 처리
+     */
+    private void handleTeumRequestReport(User reporter, TeumRequest targetTeum) {
+        TeumResponse response = teumResponseRepository.findRequestAndReceiver(targetTeum.getId(), reporter.getId())
+                .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
+
+        // 상태를 REPORTED로 변경
+        response.changeStatus(ResponseStatus.REPORTED);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -64,6 +64,10 @@ public class ReportServiceImpl implements ReportService {
             targetTeum = teumRequestRepository.findById(request.getTargetId())
                     .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
 
+            if (reporter.getId().equals(targetTeum.getUser().getId())) {
+                throw new ReportException(ReportErrorStatus.REPORT_SELF_NOT_ALLOWED);
+            }
+
             // 신고자의 응답 상태를 REPORTED로 변경
             handleTeumRequestReport(reporter, targetTeum);
         } else {
@@ -88,6 +92,10 @@ public class ReportServiceImpl implements ReportService {
     private void handleTeumRequestReport(User reporter, TeumRequest targetTeum) {
         TeumResponse response = teumResponseRepository.findRequestAndReceiver(targetTeum.getId(), reporter.getId())
                 .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
+
+        if (response.getStatus() != ResponseStatus.PENDING) {
+            throw new ReportException(ReportErrorStatus.REPORT_INVALID_STATUS); // 혹은 적절한 에러 코드
+        }
 
         // 상태를 REPORTED로 변경
         response.changeStatus(ResponseStatus.REPORTED);

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -334,7 +334,7 @@ public class TeumConverter {
             switch (response.getStatus()) {
                 case PENDING -> pending.add(participant);
                 case ACCEPTED -> accepted.add(participant);
-                case REJECTED, LEFT -> cancelled.add(participant);
+                case REJECTED, LEFT, REPORTED -> cancelled.add(participant);
                 case RESEND -> resend.add(participant);
             }
         }

--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
@@ -6,5 +6,6 @@ public enum ResponseStatus {
     REJECTED,   // 수신자가 요청을 거절
     RESEND,     // 수신자가 시간대 바꿔 재요청
     LEFT,       // 수신자가 요청을 수락했다가 취소함
-    CANCELED_BY_REQUESTER  // 송신자가 요청을 취소하여 응답 무효
+    CANCELED_BY_REQUESTER,  // 송신자가 요청을 취소하여 응답 무효
+    REPORTED    // 수신자가 해당 요청을 신고함
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#299 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 신고 접수 시 '틈 요청' 즉시 숨김 로직 구현
  - ReportServiceImpl에서 TEUM_REQUEST 타입 신고 시, 신고자의 TeumResponse 상태를 REPORTED로 자동 변경
  - 친구 홈(PENDING 상태 조회)에서 해당 요청이 즉시 제외
- 틈 요청 기록 보존 및 미응답 표시 처리
  -  TeumConverter에서 REPORTED 상태를 cancelled 리스트로 분류하여 기록 화면에 노출
- 도메인 엔티티 및 Enum 확장
  - ResponseStatus Enum에 REPORTED 상태를 추가하여 신고된 응답을 명확히 구분

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 신고 접수 | <img width="1179" height="279" alt="image" src="https://github.com/user-attachments/assets/103ae84b-352d-42bf-8d83-240a7665994b" /> |
|REPORTED 상태로 변경됨|<img width="1283" height="104" alt="image" src="https://github.com/user-attachments/assets/1406d83b-7313-4c2f-a095-80c7b5169e85" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Teum 요청 신고 시 신고자의 응답 상태가 자동으로 "신고됨"으로 업데이트되도록 개선했습니다.
  * 응답 상태 분류를 확장하여 "신고됨" 상태를 취소된 참여로 포함하도록 변경했습니다.

* **버그 수정**
  * 대기 중이 아닌 요청에 대한 신고 시 적절한 오류(잘못된 상태)를 반환하도록 처리했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->