### PR TITLE
Bug : 마이페이지 알림 설정 업데이트 오류 수정 및 조회 API 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
+++ b/src/main/java/umc/teumteum/server/domain/user/controller/UserController.java
@@ -260,4 +260,15 @@ public class UserController {
         List<UserResponseDTO.TodoDTO> result = userService.getPublicTodo(user);
         return ApiResponse.of(UserSuccessStatus._PUBLIC_TODO_LOADED, result);
     }
+
+    @Operation(
+            summary = "마이페이지 알림 설정 조회",
+            description = "마이페이지에서 사용자의 알림 설정 상태를 조회합니다.")
+    @GetMapping(value = "/mypage/alarm", produces = "application/json")
+    public ApiResponse<UserResponseDTO.NotificationSettingDTO> getAlarmSetting(
+            @CurrentUser @Parameter(hidden = true) User user) {
+        UserResponseDTO.NotificationSettingDTO response = userService.getAlarmSetting(user);
+        return ApiResponse.of(UserSuccessStatus._ALARM_STATE_LOADED, response);
+    }
+
 }

--- a/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/user/converter/UserConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.dto.UserResponseDTO;
 import umc.teumteum.server.domain.user.dto.UserSearchResponseDto;
+import umc.teumteum.server.domain.user.entity.NotificationSetting;
 import umc.teumteum.server.domain.user.entity.Routine;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
@@ -62,6 +63,15 @@ public class UserConverter {
                 .title(schedule.getTitle())
                 .startTime(schedule.getStartTime().toLocalTime())
                 .endTime(schedule.getEndTime().toLocalTime())
+                .build();
+    }
+
+    public UserResponseDTO.NotificationSettingDTO toNotificationSettingDTO(NotificationSetting setting) {
+        return UserResponseDTO.NotificationSettingDTO.builder()
+                .todayTodo(setting.getTodayTodo())
+                .remindAlarm(setting.getRemindAlarm())
+                .follow(setting.getFollow())
+                .teum(setting.getTeum())
                 .build();
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/umc/teumteum/server/domain/user/dto/UserResponseDTO.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.user.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -95,4 +96,21 @@ public class UserResponseDTO {
     private LocalTime endTime;
   }
 
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  public static class NotificationSettingDTO {
+    @Schema(description = "오늘의 일정 - 오전 9시 투두 일림 여부", example = "true")
+    private Boolean todayTodo;
+
+    @Schema(description = "리마인드 알림 - 투두에 등록한 리마인드 알림 여부", example = "true")
+    private Boolean remindAlarm;
+
+    @Schema(description = "새로운 팔로워 - 나를 팔로우한 새로운 친구가 있을 때", example = "true")
+    private Boolean follow;
+
+    @Schema(description = "틈 요청 - 맞팔로우한 사용자의 틈 요청 알림", example = "true")
+    private Boolean teum;
+
+  }
 }

--- a/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/user/exception/status/UserSuccessStatus.java
@@ -27,6 +27,8 @@ public enum UserSuccessStatus implements BaseCode {
     _SLEEP_PATTERN_DELETED(HttpStatus.OK,"USER20015","수면 패턴 삭제가 완료되었습니다."),
     _SOCIAL_ACCOUNT_LOADED(HttpStatus.OK,"USER20016","소셜 계정 정보 조회가 완료되었습니다."),
     _PUBLIC_TODO_LOADED(HttpStatus.OK,"USER20017","공개된 투두 조회가 완료되었습니다."),
+    _ALARM_STATE_LOADED(HttpStatus.OK, "USER20018", "알림 설정 조회 성공"),
+
 
 
 

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserService.java
@@ -55,4 +55,6 @@ public interface UserService {
     UserResponseDTO.AccountInfoDTO getAccountInfo(User user);
 
     List<UserResponseDTO.TodoDTO> getPublicTodo(User user);
+
+    UserResponseDTO.NotificationSettingDTO getAlarmSetting(User user);
 }

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -600,6 +600,16 @@ public class UserServiceImpl implements UserService {
                 .toList();
     }
 
+    // 마이페이지 - 알람 여부 조회
+    @Override
+    @Transactional(readOnly = true)
+    public UserResponseDTO.NotificationSettingDTO getAlarmSetting(User user) {
+        NotificationSetting setting = notificationSettingRepository.findByUser(user)
+                .orElseThrow(() -> new UserException(UserErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        return userConverter.toNotificationSettingDTO(setting);
+    }
+
 
     /**
      * 유저 프로필 삭제 헬퍼 메서드

--- a/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/user/service/UserServiceImpl.java
@@ -305,8 +305,9 @@ public class UserServiceImpl implements UserService {
         setting.update(
                 request.getTodayTodo(),
                 request.getRemindAlarm(),
-                request.getTeum(), request.getFollow()
-        );
+                request.getFollow(),
+                request.getTeum()
+                );
     }
 
     // 마이페이지 - 반복일정 조회


### PR DESCRIPTION
### 👀 관련 이슈
#348 

### ✨ 작업한 내용
* 마이페이지 알림 설정 업데이트 로직에서 follow / teum 파라미터 순서가 뒤바뀌어 저장되던 버그 수정
* 마이페이지 알림 설정 조회 API 추가 (알림 설정 화면 진입 시 초기 토글 상태를 조회할 수 있도록 보완)


### 🌀 PR Point
**이번 PR에서는 USER4041 에러 자체를 직접적으로 처리하지는 않았습니다. -> 해당 에러는 기존에 생성된 회원 데이터에서 발생하는 문제로 확인**

현재는 테스트 앱 상태이고 실사용자 유입 시에는 소셜 로그인 최초 생성 과정에서 NotificationSetting이 함께 생성되므로 실사용 환경에서는 문제가 발생하지 않을 것으로 판단했습니다.

대신, 실사용 시 영향을 줄 수 있는 알림 설정 업데이트 파라미터 매핑 오류`(파라미터 순서가 바뀌어 있는걸 발견했습니다.)`를 우선 수정하고 알림 설정 조회 API를 추가하였습니다.

### 🍰 참고사항
x

### 📷 스크린샷 또는 GIF
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알림 설정 조회 기능 추가: 사용자는 이제 마이페이지에서 오늘의 할 일 알림, 리마인드 알림, 팔로우 알림, 팀 알림 등 모든 알림 설정을 한눈에 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->