### PR TITLE
Hotfix : 리마인드 알림 스케줄러 트랜잭션 누락으로 인한 에러 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -1,5 +1,6 @@
 package umc.teumteum.server.global.scheduler;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +23,7 @@ public class RemindAlarmScheduler {
     private final ScheduleReminderRepository scheduleReminderRepository;
     private final NotificationUseCases notificationUseCases;
 
+    @Transactional
     @Scheduled(fixedRate = 60000, zone = "Asia/Seoul") // 1분마다 실행
     public void remindAlarm() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -1,11 +1,11 @@
 package umc.teumteum.server.global.scheduler;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
 import umc.teumteum.server.domain.home.entity.enums.DispatchStatus;


### PR DESCRIPTION
### 👀 관련 이슈
서버 작업을 하다가 @Scheduled 메서드에서 JPA update 쿼리를 실행하면서 트랜잭션이 열려 있지 않아 TransactionRequired~ 이 발생하고 있는 걸 확인했습니다
```

[ERROR] Unexpected error occurred in scheduled task

org.springframework.dao.InvalidDataAccessApiUsageException:
No EntityManager with actual transaction available for current thread
- cannot reliably process 'flush' call

at umc.teumteum.server.global.scheduler.RemindAlarmScheduler.remindAlarm(RemindAlarmScheduler.java:39)

```

### ✨ 작업한 내용
RemindAlarmScheduler의 remindAlarm() 메서드에 @Transactional을 추가하여 스케줄러 실행 시 트랜잭션이 정상적으로 생성되도록 수정했습니다.

### 🌀 PR Point
x

### 🍰 참고사항
- 기존 로직 및 흐름은 변경하지 않았습니다.

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 스케줄된 리마인더 처리의 안정성과 데이터 일관성이 향상되었습니다.  
  * 예약 알림 동작의 신뢰성이 개선되어 실패나 중복 처리 가능성이 줄었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->