### PR TITLE
Chore: 카카오 ID Token 검증 실패 에러 로그 추가 및 TTL 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class GoogleOAuthServiceImpl implements OAuthService {
 
-    private static final long NONCE_TTL_HOURS = 2;
+    private static final long NONCE_TTL_HOURS = 1;
 
     private final GoogleIdTokenVerifier googleIdTokenVerifier;
 

--- a/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
@@ -28,7 +28,7 @@ import java.time.Duration;
 public class KakaoOAuthServiceImpl implements OAuthService {
 
     private static final String KAKAO_ISSUER = "https://kauth.kakao.com";
-    private static final long NONCE_TTL_HOURS = 2;
+    private static final long NONCE_TTL_HOURS = 12;
 
     @Value("${auth.kakao.platform-key}")
     private String platformKey;
@@ -98,6 +98,7 @@ public class KakaoOAuthServiceImpl implements OAuthService {
                     .build()
                     .verify(idToken);
         } catch (JwkException | JWTVerificationException e) {
+            log.error("카카오 ID Token 검증 실패 - {}", e.getMessage());
             throw new AuthException(AuthErrorStatus.KAKAO_ID_TOKEN_VERIFICATION_FAILED);
         }
     }


### PR DESCRIPTION
### 👀 관련 이슈
#320 

### ✨ 작업한 내용
- 현재 서버에서 발생하고 있는 카카오 ID 토큰 검증 실패 원인을 확인하기 위한 에러 로그 추가
- 카카오/구글 ID 토큰 만료시간에 따라 TTL 수정

### 🌀 PR Point
X

### 🍰 참고사항
- 카카오 ID 토큰 만료시간 - 12시간
  <img width="1530" height="794" alt="image" src="https://github.com/user-attachments/assets/bf739c84-b271-4846-8f64-55f1e9c945ad" />
- 구글 ID 토큰 만료시간 - 1시간
  <img width="166" height="54" alt="스크린샷 2026-01-11 오후 8 43 59" src="https://github.com/user-attachments/assets/5abf244b-ac51-43c8-84fb-125d486c0798" />


### 📷 스크린샷 또는 GIF
<img width="1307" height="100" alt="스크린샷 2026-01-11 오후 8 39 52" src="https://github.com/user-attachments/assets/890267bf-4e14-49fc-bee5-4e4c0c65d73d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * Google OAuth 보안이 강화되어 nonce 유효 기간이 2시간에서 1시간으로 단축되었습니다.
  * Kakao OAuth 사용 편의성 개선을 위해 nonce 유효 기간이 2시간에서 12시간으로 연장되었습니다.
  * ID 토큰 검증 실패 시 에러 로깅이 추가되어 문제 추적이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->