### PR TITLE
Feat : 마이페이지 공개 투두 조회

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/home/repository/ScheduleRepository.java
@@ -358,4 +358,20 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Modifying(clearAutomatically = true,flushAutomatically = true)
     @Query("DELETE FROM Schedule s WHERE s.user.id = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+
+    /**
+     *  공개 투두 조회
+     *  userId
+     */
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId
+      AND s.routineStatus <> umc.teumteum.server.domain.home.entity.enums.RoutineStatus.DELETED
+      AND s.date = :date
+      AND s.isPublic = true
+    """)
+    List<Schedule> findByUserAndDateAndIsPublicAndRoutineStatus(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -46,12 +46,12 @@ public class UserController {
     }
 
     @Operation(
-        summary = "마이페이지 정보 조회",
-        description = "사용자의 프로필, 이름, 직업 분야, 아이디 등 마이페이지에 필요한 정보를 조회합니다."
+            summary = "마이페이지 정보 조회",
+            description = "사용자의 프로필, 이름, 직업 분야, 아이디 등 마이페이지에 필요한 정보를 조회합니다."
     )
     @GetMapping(value = "/mypage", produces = "application/json")
     public ApiResponse<UserResponseDTO.MyPageDTO> getMypageInfo(
-        @Parameter(hidden = true) @CurrentUser User user
+            @Parameter(hidden = true) @CurrentUser User user
     ) {
         UserResponseDTO.MyPageDTO response = userService.getMyPage(user);
         return ApiResponse.of(UserSuccessStatus._USER_FOUND, response);
@@ -65,20 +65,21 @@ public class UserController {
     public ApiResponse<Void> updateProfile(
             @Valid @RequestBody UserRequestDto.ProfileRequest request,
             @Parameter(hidden = true) @CurrentUser User user
-    ){
+    ) {
         userService.updateProfile(request, user);
-        return ApiResponse.of(UserSuccessStatus._PROFILE_UPDATED,null);
+        return ApiResponse.of(UserSuccessStatus._PROFILE_UPDATED, null);
     }
+
     @Operation(
             summary = "마이페이지 프로필 수정용 Presigned URL 발급",
             description = "프로필 수정 과정에서 프로필 이미지를 S3에 직접 업로드할 수 있는 Presigned URL을 발급합니다."
     )
     @PostMapping(value = "/mypage/profile-image/presigned-url", produces = "application/json")
     public ApiResponse<OnboardingResponseDto.ProfileImagePresignedUrlResponse> getPresignedImagePresignedUrl(
-        HttpServletRequest httpServletRequest,
-        @RequestBody @Valid OnboardingRequestDto.ProfileImagePresignedUrlRequest request,
-        @CurrentUser @Parameter(hidden = true) User user
-    ){
+            HttpServletRequest httpServletRequest,
+            @RequestBody @Valid OnboardingRequestDto.ProfileImagePresignedUrlRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
+    ) {
         OnboardingResponseDto.ProfileImagePresignedUrlResponse response =
                 userService.generateProfileImagePresignedUrl(httpServletRequest, request, user);
         return ApiResponse.of(UserSuccessStatus._USER_PRESIGNED_URL_ISSUED, response);
@@ -90,12 +91,12 @@ public class UserController {
     )
     @PostMapping(value = "/mypage/profile-image", produces = "application/json")
     public ApiResponse<Object> saveProfileImageKey(
-                HttpServletRequest httpServletRequest,
-                @RequestBody @Valid OnboardingRequestDto.ProfileImageRequest request,
-                @CurrentUser @Parameter(hidden = true) User user
+            HttpServletRequest httpServletRequest,
+            @RequestBody @Valid OnboardingRequestDto.ProfileImageRequest request,
+            @CurrentUser @Parameter(hidden = true) User user
     ) {
-            userService.saveProfileImage(httpServletRequest, request, user);
-            return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_UPDATED, null);
+        userService.saveProfileImage(httpServletRequest, request, user);
+        return ApiResponse.of(UserSuccessStatus._PROFILE_IMAGE_UPDATED, null);
     }
 
     @Operation(
@@ -129,11 +130,11 @@ public class UserController {
     )
     @GetMapping(value = "/mypage/routines", produces = "application/json")
     public ApiResponse<List<UserResponseDTO.RoutineDTO>> getRoutines(
-            @Parameter(name = "weekday",description = "조회할 요일", example = "MONDAY") @RequestParam("weekday") Weekday weekday,
+            @Parameter(name = "weekday", description = "조회할 요일", example = "MONDAY") @RequestParam("weekday") Weekday weekday,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         List<UserResponseDTO.RoutineDTO> response = userService.getRoutines(weekday, user);
-        return ApiResponse.of(UserSuccessStatus._ROUTINE_LOADED,response);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_LOADED, response);
     }
 
     @Operation(
@@ -142,8 +143,8 @@ public class UserController {
     )
     @DeleteMapping(value = "/mypage/routines/{routineId}", produces = "application/json")
     public ApiResponse<Object> deleteRoutine(
-            @Parameter(name= "routineId", description = "삭제할 Routine Id", example = "123") @PathVariable("routineId") Long routineId
-    ){
+            @Parameter(name = "routineId", description = "삭제할 Routine Id", example = "123") @PathVariable("routineId") Long routineId
+    ) {
         userService.deleteRoutine(routineId);
         return ApiResponse.of(UserSuccessStatus._ROUTINE_DELETED, null);
     }
@@ -156,9 +157,9 @@ public class UserController {
     public ApiResponse<Object> saveRoutine(
             @RequestBody @Valid OnboardingRequestDto.RoutineDTO request,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         userService.saveRoutine(request, user);
-        return ApiResponse.of(UserSuccessStatus._ROUTINE_ADDED,null);
+        return ApiResponse.of(UserSuccessStatus._ROUTINE_ADDED, null);
     }
 
     @Operation(
@@ -167,10 +168,10 @@ public class UserController {
     )
     @PatchMapping(value = "/mypage/routines/{routineId}", produces = "application/json")
     public ApiResponse<Object> updateRoutine(
-            @Parameter(name= "routineId", description = "수정할 Routine Id", example = "123") @PathVariable("routineId") Long routineId,
+            @Parameter(name = "routineId", description = "수정할 Routine Id", example = "123") @PathVariable("routineId") Long routineId,
             @RequestBody @Valid OnboardingRequestDto.RoutineDTO request,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         userService.updateRoutine(routineId, request, user);
         return ApiResponse.of(UserSuccessStatus._ROUTINE_UPDATED, null);
     }
@@ -183,7 +184,7 @@ public class UserController {
     public ApiResponse<Object> updateSleepPattern(
             @RequestBody @Valid OnboardingRequestDto.SleepPatternRequest request,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         userService.updateSleepPattern(request, user);
         return ApiResponse.of(UserSuccessStatus._SLEEP_PATTERN_UPDATED, null);
     }
@@ -195,7 +196,7 @@ public class UserController {
     @DeleteMapping(value = "/mypage/sleep-pattern", produces = "application/json")
     public ApiResponse<Object> deleteSleepPattern(
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         userService.deleteSleepPattern(user);
         return ApiResponse.of(UserSuccessStatus._SLEEP_PATTERN_DELETED, null);
     }
@@ -207,7 +208,7 @@ public class UserController {
     @GetMapping(value = "/mypage/reminders", produces = "application/json")
     public ApiResponse<UserResponseDTO.RemindAlarmList> getReminders(
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         UserResponseDTO.RemindAlarmList response = userService.getReminders(user);
         return ApiResponse.of(UserSuccessStatus._REMIND_ALARM_LOADED, response);
     }
@@ -220,7 +221,7 @@ public class UserController {
     public ApiResponse<Object> updateReminders(
             @RequestBody @Valid OnboardingRequestDto.RemindAlarmList request,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         userService.updateReminders(request, user);
         return ApiResponse.of(UserSuccessStatus._REMIND_ALARM_UPDATED, null);
     }
@@ -233,7 +234,7 @@ public class UserController {
     public ApiResponse<Object> deleteUser(
             HttpServletRequest httpServletRequest,
             @CurrentUser @Parameter(hidden = true) User user
-    ){
+    ) {
         authService.logout(httpServletRequest, user);
         userService.deleteUser(user);
         return ApiResponse.of(UserSuccessStatus._USER_DELETED, null);
@@ -245,10 +246,18 @@ public class UserController {
     )
     @GetMapping(value = "/mypage/accounts", produces = "application/json")
     public ApiResponse<UserResponseDTO.AccountInfoDTO> getAccount(
-            @CurrentUser @Parameter(hidden = true) User user){
+            @CurrentUser @Parameter(hidden = true) User user) {
         UserResponseDTO.AccountInfoDTO result = userService.getAccountInfo(user);
         return ApiResponse.of(UserSuccessStatus._SOCIAL_ACCOUNT_LOADED, result);
     }
 
-
+    @Operation(
+            summary = "마이페이지 공개 투두 조회",
+            description = "마이페이지에서 해당 날짜의 투두 중 공개된 2개의 투두를 조회합니다.")
+    @GetMapping(value = "/mypage/public-todo", produces = "application/json")
+    public ApiResponse<List<UserResponseDTO.TodoDTO>> getPublicTodo(
+            @CurrentUser @Parameter(hidden = true) User user) {
+        List<UserResponseDTO.TodoDTO> result = userService.getPublicTodo(user);
+        return ApiResponse.of(UserSuccessStatus._PUBLIC_TODO_LOADED, result);
+    }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package umc.teumteum.server.domain.user.converter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
 import umc.teumteum.server.domain.user.entity.Routine;
@@ -52,6 +53,15 @@ public class UserConverter {
         return UserResponseDTO.AccountInfoDTO.builder()
                 .email(user.getEmail())
                 .socialType(user.getSocialType())
+                .build();
+    }
+
+    // schedule -> UserResponseDTO.TodoDTO
+    public static UserResponseDTO.TodoDTO toTodoDTO(Schedule schedule) {
+        return UserResponseDTO.TodoDTO.builder()
+                .title(schedule.getTitle())
+                .startTime(schedule.getStartTime().toLocalTime())
+                .endTime(schedule.getEndTime().toLocalTime())
                 .build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -1,12 +1,14 @@
 package umc.teumteum.server.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.Weekday;
+import umc.teumteum.server.global.util.TimeSerializer;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -75,4 +77,22 @@ public class UserResponseDTO {
     @Schema(description = "소셜타입", example = "kakao")
     private SocialType socialType;
   }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class TodoDTO {
+
+    @Schema(description = "투두 제목", example = "수영장 가기")
+    private String title;
+
+    @Schema(description = "시작 시간", example = "10:00")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "11:00")
+    @JsonSerialize(using = TimeSerializer.class)
+    private LocalTime endTime;
+  }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -87,7 +87,7 @@ public class UserResponseDTO {
     private String title;
 
     @Schema(description = "시작 시간", example = "10:00")
-    @JsonFormat(pattern = "HH:mm")
+    @JsonSerialize(using = TimeSerializer.class)
     private LocalTime startTime;
 
     @Schema(description = "종료 시간", example = "11:00")

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -26,6 +26,7 @@ public enum UserSuccessStatus implements BaseCode {
     _USER_DELETED(HttpStatus.OK,"USER20014","회원 탈퇴가 완료되었습니다."),
     _SLEEP_PATTERN_DELETED(HttpStatus.OK,"USER20015","수면 패턴 삭제가 완료되었습니다."),
     _SOCIAL_ACCOUNT_LOADED(HttpStatus.OK,"USER20016","소셜 계정 정보 조회가 완료되었습니다."),
+    _PUBLIC_TODO_LOADED(HttpStatus.OK,"USER20017","공개된 투두 조회가 완료되었습니다."),
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -53,4 +53,6 @@ public interface UserService {
     void deleteSleepPattern(User user);
 
     UserResponseDTO.AccountInfoDTO getAccountInfo(User user);
+
+    List<UserResponseDTO.TodoDTO> getPublicTodo(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -582,6 +582,8 @@ public class UserServiceImpl implements UserService {
         return UserConverter.toAccountInfoDTO(user);
     }
 
+    // 마이페이지 - 공개 투두 조회
+    @Transactional(readOnly = true)
     @Override
     public List<UserResponseDTO.TodoDTO> getPublicTodo(User user) {
 
@@ -596,10 +598,6 @@ public class UserServiceImpl implements UserService {
                 .map(UserConverter::toTodoDTO)
                 .toList();
     }
-
-    // 마이페이지 - 공개 투두 조회
-    @Transactional(readOnly = true)
-
 
 
     /**

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -582,6 +582,26 @@ public class UserServiceImpl implements UserService {
         return UserConverter.toAccountInfoDTO(user);
     }
 
+    @Override
+    public List<UserResponseDTO.TodoDTO> getPublicTodo(User user) {
+
+        // 1. 스케줄 조회
+        LocalDate now = LocalDate.now();
+        List<Schedule> schedulesList = scheduleRepository.findByUserAndDateAndIsPublicAndRoutineStatus(user.getId(), now);
+
+        // 2. 시작시간 기준으로 정렬 후 상위 2개 반환
+        return schedulesList.stream()
+                .sorted(Comparator.comparing(Schedule::getStartTime))
+                .limit(2)
+                .map(UserConverter::toTodoDTO)
+                .toList();
+    }
+
+    // 마이페이지 - 공개 투두 조회
+    @Transactional(readOnly = true)
+
+
+
     /**
      * 유저 프로필 삭제 헬퍼 메서드
      */


### PR DESCRIPTION
### 👀 관련 이슈

<!-- 관련 이슈를 적어주세요 -->
#341 

### ✨ 작업한 내용

<!-- 작업한 내용을 적어주세요 -->
- 마이페이지에서 공개된 투두 목록을 조회하기 위한 API 추가했습니다.
- 스케줄 테이블에서 유저, 날짜, 루틴 상태(DELETED 제외), 공개 여부를 기준으로 조회한 뒤, startTime 기준으로 정렬 후 상위 2개만 반환하도록 구현했습니다.

### 🌀 PR Point

<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
GET `/api/users/mypage/public-todo`

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->
X

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자의 공개 투두를 조회하는 신규 API 엔드포인트 추가(현재 날짜 기준).
  * 공개 일정 중 시작시간 기준 상위 2개를 반환해 시간순으로 표시.
  * 응답에 투두 항목(title, 시작시간, 종료시간)을 포함하고, 성공 상태 메시지 코드가 추가됨.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->