### PR TITLE
Fix : amazoncorretto 기반 Dockerfile yum 옵션 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:21
 
-RUN yum makecache --refresh && \
+RUN yum -y makecache && \
     yum -y install shadow-utils && \
     groupadd -r app && \
     useradd -r -g app app && \


### PR DESCRIPTION
### 👀 관련 이슈
x

### ✨ 작업한 내용
amazoncorretto:21 이미지에서 지원하지 않는 `yum makecache --refresh` 옵션으로 인해 Docker build가 실패하던 문제를 수정함. --refresh 옵션을 제거하고 호환되는 `yum -y makecache` 방식으로 변경

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 컨테이너 빌드 프로세스 최적화로 배포 효율성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->