### PR TITLE
[Feat] 관리자용 신고 처리 API 구현 및 제재 처리

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
@@ -8,19 +8,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("SELECT f FROM Friend f " +
             "WHERE f.follower.id = :followerId " +
-            "AND f.following.status = 'ACTIVE'")
-    Slice<Friend> findByFollowerId(@Param("followerId") Long followerId, Pageable pageable);
+            "AND f.following.status = :status ")
+    Slice<Friend> findByFollowerId(@Param("followerId") Long followerId, @Param("status") UserStatus status, Pageable pageable);
 
     @Query("SELECT f FROM Friend f " +
             "WHERE f.following.id = :followingId " +
-            "AND f.follower.status = 'ACTIVE'")
-    Slice<Friend> findByFollowingId(@Param("followingId") Long followingId, Pageable pageable);
+            "AND f.follower.status = :status ")
+    Slice<Friend> findByFollowingId(@Param("followingId") Long followingId, @Param("status") UserStatus status, Pageable pageable);
 
     Optional<Friend> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
@@ -30,12 +31,12 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("SELECT f1 FROM Friend f1 " +
             "WHERE f1.follower = :user " +
-            "AND f1.following.status = 'ACTIVE' " +
+            "AND f1.following.status = :status " +
             "AND EXISTS (SELECT f2 FROM Friend f2 " +
             "WHERE f2.follower = f1.following " +
             "AND f2.following = :user) " +
             "AND f1.following != :excludeUser")
-    Slice<Friend> findMutualFriendsExcluding(User user, User excludeUser, Pageable pageable);
+    Slice<Friend> findMutualFriendsExcluding(User user, User excludeUser, @Param("status") UserStatus status, Pageable pageable);
 
     // 차단 시 두 유저 간의 모든 팔로우 관계(A->B, B->A)를 삭제
     @Modifying(clearAutomatically = true)

--- a/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
@@ -12,9 +12,15 @@ import umc.teumteum.server.domain.user.entity.User;
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
-    Slice<Friend> findByFollowerId(Long followerId, Pageable pageable);
+    @Query("SELECT f FROM Friend f " +
+            "WHERE f.follower.id = :followerId " +
+            "AND f.following.status = 'ACTIVE'")
+    Slice<Friend> findByFollowerId(@Param("followerId") Long followerId, Pageable pageable);
 
-    Slice<Friend> findByFollowingId(Long followingId, Pageable pageable);
+    @Query("SELECT f FROM Friend f " +
+            "WHERE f.following.id = :followingId " +
+            "AND f.follower.status = 'ACTIVE'")
+    Slice<Friend> findByFollowingId(@Param("followingId") Long followingId, Pageable pageable);
 
     Optional<Friend> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
@@ -24,6 +30,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("SELECT f1 FROM Friend f1 " +
             "WHERE f1.follower = :user " +
+            "AND f1.following.status = 'ACTIVE' " +
             "AND EXISTS (SELECT f2 FROM Friend f2 " +
             "WHERE f2.follower = f1.following " +
             "AND f2.following = :user) " +

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -30,6 +30,7 @@ import umc.teumteum.server.domain.home.entity.enums.ScheduleType;
 import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.notification.service.NotificationUseCases;
 import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.util.S3Util;
@@ -120,7 +121,7 @@ public class FriendServiceImpl implements FriendService {
 
         // 4. 맞팔로우 관계 조회 (특정 사용자 제외)
         Slice<Friend> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(loginUser, excludeUser,
-                pageable);
+                UserStatus.ACTIVE, pageable);
 
         // 5. 맞팔로우한 상대방들에 대한 S3 프리사인드 URL 생성 및 Dto 변환
         List<FriendResponseDto.MutualFriend> mutualFriendList = mutualFriendsSlice.getContent()
@@ -171,7 +172,7 @@ public class FriendServiceImpl implements FriendService {
                 Sort.by(Sort.Order.desc("isFavorite"), Sort.Order.asc("following.nickname"))
         );
 
-        Slice<Friend> slice = friendRepository.findByFollowerId(userId, pageable);
+        Slice<Friend> slice = friendRepository.findByFollowerId(userId, UserStatus.ACTIVE, pageable);
 
         List<FriendResponseDto.FollowingFriend> dtoList = slice.getContent().stream()
                 .map(friend -> {
@@ -194,7 +195,7 @@ public class FriendServiceImpl implements FriendService {
                 Sort.by("follower.nickname").ascending()
         );
 
-        Slice<Friend> slice = friendRepository.findByFollowingId(userId, pageable);
+        Slice<Friend> slice = friendRepository.findByFollowingId(userId, UserStatus.ACTIVE, pageable);
 
         List<FriendResponseDto.FollowerFriend> dtoList = slice.getContent().stream()
                 .map(friend -> {

--- a/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
+++ b/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import umc.teumteum.server.domain.report.dto.ReportRequestDto;
 import umc.teumteum.server.domain.report.dto.ReportResponseDto;
 import umc.teumteum.server.domain.report.exception.status.ReportSuccessStatus;
 import umc.teumteum.server.domain.report.service.ReportService;
@@ -30,5 +31,15 @@ public class AdminReportController {
                 = reportService.getReportDetail(reportId);
 
         return ApiResponse.of(ReportSuccessStatus.REPORT_DETAIL_FETCHED, response);
+    }
+
+    @Operation(summary = "신고 처리 (피드백)", description = "관리자가 신고에 대해 정지 또는 반려 처리를 진행합니다.")
+    @PatchMapping("/{reportId}/process")
+    public ApiResponse<Void> processReport(
+            @PathVariable Long reportId,
+            @RequestBody ReportRequestDto.ProcessReport request
+    ) {
+        reportService.processReport(reportId, request);
+        return ApiResponse.of(ReportSuccessStatus.REPORT_PROCESSED, null);
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
+++ b/src/main/java/umc/teumteum/server/domain/report/controller/AdminReportController.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.domain.report.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,11 +34,11 @@ public class AdminReportController {
         return ApiResponse.of(ReportSuccessStatus.REPORT_DETAIL_FETCHED, response);
     }
 
-    @Operation(summary = "신고 처리 (피드백)", description = "관리자가 신고에 대해 정지 또는 반려 처리를 진행합니다.")
+    @Operation(summary = "신고 처리 (피드백)", description = "관리자가 신고에 대해 정지 또는 반려 처리를 진행합니다. (SUSPEND, DISMISS)")
     @PatchMapping("/{reportId}/process")
     public ApiResponse<Void> processReport(
             @PathVariable Long reportId,
-            @RequestBody ReportRequestDto.ProcessReport request
+            @Valid @RequestBody ReportRequestDto.ProcessReport request
     ) {
         reportService.processReport(reportId, request);
         return ApiResponse.of(ReportSuccessStatus.REPORT_PROCESSED, null);

--- a/src/main/java/umc/teumteum/server/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/report/dto/ReportRequestDto.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.teumteum.server.domain.report.entity.enums.ReportProcessType;
 import umc.teumteum.server.domain.report.entity.enums.TargetType;
 
 public class ReportRequestDto {
@@ -31,5 +32,19 @@ public class ReportRequestDto {
 
         @Schema(description = "기타 사유(reasonId가 7일 때)를 선택했을 경우 구체적인 내용을 입력합니다. 그 외에는 null을 보내주세요.", example = "상대방이 지속적으로 비속어를 사용합니다.")
         private String otherReason;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "신고 처리: 관리자가 신고를 처리하는 DTO")
+    public static class ProcessReport {
+
+        @NotNull(message = "처리 방식은 필수입니다.")
+        @Schema(description = "처리 방식 (SUSPEND: 정지, DISMISS: 반려)", example = "SUSPEND")
+        private ReportProcessType processType;
+
+        @Schema(description = "관리자 처리 사유 및 메모", example = "부적절한 언어 사용 반복 확인으로 1개월 정지 처리함")
+        private String adminMemo;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/report/entity/Report.java
+++ b/src/main/java/umc/teumteum/server/domain/report/entity/Report.java
@@ -6,11 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Check;
+import umc.teumteum.server.domain.report.entity.enums.ReportProcessType;
 import umc.teumteum.server.domain.report.entity.enums.ReportStatus;
 import umc.teumteum.server.domain.report.entity.enums.TargetType;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.common.BaseEntity;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -60,5 +63,25 @@ public class Report extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private ReportStatus status = ReportStatus.OPEN;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "process_type")
+    private ReportProcessType processType; // SUSPEND(정지), DISMISS(반려)
+
+    @Column(name = "admin_memo", columnDefinition = "TEXT")
+    private String adminMemo; // 관리자 메모
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt; // 처리 완료 시점
+
+    /*
+        비즈니스 로직: 어떤 처분이든 완료되면 RESOLVED로 변경
+    */
+    public void resolve(ReportProcessType processType, String adminMemo) {
+        this.processType = processType;
+        this.adminMemo = adminMemo;
+        this.processedAt = LocalDateTime.now();
+        this.status = ReportStatus.RESOLVED; //
+    }
 
 }

--- a/src/main/java/umc/teumteum/server/domain/report/entity/enums/ReportProcessType.java
+++ b/src/main/java/umc/teumteum/server/domain/report/entity/enums/ReportProcessType.java
@@ -1,0 +1,6 @@
+package umc.teumteum.server.domain.report.entity.enums;
+
+public enum ReportProcessType {
+    SUSPEND,    // 계정 정지 (임시 또는 영구)
+    DISMISS     // 반려
+}

--- a/src/main/java/umc/teumteum/server/domain/report/entity/enums/ReportStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/entity/enums/ReportStatus.java
@@ -1,8 +1,6 @@
 package umc.teumteum.server.domain.report.entity.enums;
 
 public enum ReportStatus {
-    OPEN,       // 신고 오픈
-    REVIEWING,  // 검토 중
-    RESOLVED,   // 처리 완료
-    DISMISSED   // 처리 거부
+    OPEN,      // 신고 접수 및 대기
+    RESOLVED   // 처리 완료 (정지, 반려 등)
 }

--- a/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportErrorStatus.java
@@ -21,6 +21,7 @@ public enum ReportErrorStatus implements BaseErrorCode {
     REPORT_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "REPORT4003", "지원하지 않는 신고 대상입니다."),
     REPORT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "REPORT4004", "대기 중인 요청만 신고할 수 있습니다."),
     REPORT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REPORT4005", "이미 신고한 대상입니다."), // 중복 신고 방지용 추가
+    REPORT_ALREADY_RESOLVED(HttpStatus.BAD_REQUEST, "REPORT4006", "이미 처리가 완료된 신고 내역입니다.")
 
     ;
 

--- a/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/report/exception/status/ReportSuccessStatus.java
@@ -11,7 +11,8 @@ import umc.teumteum.server.global.apiPayload.code.ReasonDto;
 public enum ReportSuccessStatus implements BaseCode {
 
     REPORT_CREATED(HttpStatus.OK, "REPORT2001", "신고가 성공적으로 접수되었습니다."),
-    REPORT_DETAIL_FETCHED(HttpStatus.OK, "REPORT2002", "신고 상세 정보를 성공적으로 조회했습니다.");
+    REPORT_DETAIL_FETCHED(HttpStatus.OK, "REPORT2002", "신고 상세 정보를 성공적으로 조회했습니다."),
+    REPORT_PROCESSED(HttpStatus.OK, "REPORT2003", "신고 처리가 성공적으로 완료되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportService.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportService.java
@@ -7,4 +7,5 @@ import umc.teumteum.server.domain.user.entity.User;
 public interface ReportService {
     void createReport(User reporter, ReportRequestDto.CreateReport request);
     ReportResponseDto.ReportDetail getReportDetail(Long reportId);
+    void processReport(Long reportId, ReportRequestDto.ProcessReport request);
 }

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -127,6 +127,10 @@ public class ReportServiceImpl implements ReportService {
 
         // 3. 제재 처리 (SUSPEND일 경우)
         if (request.getProcessType() == ReportProcessType.SUSPEND) {
+            // TEUM_REQUEST 타입인데 데이터가 없는 경우
+            if (report.getTargetType() == TargetType.TEUM_REQUEST) {
+                throw new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND);
+            }
             // 피신고자 특정
             User reportedUser = (report.getTargetType() == TargetType.USER)
                     ? report.getTargetUser()

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -128,7 +128,7 @@ public class ReportServiceImpl implements ReportService {
         // 3. 제재 처리 (SUSPEND일 경우)
         if (request.getProcessType() == ReportProcessType.SUSPEND) {
             // TEUM_REQUEST 타입인데 데이터가 없는 경우
-            if (report.getTargetType() == TargetType.TEUM_REQUEST) {
+            if (report.getTargetType() == TargetType.TEUM_REQUEST && report.getTeumRequest() == null) {
                 throw new ReportException(ReportErrorStatus.REPORT_TARGET_NOT_FOUND);
             }
             // 피신고자 특정

--- a/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/report/service/ReportServiceImpl.java
@@ -8,6 +8,8 @@ import umc.teumteum.server.domain.report.dto.ReportRequestDto;
 import umc.teumteum.server.domain.report.dto.ReportResponseDto;
 import umc.teumteum.server.domain.report.entity.Report;
 import umc.teumteum.server.domain.report.entity.ReportReason;
+import umc.teumteum.server.domain.report.entity.enums.ReportProcessType;
+import umc.teumteum.server.domain.report.entity.enums.ReportStatus;
 import umc.teumteum.server.domain.report.entity.enums.TargetType;
 import umc.teumteum.server.domain.report.exception.ReportException;
 import umc.teumteum.server.domain.report.exception.status.ReportErrorStatus;
@@ -109,6 +111,33 @@ public class ReportServiceImpl implements ReportService {
 
         // DTO 변환 및 반환
         return ReportConverter.toReportDetail(report, totalReportCount);
+    }
+
+    @Override
+    @Transactional
+    public void processReport(Long reportId, ReportRequestDto.ProcessReport request) {
+        // 1. 신고 내역 조회
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(ReportErrorStatus.REPORT_NOT_FOUND));
+
+        // 2. 이미 완료된 신고인지 확인
+        if (report.getStatus() == ReportStatus.RESOLVED) {
+            throw new ReportException(ReportErrorStatus.REPORT_ALREADY_RESOLVED);
+        }
+
+        // 3. 제재 처리 (SUSPEND일 경우)
+        if (request.getProcessType() == ReportProcessType.SUSPEND) {
+            // 피신고자 특정
+            User reportedUser = (report.getTargetType() == TargetType.USER)
+                    ? report.getTargetUser()
+                    : report.getTeumRequest().getUser();
+
+            // User 엔티티의 suspend() 호출 (1개월 정지 or 3회 누적 시 영구 탈퇴)
+            reportedUser.suspend();
+        }
+
+        // 4. 신고 엔티티 상태 업데이트 (RESOLVED)
+        report.resolve(request.getProcessType(), request.getAdminMemo());
     }
 
     /**

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -268,7 +268,11 @@ public class TeumConverter {
                 .endTime(timeUtil.parseAndFormatEndTime(baseSchedule.getEndTime().toLocalTime()))
                 .status(baseSchedule.getStatus())
                 .participants(relatedSchedules.stream()
-                        .map(s -> toParticipantDto(s.getUser(), profileUrlByUserId.get(s.getUser().getId()))) // toParticipantDto 호출로 변경
+                        .map(s -> {
+                            User user = s.getUser();
+                            String profileUrl = (user != null) ? profileUrlByUserId.get(user.getId()) : null;
+                            return toParticipantDto(user, profileUrl);
+                        })
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -35,6 +35,8 @@ public class TeumConverter {
     private final TimeUtil timeUtil;
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final String WITHDRAWN_USER_NICKNAME = "탈퇴한 사용자";
+    private static final String SUSPENDED_USER_NICKNAME = "정지된 사용자";
+
     public TeumRequest toTeumRequest(TeumRequestDto.TeumRequest dto, User sender) {
         return TeumRequest.builder()
                 .title(dto.getTitle())
@@ -91,11 +93,7 @@ public class TeumConverter {
                 .graphicId(request.getGraphicId())
                 .isRead(response.getReadAt() != null)
                 .receiverCount(request.getTeumResponses().size())
-                .senderUser(ParticipantDto.builder()
-                        .userId(sender.getId())
-                        .nickname(maskedNickName(sender))
-                        .profileImageUrl(senderProfileImageUrl)
-                        .build())
+                .senderUser(toParticipantDto(sender, senderProfileImageUrl))
                 .date(request.getDate().toString())
                 .timeSlot(currentSlot)
                 .isResend(parent != null)
@@ -270,10 +268,7 @@ public class TeumConverter {
                 .endTime(timeUtil.parseAndFormatEndTime(baseSchedule.getEndTime().toLocalTime()))
                 .status(baseSchedule.getStatus())
                 .participants(relatedSchedules.stream()
-                        .map(s -> {
-                            var u = s.getUser();
-                            return new ParticipantDto(u.getId(), maskedNickName(u), profileUrlByUserId.get(u.getId()));
-                        })
+                        .map(s -> toParticipantDto(s.getUser(), profileUrlByUserId.get(s.getUser().getId()))) // toParticipantDto 호출로 변경
                         .collect(Collectors.toList()))
                 .build();
     }
@@ -378,9 +373,19 @@ public class TeumConverter {
 
     // User 객체와 프로필 이미지 URL을 이용해 ParticipantDto를 생성
     private ParticipantDto toParticipantDto(User user, String profileImageUrl) {
+        // ACTIVE 상태가 아니면 정보를 마스킹하여 반환
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            return ParticipantDto.builder()
+                    .userId(null)
+                    .nickname(maskedNickName(user))
+                    .profileImageUrl(User.DEFAULT_PROFILE_IMAGE)
+                    .build();
+        }
+
+        // 정상 상태일 때만 실제 데이터 반환
         return ParticipantDto.builder()
                 .userId(user.getId())
-                .nickname(maskedNickName(user))
+                .nickname(user.getNickname())
                 .profileImageUrl(profileImageUrl)
                 .build();
     }
@@ -412,9 +417,11 @@ public class TeumConverter {
                     User receiver = req.getTeumResponses().get(0).getReceiverUser(); // 수신자 추출
 
                     return TeumResponseDto.ConflictingRequest.builder()
-                            .id(req.getId())
-                            .receiverNickname(maskedNickName(receiver)) // 닉네임 유지
-                            .receiverProfileImageUrl(profileUrlMap.get(receiver.getId())) // 프로필 이미지 추가
+                            .id(receiver.getStatus() == UserStatus.ACTIVE ? req.getId() : null) // ID 마스킹
+                            .receiverNickname(maskedNickName(receiver))
+                            .receiverProfileImageUrl(receiver.getStatus() == UserStatus.ACTIVE
+                                    ? profileUrlMap.get(receiver.getId())
+                                    : User.DEFAULT_PROFILE_IMAGE)
                             .title(req.getTitle())
                             .description(req.getDescription())
                             .startTime(req.getStartTime().format(TIME_FORMATTER))
@@ -443,9 +450,18 @@ public class TeumConverter {
         if(user == null){
             return WITHDRAWN_USER_NICKNAME;
         }
+
+        // 회원 탈퇴 상태 (INACTIVE)
         if(user.getStatus() == UserStatus.INACTIVE){
             return WITHDRAWN_USER_NICKNAME;
         }
+
+        // 임시 정지(SUSPENDED) 또는 영구 정지(BANNED) 상태
+        if(user.getStatus() == UserStatus.SUSPENDED || user.getStatus() == UserStatus.BANNED){
+            return SUSPENDED_USER_NICKNAME;
+        }
+
+        // 정상 상태 (ACTIVE)
         return user.getNickname();
     }
 

--- a/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/converter/TeumConverter.java
@@ -373,6 +373,14 @@ public class TeumConverter {
 
     // User 객체와 프로필 이미지 URL을 이용해 ParticipantDto를 생성
     private ParticipantDto toParticipantDto(User user, String profileImageUrl) {
+        if (user == null) {
+            return ParticipantDto.builder()
+                    .userId(null)
+                    .nickname(WITHDRAWN_USER_NICKNAME)
+                    .profileImageUrl(User.DEFAULT_PROFILE_IMAGE)
+                    .build();
+        }
+
         // ACTIVE 상태가 아니면 정보를 마스킹하여 반환
         if (user.getStatus() != UserStatus.ACTIVE) {
             return ParticipantDto.builder()

--- a/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/repository/TeumResponseRepository.java
@@ -28,6 +28,7 @@ public interface TeumResponseRepository extends JpaRepository<TeumResponse, Long
         WHERE r.receiverUser.id = :userId
           AND r.status = :respStatus
           AND r.teumRequest.status = :reqStatus
+          AND r.teumRequest.user.status = 'ACTIVE'
           AND (r.teumRequest.date > :today OR (r.teumRequest.date = :today AND r.teumRequest.startTime > :now))
           AND NOT EXISTS (
               SELECT 1 FROM Block b 

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -96,6 +96,13 @@ public class User extends BaseEntity {
     @Column(name = "time_public")
     private Boolean timePublic = true;
 
+    @Builder.Default
+    @Column(name = "suspension_count")
+    private Integer suspensionCount = 0; // 누적 정지 횟수
+
+    @Column(name = "suspended_until")
+    private LocalDateTime suspendedUntil; // 정지 종료 일시
+
 
     /*
         양방향 연관관계
@@ -176,5 +183,37 @@ public class User extends BaseEntity {
         this.wakeTime = null;
         this.job = null;
         this.timePublic = false;
+    }
+
+    // 계정 제재 로직
+    public void suspend() {
+        this.suspensionCount++;
+        if (this.suspensionCount >= 3) {
+            this.status = UserStatus.BANNED;
+            this.inactiveAt = LocalDateTime.now();
+
+            // withdraw()와 동일한 익명화 처리
+            String token = UUID.randomUUID().toString();
+            this.socialId = "banned-" + this.id + "-" + token;
+            this.email = "banned-" + this.id + "-" + token + "@banned.local";
+
+            this.nickname = null;
+            this.job = null;
+            this.sleepTime = null;
+            this.wakeTime = null;
+            this.timePublic = false;
+            this.profileImageName = DEFAULT_PROFILE_IMAGE;
+        } else {
+            this.status = UserStatus.SUSPENDED;
+            this.suspendedUntil = LocalDateTime.now().plusMonths(1);
+        }
+    }
+
+    // 정지 해제 로직
+    public void activate() {
+        if (this.status == UserStatus.SUSPENDED) {
+            this.status = UserStatus.ACTIVE;
+            this.suspendedUntil = null;
+        }
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/entity/User.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/User.java
@@ -187,7 +187,12 @@ public class User extends BaseEntity {
 
     // 계정 제재 로직
     public void suspend() {
+        if (this.suspensionCount == null) {
+            this.suspensionCount = 0;
+        }
+
         this.suspensionCount++;
+
         if (this.suspensionCount >= 3) {
             this.status = UserStatus.BANNED;
             this.inactiveAt = LocalDateTime.now();
@@ -202,6 +207,7 @@ public class User extends BaseEntity {
             this.sleepTime = null;
             this.wakeTime = null;
             this.timePublic = false;
+            this.suspendedUntil = null;
             this.profileImageName = DEFAULT_PROFILE_IMAGE;
         } else {
             this.status = UserStatus.SUSPENDED;

--- a/src/main/java/umc/teumteum/server/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/entity/enums/UserStatus.java
@@ -2,5 +2,7 @@ package umc.teumteum.server.domain.user.entity.enums;
 
 public enum UserStatus {
     ACTIVE,    // 활성화
-    INACTIVE,  // 비활성화
+    INACTIVE,  // 일반 회원 탈퇴
+    SUSPENDED, // 임시 정지 (1개월 - 데이터 유지)
+    BANNED     // 영구 정지 (3회 적발 - 익명화 처리)
 }

--- a/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/user/repository/UserRepository.java
@@ -7,6 +7,7 @@ import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,4 +30,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("keyword") String keyword,
             @Param("loginUserId") Long loginUserId
     );
+
+    List<User> findAllByStatusAndSuspendedUntilBefore(UserStatus status, LocalDateTime dateTime);
 }

--- a/src/main/java/umc/teumteum/server/global/scheduler/UserSuspendScheduler.java
+++ b/src/main/java/umc/teumteum/server/global/scheduler/UserSuspendScheduler.java
@@ -1,0 +1,36 @@
+package umc.teumteum.server.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserSuspendScheduler {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 매일 자정(00:00)에 정지 기간이 만료된 유저들을 활성화
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void activateExpiredUsersAtMidnight() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 정지 상태이고, 정지 기한(suspendedUntil)이 현재 시점보다 이전인 유저 조회
+        List<User> expiredUsers = userRepository.findAllByStatusAndSuspendedUntilBefore(
+                UserStatus.SUSPENDED, now
+        );
+
+        // 일괄 활성화
+        expiredUsers.forEach(User::activate);
+    }
+}

--- a/src/test/java/umc/teumteum/server/unit/global/scheduler/UserSuspendSchedulerTest.java
+++ b/src/test/java/umc/teumteum/server/unit/global/scheduler/UserSuspendSchedulerTest.java
@@ -1,0 +1,50 @@
+package umc.teumteum.server.unit.global.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.repository.UserRepository;
+import umc.teumteum.server.global.scheduler.UserSuspendScheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserSuspendSchedulerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserSuspendScheduler userSuspendScheduler;
+
+    @Test
+    @DisplayName("정지 기간이 지난 유저 리스트를 가져와서 모두 ACTIVE로 변경한다")
+    void activate_expired_users_logic() {
+        // given: 정지 기간이 지난 가짜 유저 생성
+        User user = User.builder()
+                .status(UserStatus.SUSPENDED)
+                .suspendedUntil(LocalDateTime.now().minusDays(1))
+                .build();
+
+        given(userRepository.findAllByStatusAndSuspendedUntilBefore(eq(UserStatus.SUSPENDED), any(LocalDateTime.class)))
+                .willReturn(List.of(user));
+
+        // when: 스케줄러 실행
+        userSuspendScheduler.activateExpiredUsersAtMidnight();
+
+        // then: 유저 상태가 ACTIVE로 변했는지 검증
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getSuspendedUntil()).isNull();
+    }
+}

--- a/src/test/java/umc/teumteum/server/unit/teum/converter/TeumConverterTest.java
+++ b/src/test/java/umc/teumteum/server/unit/teum/converter/TeumConverterTest.java
@@ -1,0 +1,48 @@
+package umc.teumteum.server.unit.teum.converter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.teumteum.server.domain.teum.converter.TeumConverter;
+import umc.teumteum.server.domain.teum.dto.common.ParticipantDto;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.global.util.TimeUtil;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class TeumConverterTest {
+
+    @Mock
+    private TimeUtil timeUtil;
+
+    @InjectMocks
+    private TeumConverter teumConverter;
+
+    @Test
+    @DisplayName("정지된 사용자의 닉네임은 '정지된 사용자'로 마스킹되고 ID는 null이 된다")
+    void masking_test() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // given
+        User suspendedUser = User.builder()
+                .status(UserStatus.SUSPENDED)
+                .nickname("나쁜사람")
+                .build();
+
+        // when
+        Method method = TeumConverter.class.getDeclaredMethod("toParticipantDto", User.class, String.class);
+        method.setAccessible(true);
+        ParticipantDto result = (ParticipantDto) method.invoke(teumConverter, suspendedUser, "some-url");
+
+        // then
+        assertThat(result.getNickname()).isEqualTo("정지된 사용자");
+        assertThat(result.getUserId()).isNull();
+        assertThat(result.getProfileImageUrl()).isEqualTo(User.DEFAULT_PROFILE_IMAGE);
+    }
+}

--- a/src/test/java/umc/teumteum/server/unit/user/entity/UserTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/entity/UserTest.java
@@ -1,0 +1,85 @@
+package umc.teumteum.server.unit.user.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import umc.teumteum.server.domain.user.entity.User;
+import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    @DisplayName("첫 번째 정지 처분 시, 횟수가 1 증가하고 상태가 SUSPENDED가 되며 정지 기한이 설정된다")
+    void suspend_first_time() {
+        // given
+        User user = User.builder()
+                .status(UserStatus.ACTIVE)
+                .suspensionCount(0)
+                .build();
+
+        // when
+        user.suspend();
+
+        // then
+        assertThat(user.getSuspensionCount()).isEqualTo(1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.SUSPENDED);
+        assertThat(user.getSuspendedUntil()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("정지 횟수가 3회가 되는 순간, 상태는 BANNED가 되고 개인정보는 익명화 처리된다")
+    void suspend_third_time_to_banned() {
+        // given
+        User user = User.builder()
+                .id(1L)
+                .nickname("지애님")
+                .email("jiae@example.com")
+                .status(UserStatus.SUSPENDED)
+                .suspensionCount(2) // 이미 2회 정지된 상태
+                .build();
+
+        // when
+        user.suspend();
+
+        // then
+        assertThat(user.getSuspensionCount()).isEqualTo(3);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.BANNED);
+        assertThat(user.getNickname()).isNull();
+        assertThat(user.getSocialId()).contains("banned-1-");
+        assertThat(user.getEmail()).contains("@banned.local");
+        assertThat(user.getProfileImageName()).isEqualTo(User.DEFAULT_PROFILE_IMAGE);
+    }
+
+    @Test
+    @DisplayName("정지 상태인 유저를 활성화하면, 상태가 ACTIVE로 바뀌고 정지 기한이 초기화된다")
+    void activate_suspended_user() {
+        // given
+        User user = User.builder()
+                .status(UserStatus.SUSPENDED)
+                .suspendedUntil(java.time.LocalDateTime.now())
+                .build();
+
+        // when
+        user.activate();
+
+        // then
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getSuspendedUntil()).isNull();
+    }
+
+    @Test
+    @DisplayName("suspensionCount가 null인 신규 유저도 정지 처분 시 에러 없이 1회로 처리된다")
+    void suspend_with_null_count() {
+        // given
+        User user = User.builder()
+                .suspensionCount(null) // null 상태
+                .build();
+
+        // when
+        user.suspend();
+
+        // then
+        assertThat(user.getSuspensionCount()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#316 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
**1. 유저 제재 및 자동화 로직 구현**
- 3회 누적 정지 시스템: 유저가 3회 이상 정지 처분을 받을 시 BANNED 상태로 변경하고 개인정보 익명화
- 복구 스케줄러: 자정마다 정지 기간이 만료된 유저를 찾아 ACTIVE 상태로 복구

**2. 관리자용 API**
- 신고 처리: 관리자가 신고 건에 대해 정지(SUSPEND) 또는 반려(DISMISS) 처리를 할 수 있는 API 구현

**3. 단위 테스트**
- User 엔티티의 정지 횟수 증가 및 영구 정지 시 데이터 익명화 로직을 검증하는 테스트
- 스케줄러가 DB에서 만료된 유저를 식별하고 복구
- 정지된 유저의 정보가 "정지된 사용자"로 마스킹 되어 반환되는지 확인

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
<img width="844" height="206" alt="image" src="https://github.com/user-attachments/assets/a92e1900-82cd-443c-a13b-7bfba2e0fecc" />
<img width="1083" height="233" alt="image" src="https://github.com/user-attachments/assets/f27e589c-4b8a-4d04-81dd-fcb43df121c3" />
<img width="1084" height="220" alt="image" src="https://github.com/user-attachments/assets/71168358-04b9-46d9-9664-9cd256d5fce2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 신고 처리 API 추가 및 처리 유형·관리자 메모·처리 시각 기록 기능 도입.
  * 누적 정지·차단 로직 추가 및 만료 시 자동 복구 스케줄러 도입.

* **리팩터**
  * 정지·탈퇴 사용자 마스킹 규칙 중앙화 및 친구/응답 조회 시 활성 사용자만 노출되도록 필터링 강화.

* **테스트**
  * 정지·차단·활성화, 마스킹 및 스케줄러 관련 단위 테스트 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->