### PR TITLE
[Fix] 틈 요청 취소 시 상태값 길이 초과 오류 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/entity/enums/ResponseStatus.java
@@ -6,6 +6,6 @@ public enum ResponseStatus {
     REJECTED,   // 수신자가 요청을 거절
     RESEND,     // 수신자가 시간대 바꿔 재요청
     LEFT,       // 수신자가 요청을 수락했다가 취소함
-    CANCELED_BY_REQUESTER,  // 송신자가 요청을 취소하여 응답 무효
+    CANCELED,   // 송신자가 요청을 취소하여 응답 무효
     REPORTED    // 수신자가 해당 요청을 신고함
 }

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -1,7 +1,6 @@
 package umc.teumteum.server.domain.teum.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.http.client.reactive.AbstractClientHttpConnectorProperties;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -602,7 +601,7 @@ public class TeumServiceImpl implements TeumService {
         // 연결된 응답을 모두 비활성화 처리 (응답 불가하도록)
         for (TeumResponse response : request.getTeumResponses()) {
             if (response.getStatus() == ResponseStatus.PENDING) {
-                response.changeStatus(ResponseStatus.CANCELED_BY_REQUESTER);
+                response.changeStatus(ResponseStatus.CANCELED);
             }
         }
 
@@ -693,7 +692,7 @@ public class TeumServiceImpl implements TeumService {
         // 응답자가 모두 거절 또는 취소한 경우
         boolean allResponsesCancelled = request.getTeumResponses().stream()
                 .allMatch(r -> r.getStatus() == ResponseStatus.REJECTED || r.getStatus() == ResponseStatus.LEFT ||
-                        r.getStatus() == ResponseStatus.CANCELED_BY_REQUESTER);
+                        r.getStatus() == ResponseStatus.CANCELED);
 
         // 최종 취소 판단 조건
         return hasNoPending && (allSchedulesCancelled || (hasNoSchedules && allResponsesCancelled));


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#331 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- Enum 명칭 수정 및 최적화: ResponseStatus 내의 CANCELED_BY_REQUESTER 상수를 CANCELED로 변경하여 데이터베이스 저장 시 문자열 길이 제한 문제를 해결함
- 서비스 로직 업데이트: TeumServiceImpl.cancelTeumRequest 메서드에서 취소 시 할당되는 응답 상태값을 변경된 Enum 상수(ResponseStatus.CANCELED)에 맞게 수정함

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- Enum Rename 영향도: ResponseStatus 명칭 변경이 서비스 내 다른 로직(응답 조회, 상태 업데이트 등)에 미치는 영향이 없는지 확인이 필요함

### 🍰 참고사항
- 기존 DB에 CANCELED_BY_REQUESTER 값이 저장되어 있다면 마이그레이션 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **내부 개선**
  * 내부 상태 관리 로직을 개선했습니다. 사용자 환경에는 영향이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->