### PR TITLE
Fix : 리마인드 알림 스케줄러

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleReminderRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleReminderRepository.java
@@ -79,5 +79,18 @@ public interface ScheduleReminderRepository extends JpaRepository<ScheduleRemind
             @Param("next") DispatchStatus next
     );
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update ScheduleReminder r
+        set r.dispatchStatus = :to
+        where r.id = :id
+        and r.dispatchStatus = :from
+    """)
+    int updateDispatchStatusById(
+            @Param("id") Long id,
+            @Param("from") DispatchStatus from,
+            @Param("to") DispatchStatus to
+    );
+
 
 }

--- a/src/main/java/umc/teumteum/server/global/reminder/event/ReminderEvent.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/event/ReminderEvent.java
@@ -1,0 +1,6 @@
+package umc.teumteum.server.global.reminder.event;
+
+import java.util.List;
+
+public record ReminderEvent(List<Long> reminderIds){
+}

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -34,11 +34,7 @@ public class ReminderEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReminderEvent(ReminderEvent event) {
 
-        List<ScheduleReminder> reminders =
-                scheduleReminderRepository.findByIdsWithScheduleAndUser(
-                        event.reminderIds(),
-                        DispatchStatus.PROCESSING
-                );
+        List<ScheduleReminder> reminders = scheduleReminderRepository.findByScheduleIdIn(event.reminderIds());
 
         for (ScheduleReminder r : reminders) {
             try{

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -38,13 +38,22 @@ public class ReminderEventListener {
                 event.reminderIds(), DispatchStatus.PROCESSING);
 
         for (ScheduleReminder r : reminders) {
+            // 리마인드 알림 전송
             try{
                 send(r);
-                markSent(r.getId());
             } catch (Exception e){
                 markFailed(r.getId());
                 log.warn("Failed to send reminder [id={}]: {}", r.getId(), e.getMessage(), e);
+                continue;
             }
+
+            // 성공 상태 업데이트
+            try{
+                markSent(r.getId());
+            } catch (Exception e){
+                log.error("Push sent but failed to update status [id={}].", r.getId(), e);
+            }
+
         }
     }
 

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -29,7 +30,7 @@ public class ReminderEventListener {
     private final NotificationOrchestrator orchestrator;
 
     @Async
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReminderEvent(ReminderEvent event) {
 

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -1,0 +1,100 @@
+package umc.teumteum.server.global.reminder.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.teumteum.server.domain.home.entity.Schedule;
+import umc.teumteum.server.domain.home.entity.ScheduleReminder;
+import umc.teumteum.server.domain.home.entity.enums.DispatchStatus;
+import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
+import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
+import umc.teumteum.server.domain.notification.service.NotificationOrchestrator;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.global.reminder.event.ReminderEvent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderEventListener {
+
+    private final ScheduleReminderRepository scheduleReminderRepository;
+    private final NotificationOrchestrator orchestrator;
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReminderEvent(ReminderEvent event) {
+
+        List<ScheduleReminder> reminders =
+                scheduleReminderRepository.findByIdsWithScheduleAndUser(
+                        event.reminderIds(),
+                        DispatchStatus.PROCESSING
+                );
+
+        for (ScheduleReminder r : reminders) {
+            try{
+                send(r);
+                markSent(r.getId());
+            } catch (Exception e){
+                markFailed(r.getId());
+                log.warn(e.getMessage());
+            }
+        }
+    }
+
+    // 리마인드 알림 전송
+    private void send(ScheduleReminder r){
+        // data 구성
+        Schedule schedule = r.getSchedule();
+        User receiver = schedule.getUser();
+        int minutes = r.getReminderTime();
+
+        String content = minutes <= 0 ? "곧 투두가 시작돼요." : minutes + "분 뒤 투두가 시작돼요.";
+
+        Map<String, String> data = new HashMap<>();
+        data.put("scheduleId", String.valueOf(schedule.getId()));
+        data.put("title", schedule.getTitle());
+        data.put("startTime", String.valueOf(schedule.getStartTime()));
+        data.put("endTime", String.valueOf(schedule.getEndTime()));
+        data.put("reminderMinutes", String.valueOf(r.getReminderTime()));
+
+        // 푸시 알림 전송 로직 위임
+        orchestrator.saveAndPush(
+                receiver,
+                NotificationType.REMIND_ALARM,
+                content,
+                schedule.getId(),
+                data
+        );
+    }
+
+    // 성곰 상태 업데이트
+    private void markSent(Long scheduleId){
+        int updated = scheduleReminderRepository.updateDispatchStatusById(
+                scheduleId, DispatchStatus.PROCESSING, DispatchStatus.SENT
+        );
+
+        if(updated == 0){
+            log.warn("Reminder already processed.");
+        }
+    }
+
+    // 실패 상태 업데이트
+    private void markFailed(Long scheduleId){
+        int updated = scheduleReminderRepository.updateDispatchStatusById(
+                scheduleId, DispatchStatus.PROCESSING, DispatchStatus.FAILED
+        );
+
+        if(updated == 0){
+            log.warn("Reminder already processed.");
+        }
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -34,7 +34,8 @@ public class ReminderEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReminderEvent(ReminderEvent event) {
 
-        List<ScheduleReminder> reminders = scheduleReminderRepository.findByScheduleIdIn(event.reminderIds());
+        List<ScheduleReminder> reminders = scheduleReminderRepository.findByIdsWithScheduleAndUser(
+                event.reminderIds(), DispatchStatus.PROCESSING);
 
         for (ScheduleReminder r : reminders) {
             try{

--- a/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
+++ b/src/main/java/umc/teumteum/server/global/reminder/listener/ReminderEventListener.java
@@ -46,7 +46,7 @@ public class ReminderEventListener {
                 markSent(r.getId());
             } catch (Exception e){
                 markFailed(r.getId());
-                log.warn(e.getMessage());
+                log.warn("Failed to send reminder [id={}]: {}", r.getId(), e.getMessage(), e);
             }
         }
     }
@@ -77,25 +77,25 @@ public class ReminderEventListener {
         );
     }
 
-    // 성곰 상태 업데이트
-    private void markSent(Long scheduleId){
+    // 성공 상태 업데이트
+    private void markSent(Long reminderId){
         int updated = scheduleReminderRepository.updateDispatchStatusById(
-                scheduleId, DispatchStatus.PROCESSING, DispatchStatus.SENT
+                reminderId, DispatchStatus.PROCESSING, DispatchStatus.SENT
         );
 
         if(updated == 0){
-            log.warn("Reminder already processed.");
+            log.warn("Reminder [id={}] already processed.", reminderId);
         }
     }
 
     // 실패 상태 업데이트
-    private void markFailed(Long scheduleId){
+    private void markFailed(Long reminderId){
         int updated = scheduleReminderRepository.updateDispatchStatusById(
-                scheduleId, DispatchStatus.PROCESSING, DispatchStatus.FAILED
+                reminderId, DispatchStatus.PROCESSING, DispatchStatus.FAILED
         );
 
         if(updated == 0){
-            log.warn("Reminder already processed.");
+            log.warn("Reminder [id={}] already processed.", reminderId);
         }
     }
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -15,6 +15,7 @@ import umc.teumteum.server.global.reminder.event.ReminderEvent;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -47,7 +48,13 @@ public class RemindAlarmScheduler {
 
         if (locked == 0) return;
 
-        // 3. 이벤트 발생
-        eventPublisher.publishEvent(new ReminderEvent(targetIds));
+        // 3. 선점 성공한 것만 다시 조회 후 이벤트 발생
+        List<Long> lockedIds = scheduleReminderRepository.findByIdsWithScheduleAndUser(
+                targetIds, DispatchStatus.PROCESSING
+        ).stream().map(ScheduleReminder::getId).toList();
+
+        if(!lockedIds.isEmpty()){
+            eventPublisher.publishEvent(new ReminderEvent(lockedIds));
+        }
     }
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.global.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.home.entity.enums.AlarmStatus;
 import umc.teumteum.server.domain.home.entity.enums.DispatchStatus;
 import umc.teumteum.server.domain.home.repository.ScheduleReminderRepository;
-import umc.teumteum.server.domain.notification.service.NotificationUseCases;
+import umc.teumteum.server.global.reminder.event.ReminderEvent;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,47 +22,32 @@ import java.util.List;
 public class RemindAlarmScheduler {
 
     private final ScheduleReminderRepository scheduleReminderRepository;
-    private final NotificationUseCases notificationUseCases;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    @Scheduled(fixedRate = 60000, zone = "Asia/Seoul") // 1분마다 실행
+    @Scheduled(fixedRate = 60000, zone = "Asia/Seoul")
     public void remindAlarm() {
         LocalDateTime now = LocalDateTime.now();
 
-        // 1. 발송 대상 조회 (최대 100개)
+        // 1. 발송 대상 조회
         List<ScheduleReminder> targets = scheduleReminderRepository.findDueWithScheduleAndUser(
-            AlarmStatus.ACTIVE, DispatchStatus.PENDING, now, PageRequest.of(0, 100)
+                AlarmStatus.ACTIVE, DispatchStatus.PENDING, now, PageRequest.of(0, 100)
         );
 
-        if (targets.isEmpty())
-            return;
+        if(targets.isEmpty()) return;
 
-        // 2. 선점하기  (발송 상태 변경하기 PENDING -> PROCESSING)
+        // 2. 선점
         List<Long> targetIds = targets.stream().map(ScheduleReminder::getId).toList();
 
-        int lockedCount = scheduleReminderRepository.updateDispatchStatus(targetIds,
-            DispatchStatus.PENDING, DispatchStatus.PROCESSING);
-        if (lockedCount == 0) return;
+        int locked = scheduleReminderRepository.updateDispatchStatus(
+                targetIds,
+                DispatchStatus.PENDING,
+                DispatchStatus.PROCESSING
+        );
 
-        processNotifications(targetIds);
+        if (locked == 0) return;
 
-    }
-    public void processNotifications(List<Long> targetIds) {
-
-        // 3. 선점 성공한 것들 다시 조회
-        List<ScheduleReminder> locked = scheduleReminderRepository.findByIdsWithScheduleAndUser(targetIds,DispatchStatus.PROCESSING);
-        if(locked.isEmpty()) return;
-
-        // 4. DB 저장 & 푸시알림 & 상태변경 UseCase에 위임
-        try{
-            notificationUseCases.notifyReminder(locked);
-        } catch(Exception e){
-            log.error("리마인드 알림 발송 실패. locked count={}", locked.size(), e);
-            // PROCESSING 상태인 리마인더들 -> FAILED로 변경
-            List<Long> lockedIds = locked.stream().map(ScheduleReminder::getId).toList();
-            scheduleReminderRepository.updateDispatchStatusByIds(
-                    lockedIds, DispatchStatus.PROCESSING, DispatchStatus.FAILED
-            );
-        }
+        // 3. 이벤트 발생
+        eventPublisher.publishEvent(new ReminderEvent(targetIds));
     }
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/RemindAlarmScheduler.java
@@ -15,7 +15,6 @@ import umc.teumteum.server.global.reminder.event.ReminderEvent;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#326 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
기존 스케줄러 로직은 한 트랜잭션 안에서 FCM 전송과 DB 저장을 동시에 처리하면서 세션 문제가 발생했습니다.
이를 해결하기 위해 스케줄러를 통해 발신 대상을 조회 및 선점하고 커밋 이후에 이벤트 리스너를 통해 notification 엔티티를 생성하고 FCM 푸시 알림을 전송하는 로직으로 수정했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
리마인드 알림 전송 스케줄러 개선

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 알림 전송을 이벤트 기반으로 전환해 발행/처리 흐름을 분리하고 확장성 향상
  * 스케줄러는 직접 전송하지 않고 알림 ID를 발행해 처리 책임 분리

* **New**
  * 알림 대상 ID를 담는 이벤트 타입과 이를 비동기/별도 트랜잭션으로 처리하는 리스너 추가
  * 개별 알림 상태를 원자적으로 업데이트하는 단일-항목 상태 전환 지원 추가

* **버그 픽스**
  * 전송 성공/실패에 따른 상태 업데이트와 실패 로깅을 강화해 일관성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->