### PR TITLE
Hotfix : 스케줄러 트랜잭션 분리로 알림 처리 중 JPA flush 오류 방지

### DIFF
--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -30,16 +30,23 @@ public class RemindAlarmScheduler {
 
         // 1. 발송 대상 조회 (최대 100개)
         List<ScheduleReminder> targets = scheduleReminderRepository.findDueWithScheduleAndUser(
-                AlarmStatus.ACTIVE, DispatchStatus.PENDING, now, PageRequest.of(0, 100)
+            AlarmStatus.ACTIVE, DispatchStatus.PENDING, now, PageRequest.of(0, 100)
         );
 
-        if(targets.isEmpty()) return;
+        if (targets.isEmpty())
+            return;
 
         // 2. 선점하기  (발송 상태 변경하기 PENDING -> PROCESSING)
         List<Long> targetIds = targets.stream().map(ScheduleReminder::getId).toList();
 
-        int lockedCount = scheduleReminderRepository.updateDispatchStatus(targetIds,DispatchStatus.PENDING,DispatchStatus.PROCESSING);
-        if(lockedCount == 0) return;
+        int lockedCount = scheduleReminderRepository.updateDispatchStatus(targetIds,
+            DispatchStatus.PENDING, DispatchStatus.PROCESSING);
+        if (lockedCount == 0) return;
+
+        processNotifications(targetIds);
+
+    }
+    public void processNotifications(List<Long> targetIds) {
 
         // 3. 선점 성공한 것들 다시 조회
         List<ScheduleReminder> locked = scheduleReminderRepository.findByIdsWithScheduleAndUser(targetIds,DispatchStatus.PROCESSING);


### PR DESCRIPTION
### 👀 관련 이슈
기존 @Scheduled 알림 스케줄러에서 DB 상태 변경과 외부 알림 발송 로직이 하나의 트랜잭션 안에서 실행되고 있었습니다.

이 구조에서 알림 발송 중 예외가 발생할 경우, Hibernate Session이 오염된 상태로 추가적인 DB flush가 시도되어 아래와 같은 런타임 오류가 발생하는 것을 확인했습니다.

```
[   scheduling-1] org.hibernate.AssertionFailure           : HHH000099: an assertion failure occurred (this may indicate a bug in Hibernate, but is more likely due to unsafe use of the session): org.hibernate.AssertionFailure: null id in umc.teumteum.server.domain.notification.entity.Notification entry (don't flush the Session after an exception occurs)
2026-01-04T04:17:28.861+09:00 ERROR 1 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

org.hibernate.AssertionFailure: null id in umc.teumteum.server.domain.notification.entity.Notification entry (don't flush the Session after an exception occurs)
        at org.hibernate.event.internal.DefaultFlushEntityEventListener.checkId(DefaultFlushEntityEventListener.java:86) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.DefaultFlushEntityEventListener.getValues(DefaultFlushEntityEventListener.java:182) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.DefaultFlushEntityEventListener.onFlushEntity(DefaultFlushEntityEventListener.java:141) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:127) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.AbstractFlushingEventListener.flushEntities(AbstractFlushingEventListener.java:269) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.AbstractFlushingEventListener.flushEverythingToExecutions(AbstractFlushingEventListener.java:90) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.AbstractFlushingEventListener.flushEverythingToExecutions(AbstractFlushingEventListener.java:84) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:40) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:127) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1429) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at org.hibernate.internal.SessionImpl.flush(SessionImpl.java:1415) ~[hibernate-core-6.6.18.Final.jar!/:6.6.18.Final]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
        at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:320) ~[spring-orm-6.2.8.jar!/:6.2.8]
        at jdk.proxy2/jdk.proxy2.$Proxy196.flush(Unknown Source) ~[na:na]
        at org.springframework.data.jpa.repository.query.JpaQueryExecution$ModifyingExecution.doExecute(JpaQueryExecution.java:264) ~[spring-data-jpa-3.5.1.jar!/:3.5.1]
        at org.springframework.data.jpa.repository.query.JpaQueryExecution.execute(JpaQueryExecution.java:93) ~[spring-data-jpa-3.5.1.jar!/:3.5.1]
        at org.springframework.data.jpa.repository.query.AbstractJpaQuery.doExecute(AbstractJpaQuery.java:160) ~[spring-data-jpa-3.5.1.jar!/:3.5.1]
        at org.springframework.data.jpa.repository.query.AbstractJpaQuery.execute(AbstractJpaQuery.java:148) ~[spring-data-jpa-3.5.1.jar!/:3.5.1]
        at org.springframework.data.repository.core.support.RepositoryMethodInvoker.doInvoke(RepositoryMethodInvoker.java:170) ~[spring-data-commons-3.5.1.jar!/:3.5.1]
        at org.springframework.data.repository.core.support.RepositoryMethodInvoker.invoke(RepositoryMethodInvoker.java:158) ~[spring-data-commons-3.5.1.jar!/:3.5.1]
        at org.springframework.data.repository.core.support.QueryExecutorMethodInterceptor.doInvoke(QueryExecutorMethodInterceptor.java:170) ~[spring-data-commons-3.5.1.jar!/:3.5.1]
```


### ✨ 작업한 내용
* 알림 선점(DB 상태 변경) 과 알림 발송 로직을 분리
* DB 선점 로직은 트랜잭션으로 보호
* 외부 알림 발송 및 후속 상태 변경은 별도 메서드에서 처리하도록 구조 개선

### 🌀 PR Point
x

### 🍰 참고사항
비즈니스 로직 변경은 없습니다!

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 리마인더 알림 전송 실패 시 상태 추적 및 오류 처리 개선
  * 알림 처리 안정성 강화로 더욱 신뢰할 수 있는 리마인더 서비스 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->