### PR TITLE
Refactor : 기획 변경에 따라, 채움활동 등록 로직에서 스케줄 중복 검사 제거

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/home/service/ActivityServiceImpl.java
@@ -159,21 +159,21 @@ public class ActivityServiceImpl implements ActivityService{
       throw new HomeException(HomeErrorStatus._INVALID_TIME_RANGE);
     }
 
-    // 1. 중복 스케줄 체크
-    LocalDate date = request.getStartTime().toLocalDate();
-    LocalDateTime startTime = request.getStartTime();
-    LocalDateTime endTime = request.getEndTime();
-
-    // 1-1. 틈 & 수면패턴 중복 검사 -> 등록 불가
-    conflictValidator.validateTodo(user, startTime, endTime);
-    // 1-2. 스케줄 중복 검사 -> 등록 가능
-    boolean hasConflict = scheduleRepository.existsConflictSchedule(
-        user.getId(), date, startTime, endTime
-    );
-    if (hasConflict) {
-      // 일정이 겹치면 예외
-      throw new HomeException(HomeErrorStatus._SCHEDULE_CONFLICT);
-    }
+//    // 1. 중복 스케줄 체크
+//    LocalDate date = request.getStartTime().toLocalDate();
+//    LocalDateTime startTime = request.getStartTime();
+//    LocalDateTime endTime = request.getEndTime();
+//
+//    // 1-1. 틈 & 수면패턴 중복 검사 -> 등록 불가
+//    conflictValidator.validateTodo(user, startTime, endTime);
+//    // 1-2. 스케줄 중복 검사 -> 등록 가능
+//    boolean hasConflict = scheduleRepository.existsConflictSchedule(
+//        user.getId(), date, startTime, endTime
+//    );
+//    if (hasConflict) {
+//      // 일정이 겹치면 예외
+//      throw new HomeException(HomeErrorStatus._SCHEDULE_CONFLICT);
+//    }
 
     // 2. 키를 가지고 Wish 관련 데이터들 조회 없으면 예외
     String title = aiContentsRedisTemplate.opsForValue().get(WISH_TITLE_PREFIX + wishUUID);


### PR DESCRIPTION
### 👀 관련 이슈
x, QA 작업입니다.

### ✨ 작업한 내용
* 기획 변경에 따라 채움활동 등록 로직에서 진행하던 스케줄 중복 검사 스텝을 제거하였습니다.

1. 틈 요청 및 수면패턴과 중복되는지 검사
2. 스케줄과 중복되는지 검사

이 두가지 검사를 제거하였습니다.

### 🌀 PR Point
x

### 🍰 참고사항
x

### 📷 스크린샷 또는 GIF
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 일정 중복 검증 로직 비활성화로 인해 시스템이 중복된 일정 생성을 더 이상 제한하지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->