### PR TITLE
Feat: 계정 정보 조회 API 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -239,5 +239,16 @@ public class UserController {
         return ApiResponse.of(UserSuccessStatus._USER_DELETED, null);
     }
 
+    @Operation(
+            summary = "마이페이지 소셜 계정 정보 조회",
+            description = "마이페이지에서 소셜타입과 이메일 정보를 조회합니다."
+    )
+    @GetMapping(value = "/mypage/accounts", produces = "application/json")
+    public ApiResponse<UserResponseDTO.AccountInfoDTO> getAccount(
+            @CurrentUser @Parameter(hidden = true) User user){
+        UserResponseDTO.AccountInfoDTO result = userService.getAccountInfo(user);
+        return ApiResponse.of(UserSuccessStatus._SOCIAL_ACCOUNT_LOADED, result);
+    }
+
 
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -46,4 +46,12 @@ public class UserConverter {
                 .endTime(routine.getEndTime())
                 .build();
     }
+
+    // user -> UserResponseDTO.AccountInfoDTO
+    public static UserResponseDTO.AccountInfoDTO toAccountInfoDTO(User user) {
+        return UserResponseDTO.AccountInfoDTO.builder()
+                .email(user.getEmail())
+                .socialType(user.getSocialType())
+                .build();
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
 
 import java.time.LocalTime;
@@ -61,5 +62,17 @@ public class UserResponseDTO {
 
     @Schema(description = "리마인드 알림 설정 (1, 3, 5, 10, 30, 빈 배열)", example = "[1, 5, 30]")
     private List<Integer> remindAlarms;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class AccountInfoDTO {
+
+    @Schema(description = "이메일", example = "teum@naver.com")
+    private String email;
+
+    @Schema(description = "소셜타입", example = "kakao")
+    private SocialType socialType;
   }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -25,6 +25,7 @@ public enum UserSuccessStatus implements BaseCode {
     _REMIND_ALARM_UPDATED(HttpStatus.OK,"USER20013","리마인드 알림 설정 수정이 완료되었습니다."),
     _USER_DELETED(HttpStatus.OK,"USER20014","회원 탈퇴가 완료되었습니다."),
     _SLEEP_PATTERN_DELETED(HttpStatus.OK,"USER20015","수면 패턴 삭제가 완료되었습니다."),
+    _SOCIAL_ACCOUNT_LOADED(HttpStatus.OK,"USER20016","소셜 계정 정보 조회가 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -51,4 +51,6 @@ public interface UserService {
     void deleteUser(User user);
 
     void deleteSleepPattern(User user);
+
+    UserResponseDTO.AccountInfoDTO getAccountInfo(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -574,6 +574,15 @@ public class UserServiceImpl implements UserService {
         u.updateSleepPattern(null, null);
     }
 
+    // 마이페이지 - 소셜 계정 정보 조회
+    @Override
+    public UserResponseDTO.AccountInfoDTO getAccountInfo(User user) {
+        User u = userRepository.findById(user.getId())
+                .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
+
+        return UserConverter.toAccountInfoDTO(u);
+    }
+
     /**
      * 유저 프로필 삭제 헬퍼 메서드
      */

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -575,12 +575,10 @@ public class UserServiceImpl implements UserService {
     }
 
     // 마이페이지 - 소셜 계정 정보 조회
+    @Transactional(readOnly = true)
     @Override
     public UserResponseDTO.AccountInfoDTO getAccountInfo(User user) {
-        User u = userRepository.findById(user.getId())
-                .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
-
-        return UserConverter.toAccountInfoDTO(u);
+        return UserConverter.toAccountInfoDTO(user);
     }
 
     /**


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#312 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 마이페이지에서 사용자의 소셜 계정 타입과 이메일을 조회하는 API 구현했습니다.
### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- GET `api/users/mypage/accounts`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에서 개인 소셜 계정 정보(이메일, 소셜 종류)를 조회할 수 있는 계정 조회 API가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->