### PR TITLE
Feat: 카카오 로그인 OIDC 방식 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ dependencies {
 
     // JWT - OIDC ID 토큰
     implementation 'com.auth0:java-jwt:4.5.0'
-    implementation 'com.auth0:jwks-rsa:0.22.1'
+    implementation 'com.auth0:jwks-rsa:0.23.0'
 
 	// Levenshtein
 	implementation 'org.apache.commons:commons-text:1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,6 @@ dependencies {
 	testImplementation "org.testcontainers:junit-jupiter:2.0.3"
 	testImplementation "org.testcontainers:testcontainers:2.0.3"
 
-
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.1'
@@ -118,10 +117,14 @@ dependencies {
 	implementation 'software.amazon.awssdk:auth'
 	implementation 'software.amazon.awssdk:s3'
 
-	// JWT
+    // JWT - 자체 토큰
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // JWT - OIDC ID 토큰
+    implementation 'com.auth0:java-jwt:4.5.0'
+    implementation 'com.auth0:jwks-rsa:0.22.1'
 
 	// Levenshtein
 	implementation 'org.apache.commons:commons-text:1.10.0'

--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
 
     @Operation(
             summary = "소셜 로그인",
-            description = "카카오, 네이버, 구글에 대한 소셜 플랫폼을 통한 로그인을 처리합니다."
+            description = "카카오, 네이버, 구글 소셜 플랫폼을 통한 로그인을 처리합니다."
     )
     @PostMapping(value = "/social-login/{socialType}", produces = "application/json")
     public ApiResponse<AuthResponseDto.LoginResponse> socialLogin(

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
@@ -17,8 +17,11 @@ public class AuthRequestDto {
     public static class SocialLoginRequest {
 
         @NotBlank(message = "소셜 타입별 토큰은 필수입니다.")
-        @Schema(description = "소셜 타입별 토큰. 카카오/네이버는 accessToken, 구글은 idToken을 전달", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+        @Schema(description = "소셜 타입별 토큰. 네이버는 accessToken, 카카오/구글은 idToken을 전달", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
         private String token;
+
+        @Schema(description = "카카오 로그인에서 쓰이는 재생 공격 방지용 필드 (UUID 형식)", example = "550e8400-e29b-41d4-a716-446655440000")
+        private String nonce;
     }
 
 

--- a/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/dto/AuthRequestDto.java
@@ -20,7 +20,7 @@ public class AuthRequestDto {
         @Schema(description = "소셜 타입별 토큰. 네이버는 accessToken, 카카오/구글은 idToken을 전달", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
         private String token;
 
-        @Schema(description = "카카오 로그인에서 쓰이는 재생 공격 방지용 필드 (UUID 형식)", example = "550e8400-e29b-41d4-a716-446655440000")
+        @Schema(description = "카카오/구글 로그인에서 쓰이는 재생 공격 방지용 필드 (UUID 형식)", example = "550e8400-e29b-41d4-a716-446655440000")
         private String nonce;
     }
 

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
@@ -12,16 +12,15 @@ public enum AuthErrorStatus implements BaseErrorCode {
 
     // Auth 도메인 인증 관련
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "AUTH4001", "지원하지 않는 소셜 로그인 타입입니다."),
-    NAVER_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4003", "네이버 사용자 정보 조회에 실패했습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4004", "유효하지 않은 리프레시 토큰입니다."),
-    GOOGLE_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4005", "구글 사용자 정보 조회에 실패했습니다."),
-    NONCE_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH4006", "해당 소셜 로그인은 nonce가 필수입니다."),
+    NAVER_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "네이버 사용자 정보 조회에 실패했습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4003", "유효하지 않은 리프레시 토큰입니다."),
+    NONCE_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH4004", "해당 소셜 로그인은 nonce가 필수입니다."),
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4011", "리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH4012", "리프레시 토큰이 일치하지 않습니다."),
-    NONCE_ALREADY_USED(HttpStatus.UNAUTHORIZED, "AUTH4013", "이미 사용된 nonce입니다. 재생 공격이 의심됩니다."),
+    NONCE_ALREADY_USED(HttpStatus.UNAUTHORIZED, "AUTH4013", "이미 사용된 nonce입니다."),
     KAKAO_ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4014", "카카오 ID Token 검증에 실패했습니다."),
-
+    GOOGLE_ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4015", "구글 ID Token 검증에 실패했습니다."),
 
 
     ;

--- a/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/exception/status/AuthErrorStatus.java
@@ -12,12 +12,16 @@ public enum AuthErrorStatus implements BaseErrorCode {
 
     // Auth 도메인 인증 관련
     INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST, "AUTH4001", "지원하지 않는 소셜 로그인 타입입니다."),
-    KAKAO_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4002", "카카오 사용자 정보 조회에 실패했습니다."),
     NAVER_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4003", "네이버 사용자 정보 조회에 실패했습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4004", "유효하지 않은 리프레시 토큰입니다."),
     GOOGLE_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4005", "구글 사용자 정보 조회에 실패했습니다."),
+    NONCE_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH4006", "해당 소셜 로그인은 nonce가 필수입니다."),
+
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4011", "리프레시 토큰이 존재하지 않습니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH40112", "리프레시 토큰이 일치하지 않습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH4012", "리프레시 토큰이 일치하지 않습니다."),
+    NONCE_ALREADY_USED(HttpStatus.UNAUTHORIZED, "AUTH4013", "이미 사용된 nonce입니다. 재생 공격이 의심됩니다."),
+    KAKAO_ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4014", "카카오 ID Token 검증에 실패했습니다."),
+
 
 
     ;

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -36,10 +36,10 @@ import umc.teumteum.server.global.jwt.JwtProvider;
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    @Value("${jwt.access-expiration-ms}")
+    @Value("${auth.jwt.access-expiration-ms}")
     private long accessExpirationMs;
 
-    @Value("${jwt.refresh-expiration-ms}")
+    @Value("${auth.jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
 
     @Resource(name = "kakaoOAuthServiceImpl") private OAuthService kakaoOAuthService;
@@ -57,8 +57,6 @@ public class AuthServiceImpl implements AuthService {
     @Resource(name = "atBlacklistRedisTemplate") private RedisTemplate<String, String> atBlacklistRedisTemplate;
 
 
-
-
     // 인증 - 소셜로그인
     @Override
     @Transactional
@@ -67,7 +65,7 @@ public class AuthServiceImpl implements AuthService {
         SocialType type = SocialType.from(socialType);
 
         // 2. 소셜 로그인 - 사용자 정보 불러오기
-        OAuthUserInfo userInfo = getOAuthUserInfo(type, request.getToken());
+        OAuthUserInfo userInfo = getOAuthUserInfo(type, request.getToken(), request.getNonce());
 
         // 3. 사용자 조회 (없으면 생성)
         User user = userService.findOrCreateUser(userInfo);
@@ -153,9 +151,9 @@ public class AuthServiceImpl implements AuthService {
 
 
     // OAuth 사용자 정보 조회
-    private OAuthUserInfo getOAuthUserInfo(SocialType socialType, String token) {
+    private OAuthUserInfo getOAuthUserInfo(SocialType socialType, String token, String nonce) {
         return switch (socialType) {
-            case SocialType.KAKAO -> kakaoOAuthService.getUserInfoWithAccessToken(token);
+            case SocialType.KAKAO -> kakaoOAuthService.getUserInfoWithIdToken(token, nonce);
             case SocialType.NAVER -> naverOAuthService.getUserInfoWithAccessToken(token);
             case SocialType.GOOGLE -> googleOAuthService.getUserInfoWithIdToken(token);
         };
@@ -287,7 +285,7 @@ public class AuthServiceImpl implements AuthService {
 
         // 요청받은 RT와 Redis에 저장된 RT 다름
         if (!refreshToken.equals(savedRefreshToken)) {
-            log.warn("[토큰 탈취 의심] : 요청 RT != Redis RT - userId: {}, sessionId: {}", userId, sessionId);
+            log.warn("[Refresh 토큰 탈취 의심] : 요청 RT != Redis RT - userId: {}, sessionId: {}", userId, sessionId);
 
             // 동일한 sessionID를 갖는 AT 블랙리스트 저장
             saveAccessTokenBlacklist(userId, sessionId, accessExpirationMs);

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -155,7 +155,7 @@ public class AuthServiceImpl implements AuthService {
         return switch (socialType) {
             case SocialType.KAKAO -> kakaoOAuthService.getUserInfoWithIdToken(token, nonce);
             case SocialType.NAVER -> naverOAuthService.getUserInfoWithAccessToken(token);
-            case SocialType.GOOGLE -> googleOAuthService.getUserInfoWithIdToken(token);
+            case SocialType.GOOGLE -> googleOAuthService.getUserInfoWithIdToken(token, nonce);
         };
     }
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
@@ -3,7 +3,10 @@ package umc.teumteum.server.domain.auth.service;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import umc.teumteum.server.domain.auth.converter.AuthConverter;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
@@ -11,32 +14,83 @@ import umc.teumteum.server.domain.auth.exception.AuthException;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GoogleOAuthServiceImpl implements OAuthService {
 
+    private static final long NONCE_TTL_HOURS = 2;
+
     private final GoogleIdTokenVerifier googleIdTokenVerifier;
 
-    // 사용자 정보 조회
+    @Resource(name = "nonceRedisTemplate")
+    private RedisTemplate<String, String> nonceRedisTemplate;
+
+
     @Override
-    public OAuthUserInfo getUserInfoWithIdToken(String idToken) {
+    public OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
+        // 1. Nonce 검증 및 저장
+        validateAndSaveNonce(nonce);
+
+        // 2. ID Token 검증
+        GoogleIdToken googleIdToken = verifyIdToken(idToken);
+
+        // 3. Nonce 클레임 검증
+        verifyNonceClaim(googleIdToken.getPayload(), nonce);
+
+        // 4. 사용자 정보 추출
+        Payload payload = googleIdToken.getPayload();
+        String socialId = payload.getSubject();
+        String email = payload.getEmail();
+
+        // 5. OAuthUserInfo 반환
+        return AuthConverter.toOAuthUserInfo(SocialType.GOOGLE, socialId, email);
+    }
+
+    private void validateAndSaveNonce(String nonce) {
+        // 1. nonce 확인
+        if (nonce == null || nonce.isBlank()) {
+            throw new AuthException(AuthErrorStatus.NONCE_REQUIRED);
+        }
+
+        // 2. Redis 키 생성
+        String key = getNonceKey(nonce);
+
+        // 3. Redis에 저장 시도
+        Boolean wasUsed = nonceRedisTemplate.opsForValue()
+                .setIfAbsent(key, "used", Duration.ofHours(NONCE_TTL_HOURS));
+
+        // 4. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
+        if (Boolean.FALSE.equals(wasUsed)) {
+            log.warn("[ID 토큰 탈취 의심] : 이미 사용한 ID Token & nonce로 로그인 시도");
+            throw new AuthException(AuthErrorStatus.NONCE_ALREADY_USED);
+        }
+    }
+
+    private String getNonceKey(String nonce) {
+        return String.format("USED_NONCE:%s", nonce);
+    }
+
+    private GoogleIdToken verifyIdToken(String idToken){
         try {
-            // 1. ID Token 검증
             GoogleIdToken googleIdToken = googleIdTokenVerifier.verify(idToken);
             if (googleIdToken == null) {
-                throw new AuthException(AuthErrorStatus.GOOGLE_USER_INFO_FAILED);
+                throw new AuthException(AuthErrorStatus.GOOGLE_ID_TOKEN_VERIFICATION_FAILED);
             }
+            return googleIdToken;
+        } catch (GeneralSecurityException | IOException ex) {
+            throw new AuthException(AuthErrorStatus.GOOGLE_ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
 
-            // 2. 사용자 정보 추출
-            Payload payload = googleIdToken.getPayload();
-            String socialId = payload.getSubject();
-            String email = payload.getEmail();
-
-            // 3. OAuthUserInfo 반환
-            return AuthConverter.toOAuthUserInfo(SocialType.GOOGLE, socialId, email);
-
-        } catch (Exception e) {
-            throw new AuthException(AuthErrorStatus.GOOGLE_USER_INFO_FAILED);
+    private void verifyNonceClaim(Payload payload, String nonce) {
+        String tokenNonce = (String) payload.get("nonce");
+        if (tokenNonce == null || !tokenNonce.equals(nonce)) {
+            throw new AuthException(AuthErrorStatus.GOOGLE_ID_TOKEN_VERIFICATION_FAILED);
         }
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
@@ -1,52 +1,113 @@
 package umc.teumteum.server.domain.auth.service;
 
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 import umc.teumteum.server.domain.auth.converter.AuthConverter;
 import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.auth.exception.AuthException;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 
-import java.util.Map;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuthServiceImpl implements OAuthService {
 
-    private final RestTemplate restTemplate;
+    private static final String KAKAO_ISSUER = "https://kauth.kakao.com";
+    private static final long NONCE_TTL_HOURS = 2;
 
-    // 사용자 정보 조회
+    @Value("${auth.kakao.platform-key}")
+    private String platformKey;
+
+    private final JwkProvider kakaoJwkProvider;
+
+    @Resource(name = "nonceRedisTemplate")
+    private RedisTemplate<String, String> nonceRedisTemplate;
+
+
     @Override
-    public OAuthUserInfo getUserInfoWithAccessToken(String accessToken) {
-        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+    public OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
+        // 1. Nonce 검증 및 저장
+        validateAndSaveNonce(nonce);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
+        // 2. ID Token 검증
+        DecodedJWT verifiedJwt = verifyIdToken(idToken, nonce);
 
-        HttpEntity<Void> request = new HttpEntity<>(headers);
+        // 3. 사용자 정보 추출
+        String socialId = verifiedJwt.getSubject();
+        String email = verifiedJwt.getClaim("email").asString();
 
-        try {
-            ResponseEntity<Map> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, request, Map.class);
-            Map<String, Object> body = response.getBody();
+        // 4. OAuthUserInfo 반환
+        return AuthConverter.toOAuthUserInfo(SocialType.KAKAO, socialId, email);
+    }
 
-            if (body == null || !body.containsKey("id")) {
-                throw new AuthException(AuthErrorStatus.KAKAO_USER_INFO_FAILED);
-            }
 
-            String socialId = String.valueOf(body.get("id"));
-            Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
-            String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
-
-            return AuthConverter.toOAuthUserInfo(SocialType.KAKAO, socialId, email);
-
-        } catch (Exception e) {
-            throw new AuthException(AuthErrorStatus.KAKAO_USER_INFO_FAILED);
+    private void validateAndSaveNonce(String nonce) {
+        // 1. nonce 확인
+        if (nonce == null || nonce.isBlank()) {
+            throw new AuthException(AuthErrorStatus.NONCE_REQUIRED);
         }
+
+        // 2. Redis 키 생성
+        String key = getNonceKey(nonce);
+
+        // 3. Redis에 저장 시도
+        Boolean wasUsed = nonceRedisTemplate.opsForValue()
+                .setIfAbsent(key, "used", Duration.ofHours(NONCE_TTL_HOURS));
+
+        // 4. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
+        if (Boolean.FALSE.equals(wasUsed)) {
+            log.warn("[ID 토큰 탈취 의심] : 이미 사용한 ID Token & nonce로 로그인 시도");
+            throw new AuthException(AuthErrorStatus.NONCE_ALREADY_USED);
+        }
+    }
+
+    private String getNonceKey(String nonce) {
+        return String.format("USED_NONCE:%s", nonce);
+    }
+
+    private DecodedJWT verifyIdToken(String idToken, String nonce) {
+        try {
+            // 1. 파싱해서 kid 가져오기
+            DecodedJWT jwt = JWT.decode(idToken);
+            String kid = jwt.getKeyId();
+
+            // 2. 공개키로 RSA256 알고리즘 생성
+            Algorithm algorithm = getAlgorithm(kid);
+
+            // 3. ID Token 검증 및 반환
+            return JWT.require(algorithm)
+                    .withIssuer(KAKAO_ISSUER)
+                    .withAudience(platformKey)
+                    .withClaim("nonce", nonce)
+                    .acceptLeeway(10)
+                    .build()
+                    .verify(idToken);
+        } catch (JwkException | JWTVerificationException e) {
+            throw new AuthException(AuthErrorStatus.KAKAO_ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private Algorithm getAlgorithm(String kid) throws JwkException {
+        // 1. kid로 공개키 찾기
+        Jwk jwk = kakaoJwkProvider.get(kid);
+        RSAPublicKey publicKey = (RSAPublicKey) jwk.getPublicKey();
+
+        // 2. 알고리즘 생성
+        return Algorithm.RSA256(publicKey, null);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
@@ -8,6 +8,6 @@ public interface OAuthService {
     }
 
     default OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
-        throw new UnsupportedOperationException("해당 소셜에서는 nonce를 포함한 ID Token 방식을 지원하지 않음");
+        throw new UnsupportedOperationException("해당 소셜에서는 ID Token 방식을 지원하지 않음");
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
@@ -7,10 +7,6 @@ public interface OAuthService {
         throw new UnsupportedOperationException("해당 소셜에서는 AccessToken 방식을 지원하지 않음");
     }
 
-    default OAuthUserInfo getUserInfoWithIdToken(String idToken) {
-        throw new UnsupportedOperationException("해당 소셜에서는 ID Token 방식을 지원하지 않음");
-    }
-
     default OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
         throw new UnsupportedOperationException("해당 소셜에서는 nonce를 포함한 ID Token 방식을 지원하지 않음");
     }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/OAuthService.java
@@ -4,10 +4,14 @@ import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 
 public interface OAuthService {
     default OAuthUserInfo getUserInfoWithAccessToken(String accessToken) {
-        throw new UnsupportedOperationException("해당 소셜에서는 accessToken 지원하지 않음");
+        throw new UnsupportedOperationException("해당 소셜에서는 AccessToken 방식을 지원하지 않음");
     }
 
     default OAuthUserInfo getUserInfoWithIdToken(String idToken) {
-        throw new UnsupportedOperationException("해당 소셜에서는 idToken 지원하지 않음");
+        throw new UnsupportedOperationException("해당 소셜에서는 ID Token 방식을 지원하지 않음");
+    }
+
+    default OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
+        throw new UnsupportedOperationException("해당 소셜에서는 nonce를 포함한 ID Token 방식을 지원하지 않음");
     }
 }

--- a/src/main/java/umc/teumteum/server/global/config/GoogleOAuthConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/GoogleOAuthConfig.java
@@ -12,13 +12,13 @@ import java.util.Collections;
 @Configuration
 public class GoogleOAuthConfig {
 
-  @Value("${oauth.google.client-id}")
-  private String clientId;
+    @Value("${auth.google.client-id}")
+    private String clientId;
 
-  @Bean
-  public GoogleIdTokenVerifier googleIdTokenVerifier() {
-    return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
-            .setAudience(Collections.singletonList(clientId))
-            .build();
-  }
+    @Bean
+    public GoogleIdTokenVerifier googleIdTokenVerifier() {
+        return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
+    }
 }

--- a/src/main/java/umc/teumteum/server/global/config/KakaoOAuthConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/KakaoOAuthConfig.java
@@ -1,0 +1,21 @@
+package umc.teumteum.server.global.config;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class KakaoOAuthConfig {
+
+    @Bean
+    public JwkProvider kakaoJwkProvider() throws Exception {
+        // 카카오 JWKS 엔드포인트
+        return new JwkProviderBuilder(URI.create("https://kauth.kakao.com/.well-known/jwks.json").toURL())
+                .cached(10, 24, TimeUnit.HOURS)
+                .build();
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/config/KakaoOAuthConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/KakaoOAuthConfig.java
@@ -11,10 +11,12 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class KakaoOAuthConfig {
 
+    private static final String KAKAO_JWKS = "https://kauth.kakao.com/.well-known/jwks.json";
+
     @Bean
     public JwkProvider kakaoJwkProvider() throws Exception {
         // 카카오 JWKS 엔드포인트
-        return new JwkProviderBuilder(URI.create("https://kauth.kakao.com/.well-known/jwks.json").toURL())
+        return new JwkProviderBuilder(URI.create(KAKAO_JWKS).toURL())
                 .cached(10, 24, TimeUnit.HOURS)
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -18,75 +18,81 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Profile("!test")
 public class RedisConfig {
 
-  @Value("${spring.data.redis.host}")
-  private String host;
+    @Value("${spring.data.redis.host}")
+    private String host;
 
-  @Value("${spring.data.redis.password}")
-  private String password;
+    @Value("${spring.data.redis.password}")
+    private String password;
 
-  @Value("${spring.data.redis.port}")
-  private int port;
+    @Value("${spring.data.redis.port}")
+    private int port;
 
-  private LettuceConnectionFactory createConnectionFactory(int dbIndex) {
-    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
-    config.setDatabase(dbIndex);
-    if (!password.isEmpty()) {
-      config.setPassword(RedisPassword.of(password));
-    }
-    LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
-    factory.afterPropertiesSet();
-    return factory;
-  }
-
-  private RedisTemplate<String, String> createRedisTemplate(LettuceConnectionFactory factory) {
-    RedisTemplate<String, String> template = new RedisTemplate<>();
-    template.setConnectionFactory(factory);
-    template.setKeySerializer(new StringRedisSerializer());
-    template.setValueSerializer(new StringRedisSerializer());
-    template.afterPropertiesSet();
-    return template;
-  }
-
-  // RT 화이트리스트용 Redis(index 0)
-  @Bean
-  public RedisTemplate<String, String> rtWhitelistRedisTemplate() {
-    return createRedisTemplate(createConnectionFactory(0));
-  }
-
-  // 알림용 Redis(index 1)
-  @Bean
-  public RedisTemplate<String, String> notificationRedisTemplate() {
-    return createRedisTemplate(createConnectionFactory(1));
-  }
-
-  // AI 컨텐츠용 Redis(index 2)
-  @Bean
-  public RedisTemplate<String, String> aiContentsRedisTemplate() {
-    return createRedisTemplate(createConnectionFactory(2));
-  }
-
-  // AT 블랙리스트용 Redis(index 3)
-  @Bean
-  public RedisTemplate<String, String> atBlacklistRedisTemplate() {
-    return createRedisTemplate(createConnectionFactory(3));
-  }
-
-  // 프로필 이미지 파일용 Redis(index 4)
-  @Bean
-  public RedisTemplate<String, String> profileImageRedisTemplate() {
-    return createRedisTemplate(createConnectionFactory(4));
-  }
-
-  @Bean
-  public RedissonClient redissonClient() {
-    Config config = new Config();
-    SingleServerConfig serverConfig = config.useSingleServer()
-            .setAddress("redis://" + host + ":" + port);
-
-    if(password != null && !password.isEmpty()) {
-      serverConfig.setPassword(password);
+    private LettuceConnectionFactory createConnectionFactory(int dbIndex) {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setDatabase(dbIndex);
+        if (!password.isEmpty()) {
+            config.setPassword(RedisPassword.of(password));
+        }
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        return factory;
     }
 
-    return Redisson.create(config);
-  }
+    private RedisTemplate<String, String> createRedisTemplate(LettuceConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    // RT 화이트리스트용 Redis (index 0)
+    @Bean
+    public RedisTemplate<String, String> rtWhitelistRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(0));
+    }
+
+    // 알림용 Redis (index 1)
+    @Bean
+    public RedisTemplate<String, String> notificationRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(1));
+    }
+
+    // AI 컨텐츠용 Redis (index 2)
+    @Bean
+    public RedisTemplate<String, String> aiContentsRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(2));
+    }
+
+    // AT 블랙리스트용 Redis (index 3)
+    @Bean
+    public RedisTemplate<String, String> atBlacklistRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(3));
+    }
+
+    // 프로필 이미지 파일용 Redis (index 4)
+    @Bean
+    public RedisTemplate<String, String> profileImageRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(4));
+    }
+
+    // Nonce용 Redis (index 5)
+    @Bean
+    public RedisTemplate<String, String> nonceRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(5));
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        SingleServerConfig serverConfig = config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port);
+
+        if (password != null && !password.isEmpty()) {
+            serverConfig.setPassword(password);
+        }
+
+        return Redisson.create(config);
+    }
 }

--- a/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
+++ b/src/main/java/umc/teumteum/server/global/jwt/JwtProvider.java
@@ -17,13 +17,13 @@ import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 @Component
 public class JwtProvider {
 
-    @Value("${jwt.secret}")
+    @Value("${auth.jwt.secret}")
     private String secretKey;
 
-    @Value("${jwt.access-expiration-ms}")
+    @Value("${auth.jwt.access-expiration-ms}")
     private long accessExpirationMs;
 
-    @Value("${jwt.refresh-expiration-ms}")
+    @Value("${auth.jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
 
     private Key key;


### PR DESCRIPTION
### 👀 관련 이슈
#311

### ✨ 작업한 내용
- 카카오: OAuth 2.0 Access Token → OIDC ID Token 검증 방식으로 변경
  - `auth0 java-jwt` 라이브러리로 서명 검증
  - JWKS 엔드포인트에서 공개키 조회

- 구글/카카오: nonce 기반 재생 공격 방지 추가
  - Redis로 nonce 일회성 검증 (TTL 2시간)
  - nonce 중복 사용 시, ID Token 탈취 의심 로깅

### 🌀 PR Point
X

### 🍰 참고사항
- 검토하려던 로직은 FE 연동과 상관없기 때문에 추후 다른 이슈에서 확인 예정 (FE 연동을 고려하여 먼저 카카오/구글 반영)
- 네이버는 OIDC 미지원
- ID 토큰 검증 시 플랫폼 키 vs 클라이언트 ID 차이
  - 카카오:
    - 안드로이드 로그인 → 안드로이드 플랫폼 키로 ID Token 발급
    - 백엔드 검증 → 안드로이드 플랫폼 키로 검증
- 구글:
  - 안드로이드 로그인 → `serverClientId`에 백엔드 웹 클라이언트 ID 지정하여 ID Token 발급
  - 백엔드 검증 → 백엔드 웹 클라이언트 ID로 검증

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
|  ID Token 안에 nonce값  |  <img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/b8ce5ffc-03b4-43af-8477-9b8554ed2fff" /> |
|  잘못된 nonce값  |  <img width="500" height="600" alt="스크린샷 2026-01-07 오후 4 56 19" src="https://github.com/user-attachments/assets/78653b63-95de-437a-9aa8-1613c355d029" />  |
|  맞는 nonce값  |  <img width="500" height="600" alt="스크린샷 2026-01-07 오후 4 57 06" src="https://github.com/user-attachments/assets/c0dd1b19-e752-4dd2-802b-b181765a983b" />  |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오·구글 소셜 로그인에서 ID 토큰 기반 인증과 nonce 전달을 지원합니다.

* **Security**
  * Nonce 단회성 검증으로 재생 공격 방지(2시간 TTL) 및 ID 토큰 검증 도입으로 보안 강화.
  * 인증 오류 케이스와 메시지 개선으로 실패 원인 식별성 향상.

* **Chores**
  * OIDC/JWT 관련 라이브러리 추가 및 인증 구성 키 정리.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->