### PR TITLE
[Feat] 특정 날짜 틈 요청 조회 API에 취소 가능 여부(isCancellable) 필드 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -308,6 +308,7 @@ public class TeumConverter {
             TeumRequest request,
             boolean isCancelled,
             boolean isResend,
+            boolean isCancellable,
             Map<Long, String> profileUrlByUserId
     ) {
         // 요청 시간 정보를 TimeSlot 객체로 변환
@@ -348,6 +349,7 @@ public class TeumConverter {
                 .requester(requester)
                 .isCancelled(isCancelled)
                 .isResend(isResend)
+                .isCancellable(isCancellable)
                 .pending(pending)
                 .accepted(accepted)
                 .cancelled(cancelled)

--- a/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/dto/TeumResponseDto.java
@@ -225,6 +225,10 @@ public class TeumResponseDto {
         @Schema(description = "취소 여부", example = "true")
         private boolean isCancelled;
 
+        @JsonProperty("isCancellable")
+        @Schema(description = "취소 가능 여부 (본인 요청 & 미응답 & 시작 전)", example = "true")
+        private boolean isCancellable;
+
         @Schema(description = "PENDING 상태인 응답자 목록")
         private List<ParticipantDto> pending;
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -562,6 +562,9 @@ public class TeumServiceImpl implements TeumService {
                     // 약속 취소 여부 판단
                     boolean isCancelled = isTeumCancelled(req);
 
+                    // 취소 가능 여부 계산 로직
+                    boolean isCancellable = checkIfCancellable(req, userId);
+
                     // 요청자 + 응답자 전원의 URL 맵 구성
                     Map<Long, String> urlMap = new HashMap<>();
                     User requester = req.getUser();
@@ -573,7 +576,7 @@ public class TeumServiceImpl implements TeumService {
                     });
 
                     // DTO로 변환
-                    return teumConverter.toTeumRequestResponseDto(req, isCancelled, isResend, urlMap);
+                    return teumConverter.toTeumRequestResponseDto(req, isCancelled, isResend, isCancellable, urlMap);
                 })
                 .toList();
     }
@@ -832,6 +835,24 @@ public class TeumServiceImpl implements TeumService {
                 blockRepository.existsByBlockerAndBlocked(user2, user1)) {
             throw new GeneralException(FriendErrorStatus.BLOCK_ACTION_FORBIDDEN);
         }
+    }
+
+    // 취소 가능 여부 판단 헬퍼 메서드
+    private boolean checkIfCancellable(TeumRequest request, Long userId) {
+        // 본인이 요청자인지 확인
+        if (!request.getUser().getId().equals(userId)) {
+            return false;
+        }
+
+        // 시작 시간이 현재 시각보다 미래인지 확인
+        LocalDateTime startDateTime = LocalDateTime.of(request.getDate(), request.getStartTime());
+        if (startDateTime.isBefore(LocalDateTime.now())) {
+            return false;
+        }
+
+        // 아무도 응답하지 않았는지 확인 (모든 응답이 PENDING 상태여야 함)
+        return request.getTeumResponses().stream()
+                .allMatch(response -> response.getStatus() == ResponseStatus.PENDING);
     }
 
 }


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#324 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 본인이 요청자이고, 시작 시간이 지나지 않았으며, 상대방이 응답하지 않은 경우에 한해 true 반환
- TeumRequestDetail DTO 및 Converter 로직 수정
- TeumServiceImpl에 취소 가능 여부 판단 로직(checkIfCancellable) 구현

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 취소 여부 추가 | <img width="1171" height="827" alt="image" src="https://github.com/user-attachments/assets/3994762a-2716-402b-8b84-b45eec325213" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 팀 요청의 취소 가능 여부를 표시하는 기능 추가. 본인이 요청한 팀이 시작 전이고 모든 응답이 미확정 상태인 경우에만 취소 가능으로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->