### PR TITLE
[Feat] 관리자용 신고 상세 내용 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
+++ b/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
@@ -1,0 +1,34 @@
+package umc.teumteum.server.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.report.dto.ReportResponseDto;
+import umc.teumteum.server.domain.report.exception.status.ReportSuccessStatus;
+import umc.teumteum.server.domain.report.service.ReportService;
+import umc.teumteum.server.global.apiPayload.ApiResponse;
+
+@Tag(name = "Admin Report", description = "관리자용 신고 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "신고 상세 조회", description = "신고의 상세 내용과 피신고자의 누적 신고 횟수를 조회합니다.")
+    @GetMapping("/{reportId}")
+    public ApiResponse<ReportResponseDto.ReportDetail> getReportDetail(
+            @PathVariable Long reportId
+    ) {
+        ReportResponseDto.ReportDetail response
+                = reportService.getReportDetail(reportId);
+
+        return ApiResponse.of(ReportSuccessStatus.REPORT_DETAIL_FETCHED, response);
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/report/converter/ReportConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/report/converter/ReportConverter.java
@@ -8,6 +8,8 @@ import umc.teumteum.server.domain.report.entity.enums.TargetType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.User;
 
+import java.util.Optional;
+
 public class ReportConverter {
 
     public static Report toReport(User reporter, ReportRequestDto.CreateReport request, ReportReason reason, User targetUser, TeumRequest targetTeum) {
@@ -30,9 +32,10 @@ public class ReportConverter {
 
     public static ReportResponseDto.ReportDetail toReportDetail(Report report, long totalReportCount) {
         // 피신고자(대상 유저) 특정
-        User reportedUser = (report.getTargetType() == TargetType.USER)
-                ? report.getTargetUser()
-                : report.getTeumRequest().getUser();
+        User reportedUser = Optional.ofNullable(report.getTargetUser())
+                .orElseGet(() -> Optional.ofNullable(report.getTeumRequest())
+                        .map(TeumRequest::getUser)
+                        .orElse(null));
 
         ReportResponseDto.ReportDetail.ReportDetailBuilder builder = ReportResponseDto.ReportDetail.builder()
                 .reportId(report.getId())
@@ -46,12 +49,12 @@ public class ReportConverter {
                         .nickname(report.getReporter().getNickname())
                         .build())
                 .targetUser(ReportResponseDto.TargetUserInfo.builder()
-                        .userId(reportedUser.getId())
-                        .nickname(reportedUser.getNickname())
+                        .userId(reportedUser != null ? reportedUser.getId() : null)
+                        .nickname(reportedUser != null ? reportedUser.getNickname() : "알 수 없음")
                         .totalReportCount(totalReportCount)
                         .build());
 
-        // 틈 요청 신고인 경우 날짜까지만 포함
+        // 틈 요청 콘텐츠 매핑 (null 체크 포함)
         if (report.getTargetType() == TargetType.TEUM_REQUEST && report.getTeumRequest() != null) {
             var teum = report.getTeumRequest();
             builder.teumContent(ReportResponseDto.TeumContent.builder()

--- a/src/main/java/umc/teumteum/server/domain/report/converter/ReportConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/report/converter/ReportConverter.java
@@ -1,8 +1,10 @@
 package umc.teumteum.server.domain.report.converter;
 
 import umc.teumteum.server.domain.report.dto.ReportRequestDto;
+import umc.teumteum.server.domain.report.dto.ReportResponseDto;
 import umc.teumteum.server.domain.report.entity.Report;
 import umc.teumteum.server.domain.report.entity.ReportReason;
+import umc.teumteum.server.domain.report.entity.enums.TargetType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.User;
 
@@ -24,5 +26,42 @@ public class ReportConverter {
         }
 
         return reportBuilder.build();
+    }
+
+    public static ReportResponseDto.ReportDetail toReportDetail(Report report, long totalReportCount) {
+        // 피신고자(대상 유저) 특정
+        User reportedUser = (report.getTargetType() == TargetType.USER)
+                ? report.getTargetUser()
+                : report.getTeumRequest().getUser();
+
+        ReportResponseDto.ReportDetail.ReportDetailBuilder builder = ReportResponseDto.ReportDetail.builder()
+                .reportId(report.getId())
+                .targetType(report.getTargetType())
+                .status(report.getStatus())
+                .reasonTitle(report.getReason().getTitle())
+                .otherReason(report.getOtherReason())
+                .createdAt(report.getCreatedAt())
+                .reporter(ReportResponseDto.UserInfo.builder()
+                        .userId(report.getReporter().getId())
+                        .nickname(report.getReporter().getNickname())
+                        .build())
+                .targetUser(ReportResponseDto.TargetUserInfo.builder()
+                        .userId(reportedUser.getId())
+                        .nickname(reportedUser.getNickname())
+                        .totalReportCount(totalReportCount)
+                        .build());
+
+        // 틈 요청 신고인 경우 날짜까지만 포함
+        if (report.getTargetType() == TargetType.TEUM_REQUEST && report.getTeumRequest() != null) {
+            var teum = report.getTeumRequest();
+            builder.teumContent(ReportResponseDto.TeumContent.builder()
+                    .requestId(teum.getId())
+                    .title(teum.getTitle())
+                    .description(teum.getDescription())
+                    .date(teum.getDate().toString())
+                    .build());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/report/dto/ReportResponseDto.java
@@ -49,6 +49,8 @@ public class ReportResponseDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "신고자 기본 정보")
     public static class UserInfo {
         @Schema(description = "사용자 ID", example = "10")
@@ -60,6 +62,8 @@ public class ReportResponseDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "피신고자 정보 및 신고 통계")
     public static class TargetUserInfo {
         @Schema(description = "피신고자 ID", example = "25")
@@ -74,6 +78,8 @@ public class ReportResponseDto {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(description = "신고 대상인 틈 요청의 상세 내용")
     public static class TeumContent {
         @Schema(description = "틈 요청 고유 ID", example = "50")

--- a/src/main/java/umc/teumteum/server/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/report/dto/ReportResponseDto.java
@@ -1,0 +1,91 @@
+package umc.teumteum.server.domain.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.report.entity.enums.ReportStatus;
+import umc.teumteum.server.domain.report.entity.enums.TargetType;
+
+import java.time.LocalDateTime;
+
+public class ReportResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "신고 상세 정보 응답 DTO")
+    public static class ReportDetail {
+
+        @Schema(description = "신고 고유 ID", example = "1")
+        private Long reportId;
+
+        @Schema(description = "신고 대상 타입 (USER: 사용자, TEUM_REQUEST: 틈 요청)", example = "TEUM_REQUEST")
+        private TargetType targetType;
+
+        @Schema(description = "신고 처리 상태 (OPEN: 접수됨, PENDING: 검토중, RESOLVED: 처리완료)", example = "OPEN")
+        private ReportStatus status;
+
+        @Schema(description = "선택된 신고 사유 제목", example = "부적절한 언어 사용")
+        private String reasonTitle;
+
+        @Schema(description = "직접 입력한 기타 사유 (없을 경우 null)", example = "상대방이 지속적으로 비속어를 사용했습니다.")
+        private String otherReason;
+
+        @Schema(description = "신고 일시", example = "2023-12-30T14:30:00")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "신고자 정보")
+        private UserInfo reporter;
+
+        @Schema(description = "피신고자(대상) 정보 및 누적 통계")
+        private TargetUserInfo targetUser;
+
+        @Schema(description = "틈 요청 신고일 경우 포함되는 요청 본문 (USER 신고일 경우 null)")
+        private TeumContent teumContent;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "신고자 기본 정보")
+    public static class UserInfo {
+        @Schema(description = "사용자 ID", example = "10")
+        private Long userId;
+
+        @Schema(description = "사용자 닉네임", example = "나루")
+        private String nickname;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "피신고자 정보 및 신고 통계")
+    public static class TargetUserInfo {
+        @Schema(description = "피신고자 ID", example = "25")
+        private Long userId;
+
+        @Schema(description = "피신고자 닉네임", example = "해빗")
+        private String nickname;
+
+        @Schema(description = "해당 유저가 받은 총 신고 누적 횟수", example = "3")
+        private long totalReportCount;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "신고 대상인 틈 요청의 상세 내용")
+    public static class TeumContent {
+        @Schema(description = "틈 요청 고유 ID", example = "50")
+        private Long requestId;
+
+        @Schema(description = "틈 요청 제목", example = "오늘 저녁 같이 먹어요!")
+        private String title;
+
+        @Schema(description = "틈 요청 상세 설명", example = "강남역 근처에서 같이 저녁 드실 분 구합니다.")
+        private String description;
+
+        @Schema(description = "틈 요청 날짜", example = "2023-12-31")
+        private String date;
+    }
+}

--- a/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
@@ -10,12 +10,17 @@ import umc.teumteum.server.global.apiPayload.code.ErrorReasonDto;
 @AllArgsConstructor
 public enum ReportErrorStatus implements BaseErrorCode {
 
-    REPORT_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4001", "존재하지 않는 신고 사유입니다."),
-    REPORT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4002", "신고 대상이 존재하지 않습니다."),
-    REPORT_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT4003", "자기 자신은 신고할 수 없습니다."),
-    REPORT_OTHER_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REPORT4004", "기타 사유 선택 시, 구체적인 내용을 입력해야 합니다."),
-    REPORT_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "REPORT4005", "지원하지 않는 신고 대상입니다."),
-    REPORT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "REPORT4006", "대기 중인 요청만 신고할 수 있습니다."),
+    // 조회 관련 (404 Not Found)
+    REPORT_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4041", "존재하지 않는 신고 사유입니다."),
+    REPORT_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4042", "신고 대상이 존재하지 않습니다."),
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4043", "신고 내역을 찾을 수 없습니다."), // 신규 추가
+
+    // 제한 및 검증 관련 (400 Bad Request)
+    REPORT_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT4001", "자기 자신은 신고할 수 없습니다."),
+    REPORT_OTHER_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REPORT4002", "기타 사유 선택 시, 구체적인 내용을 입력해야 합니다."),
+    REPORT_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "REPORT4003", "지원하지 않는 신고 대상입니다."),
+    REPORT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "REPORT4004", "대기 중인 요청만 신고할 수 있습니다."),
+    REPORT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REPORT4005", "이미 신고한 대상입니다."), // 중복 신고 방지용 추가
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportSuccessStatus.java
@@ -10,7 +10,8 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 @AllArgsConstructor
 public enum ReportSuccessStatus implements BaseCode {
 
-    REPORT_CREATED(HttpStatus.CREATED, "REPORT201", "신고가 성공적으로 접수되었습니다."),
+    REPORT_CREATED(HttpStatus.OK, "REPORT2001", "신고가 성공적으로 접수되었습니다."),
+    REPORT_DETAIL_FETCHED(HttpStatus.OK, "REPORT2002", "신고 상세 정보를 성공적으로 조회했습니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/report/repository/ReportRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/report/repository/ReportRepository.java
@@ -1,7 +1,17 @@
 package umc.teumteum.server.domain.report.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.report.entity.Report;
+import umc.teumteum.server.domain.user.entity.User;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    // 유저 직접 신고 + 해당 유저의 틈 요청이 신고된 횟수 합산
+    @Query("SELECT COUNT(r) FROM Report r " +
+            "LEFT JOIN r.teumRequest tr " +
+            "WHERE r.targetUser = :user " +
+            "OR tr.user = :user")
+    long countTotalReportsByUser(@Param("user") User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportService.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportService.java
@@ -1,8 +1,10 @@
 package umc.teumteum.server.domain.report.service;
 
 import umc.teumteum.server.domain.report.dto.ReportRequestDto;
+import umc.teumteum.server.domain.report.dto.ReportResponseDto;
 import umc.teumteum.server.domain.user.entity.User;
 
 public interface ReportService {
     void createReport(User reporter, ReportRequestDto.CreateReport request);
+    ReportResponseDto.ReportDetail getReportDetail(Long reportId);
 }

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -94,6 +94,11 @@ public class ReportServiceImpl implements ReportService {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
 
+        // TEUM_REQUEST 타입인데 데이터가 없는 경우를 사전에 차단
+        if (report.getTargetType() == TargetType.TEUM_REQUEST && report.getTeumRequest() == null) {
+            throw new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND);
+        }
+
         // 피신고자 특정
         User reportedUser = (report.getTargetType() == TargetType.USER)
                 ? report.getTargetUser()

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.report.converter.ReportConverter;
 import umc.teumteum.server.domain.report.dto.ReportRequestDto;
+import umc.teumteum.server.domain.report.dto.ReportResponseDto;
 import umc.teumteum.server.domain.report.entity.Report;
 import umc.teumteum.server.domain.report.entity.ReportReason;
 import umc.teumteum.server.domain.report.entity.enums.TargetType;
@@ -84,6 +85,25 @@ public class ReportServiceImpl implements ReportService {
                 savedReport.getTargetType().name(),
                 reason.getTitle()
         );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReportResponseDto.ReportDetail getReportDetail(Long reportId) {
+        // 신고 내역 조회
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
+
+        // 피신고자 특정
+        User reportedUser = (report.getTargetType() == TargetType.USER)
+                ? report.getTargetUser()
+                : report.getTeumRequest().getUser();
+
+        // 누적 신고 횟수 조회
+        long totalReportCount = reportRepository.countTotalReportsByUser(reportedUser);
+
+        // DTO 변환 및 반환
+        return ReportConverter.toReportDetail(report, totalReportCount);
     }
 
     /**

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -92,7 +92,7 @@ public class ReportServiceImpl implements ReportService {
     public ReportResponseDto.ReportDetail getReportDetail(Long reportId) {
         // 신고 내역 조회
         Report report = reportRepository.findById(reportId)
-                .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND));
+                .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_NOT_FOUND));
 
         // TEUM_REQUEST 타입인데 데이터가 없는 경우를 사전에 차단
         if (report.getTargetType() == TargetType.TEUM_REQUEST && report.getTeumRequest() == null) {

--- a/src/main/java/umc/teumteum/server/global/config/SecurityConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,7 @@ import umc.teumteum.server.global.jwt.JwtAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#301 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->

- 관리자 전용 신고 상세 조회 API 구현
  - 신고 상세 데이터(신고자, 피신고자, 신고 사유 및 내용)를 제공하는 엔드포인트 생성 (GET /api/v1/admin/reports/{reportId})
  - 피신고자의 누적 신고 횟수(사용자 자체 신고 + 틈 요청 신고)를 합산하여 제공하는 로직 구현
- 보안 및 접근 제어 설정
  - @EnableMethodSecurity 활성화를 통해 메서드 단위 보안 적용
  - ADMIN 권한을 가진 사용자만 해당 API를 호출할 수 있도록 @PreAuthorize 적용

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 누적 신고 횟수 쿼리 최적화: ReportRepository에서 LEFT JOIN을 사용하여 teumRequest가 null인 경우(사용자 신고 건)에도 데이터가 누락되지 않고 정확한 카운트(최소 1회 이상)가 나오도록 처리
- 권한 제어 방식: 컨트롤러 레벨에서 @PreAuthorize("hasRole('ADMIN')")을 사용하여 보안을 강화

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 관리자 신고 상세 조회 | <img width="1171" height="662" alt="image" src="https://github.com/user-attachments/assets/d2a1f282-58aa-4344-872d-3092af2a5d0c" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 신고 상세 정보를 조회할 수 있는 API가 추가되었습니다. 신고자·피신고자 정보, 신고 상태·사유, 피신고자 누적 신고 수 및 관련 콘텐츠(있을 경우)를 볼 수 있습니다.
* **변경사항**
  * 성공/오류 응답 코드 및 메시지가 일부 갱신되어 더욱 구체적인 상태를 제공합니다.
* **보안**
  * 관리자 전용 접근 제어가 적용되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->