### PR TITLE
Refactor : QA 요구사항 반영, 틈 응답 알림 FCM data payload 수정

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
+++ b/src/main/java/umc/teumteum/server/domain/home/dto/request/ActivityRequestDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,7 +47,7 @@ public class ActivityRequestDto {
     private Long locationId;
 
     @Schema(description = "사용자가 직접 입력한 위치", example = "회사")
-    //@Size(max = 10, message = "위치는 10자 이내로 입력해주세요.")
+    @Size(max = 10, message = "위치는 10자 이내로 입력해주세요.")
     @NoPii
     private String customLocation;
 
@@ -53,7 +55,7 @@ public class ActivityRequestDto {
     private Long categoryId;
 
     @Schema(description = "사용자가 직접 입력한 카테고리", example = "명상")
-    //max = 10, message = "카테고리는 10자 이내로 입력해주세요.")
+    @Size(max = 10, message = "카테고리는 10자 이내로 입력해주세요.")
     @NoPii
     private String customCategory;
 

--- a/src/main/java/umc/teumteum/server/domain/notification/service/NotificationUseCases.java
+++ b/src/main/java/umc/teumteum/server/domain/notification/service/NotificationUseCases.java
@@ -12,6 +12,7 @@ import umc.teumteum.server.domain.home.entity.ScheduleReminder;
 import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
 import umc.teumteum.server.domain.teum.dto.TeumRequestDto;
 import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.entity.TeumResponse;
 import umc.teumteum.server.domain.user.entity.User;
 
 @Slf4j
@@ -64,21 +65,27 @@ public class NotificationUseCases {
   }
 
   // 틈 응답 알림
-  public void notifyTeumResponse(User sender, User receiver, Long teumResponseId, boolean accepted) {
+  public void notifyTeumResponse(User sender, User receiver, TeumResponse teumResponse, boolean accepted) {
     NotificationType type = accepted ? NotificationType.TEUM_ACCEPTED : NotificationType.TEUM_DECLINED;
     String content = type.getContent();
+
+    TeumRequest request = teumResponse.getTeumRequest();
 
     Map<String, String> data = new HashMap<>();
     data.put ("senderId", String.valueOf(sender.getId())) ;
     data.put ("senderName", sender.getNickname());
     data.put ("accepted", String.valueOf(accepted) ) ;
 
+    // date 정보 추가
+    data.put ("date", request.getDate().toString());
+    data.put("startTime", request.getStartTime().toString());
+    data.put("endTime", request.getEndTime().toString());
 
     orchestrator.saveAndPush(
         receiver,
         type,
         content,
-        teumResponseId,
+        teumResponse.getId(),
         data
     );
 

--- a/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/teum/service/TeumServiceImpl.java
@@ -281,7 +281,7 @@ public class TeumServiceImpl implements TeumService {
         notificationUseCases.notifyTeumResponse(
                 receiver,
                 requester,
-                response.getId(),
+                response,
                 isAccepted
         );
 


### PR DESCRIPTION
### 👀 관련 이슈
QA작업 입니다

### ✨ 작업한 내용
* 이전 작업에서 진행했던 부분 PM과 논의 후, 수정 (ai 활동 생성 api에서, 사용자로부터 요청 받는 데이터 사이즈 제한)
* 틈 응답 알림(수락/거절) 전송 시 FCM data payload에 틈 요청의 date, startTime, endTime 값을 추가하여 프론트에서 일정 정보를 바로 확인할 수 있도록 수정

### 🌀 PR Point
x

### 🍰 참고사항
x


### 📷 스크린샷 또는 GIF
x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 입력값 검증 강화: 위치 및 카테고리 필드를 10자 이내로 제한

* **개선 사항**
  * 알림에 포함되는 이벤트 정보 확대: 날짜, 시작 시간, 종료 시간 추가 정보 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->