### PR TITLE
Chore: Gradle plugin/dependency repository 명시

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
 rootProject.name = 'server'
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈
X

### ✨ 작업한 내용

- settings.gradle에 pluginManagement 설정 추가
- Gradle 플러그인 해석 시 사용할 저장소를 명시적으로 지정

### 🌀 PR Point

기존에는 Gradle의 암묵적 기본 플러그인 저장소 동작에 의존하고 있었음.
Maven Central fallback 과정에서 403 Forbidden이 발생해서 깃 액션이 실패하는 문제가 발생함. 
따라서 플러그인 및 의존성 저장소를 명시적으로 선언함

### 🍰 참고사항

기능 로직 변경은 없습니다

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|      |          |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Gradle 빌드 구성 업데이트로 플러그인 및 의존성 리포지토리 설정을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->