### PR TITLE
Fix : 회원 탈퇴 익명화 안되는 오류 수정 

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -171,7 +171,7 @@ public class User extends BaseEntity {
         this.socialId = "deleted-" + this.id + "-" + token;
         this.email = "deleted-" + this.id + "-" + token + "@deleted.local";
 
-        this.nickname = "탈퇴회원-" + this.id + "-" + token.substring(0, 8);
+        this.nickname = null;
         this.sleepTime = null;
         this.wakeTime = null;
         this.job = null;

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -176,7 +176,5 @@ public class User extends BaseEntity {
         this.wakeTime = null;
         this.job = null;
         this.timePublic = false;
-
-        this.profileImageName = DEFAULT_PROFILE_IMAGE;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -554,14 +554,14 @@ public class UserServiceImpl implements UserService {
         User u = userRepository.findById(user.getId())
                 .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
 
-        // 1. 유저 관련 데이터 삭제
+        // 1. 유저 익명화
+        u.withdraw();
+
+        // 2. 유저 관련 데이터 삭제
         userDataCleaner.clean(u.getId());
 
-        // 2. 프로필 이미지 삭제
+        // 3. 프로필 이미지 삭제
         deleteUserImage(u);
-
-        // 3. 유저 익명화
-        u.withdraw();
     }
 
     // 수면패턴 삭제

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -555,14 +555,14 @@ public class UserServiceImpl implements UserService {
         User u = userRepository.findById(user.getId())
                 .orElseThrow(()-> new UserException(UserErrorStatus.USER_NOT_FOUND));
 
-        // 1. 유저 익명화
+        // 1. 프로필 이미지 객체 삭제
+        deleteUserImage(u);
+
+        // 2. 유저 익명화
         u.withdraw();
 
-        // 2. 유저 관련 데이터 삭제
+        // 3. 유저 관련 데이터 삭제
         userDataCleaner.clean(u.getId());
-
-        // 3. 프로필 이미지 삭제
-        deleteUserImage(u);
     }
 
     // 수면패턴 삭제

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -92,6 +92,7 @@ public class UserServiceImpl implements UserService {
         Comparator<Map.Entry<User, Integer>> byDistance = Comparator.comparingInt(Map.Entry::getValue);
 
         return userRepository.searchUserWithBlockCheck(keyword, userId).stream()
+                .filter(u -> u.getStatus() != UserStatus.INACTIVE)
                 .map(user -> Map.entry(user,
                         distanceCalculator.apply(keywordLower, user.getNickname().toLowerCase())))
                 .sorted(byDistance)


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#329 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
[오류]
회원탈퇴 API 호출시 관련 데이터는 모두 삭제되지만 익명화가 DB에 반영되지 않던 오류가 발생했습니다.

[원인]
기존 로직에서 유저 관련 데이터를 bulk delete로 삭제한 이후 영속 상태의 User 엔티티에 대해 익명화 메서드를 수행합니다.
이 과정에서 bulk delete는 영속성 컨텍스트를 무시하고 DB에 직접 반영되기 때문에 이후 dirty checking이 동작하지 않아 User에 대한 UPDATE 쿼리가 발생하지 않았던 것으로 확인되었습니다.

[해결방안]
순서를 변경하여 익명화 메서드 -> bulk delete로 호출 순서를 변경하였습니다.


### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
DELETE `/api/users/mypage`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회원 탈퇴 시 닉네임을 제거해 익명화 처리를 개선했습니다.
  * 탈퇴 처리 흐름을 재정렬하여 프로필 이미지 삭제를 먼저 실행한 뒤 익명화 및 관련 데이터 정리로 안정성을 높였습니다.
  * 검색 결과에서 비활성화된 사용자를 제외하도록 필터링을 추가해 검색 정확성을 향상시켰습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->