### PR TITLE
PERF: 맞팔로우 목록 조회 API 부하 테스트 및 단계별 성능 최적화

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/converter/FriendConverter.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.friend.converter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.teumteum.server.domain.friend.dto.FriendResponseDto;
+import umc.teumteum.server.domain.friend.dto.MutualFriendProjection;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.home.entity.Schedule;
 import umc.teumteum.server.domain.user.entity.User;
@@ -93,13 +94,12 @@ public class FriendConverter {
     }
 
     // 친구 - 맞팔로우 목록 조회 응답
-    public static FriendResponseDto.MutualFriend toMutualFriendDto(User user, String profileImageUrl) {
+    public static FriendResponseDto.MutualFriend toMutualFriendDto(MutualFriendProjection projection, String profileImageUrl) {
         return FriendResponseDto.MutualFriend.builder()
-                .userId(user.getId())
-                .nickname(user.getNickname())
+                .userId(projection.getUserId())
+                .nickname(projection.getNickname())
                 .profileImageUrl(profileImageUrl)
-                .build()
-                ;
+                .build();
     }
 
     // 친구 - 즐겨찾기 설정/해제 응답

--- a/src/main/java/umc/teumteum/server/domain/friend/dto/MutualFriendProjection.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/dto/MutualFriendProjection.java
@@ -1,0 +1,13 @@
+package umc.teumteum.server.domain.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MutualFriendProjection {
+
+    private Long userId;
+    private String nickname;
+    private String profileImageName;
+}

--- a/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
@@ -13,7 +13,10 @@ import umc.teumteum.server.global.common.BaseEntity;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "friend")
+@Table(name = "friend", indexes = {
+        @Index(name = "idx_friend_follower_following",
+                columnList = "follower_user_id, following_user_id")
+})
 public class Friend extends BaseEntity {
 
     @Id

--- a/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/repository/FriendRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import umc.teumteum.server.domain.friend.dto.MutualFriendProjection;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
@@ -29,14 +30,26 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     Optional<Friend> findByFollowerAndFollowing(User loginUser, User targetUser);
 
-    @Query("SELECT f1 FROM Friend f1 " +
-            "WHERE f1.follower = :user " +
-            "AND f1.following.status = :status " +
-            "AND EXISTS (SELECT f2 FROM Friend f2 " +
-            "WHERE f2.follower = f1.following " +
-            "AND f2.following = :user) " +
-            "AND f1.following != :excludeUser")
-    Slice<Friend> findMutualFriendsExcluding(User user, User excludeUser, @Param("status") UserStatus status, Pageable pageable);
+    @Query("""
+        SELECT new umc.teumteum.server.domain.friend.dto.MutualFriendProjection(
+            u.id,
+            u.nickname,
+            u.profileImageName
+        )
+        FROM Friend f1
+        JOIN f1.following u
+        JOIN Friend f2 ON f2.follower = u AND f2.following = :user
+        WHERE f1.follower = :user
+          AND u.status = :status
+          AND u.id <> :excludeUserId
+        ORDER BY u.nickname ASC
+        """)
+    Slice<MutualFriendProjection> findMutualFriendsExcluding(
+            @Param("user") User user,
+            @Param("excludeUserId") Long excludeUserId,
+            @Param("status") UserStatus status,
+            Pageable pageable
+    );
 
     // 차단 시 두 유저 간의 모든 팔로우 관계(A->B, B->A)를 삭제
     @Modifying(clearAutomatically = true)

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.connection.RedisStringCommands;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.types.Expiration;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.friend.converter.FriendConverter;
@@ -123,12 +127,10 @@ public class FriendServiceImpl implements FriendService {
         validateNotSelf(loginUser.getId(), excludeUserId);
 
         // 2. 제외하려는 대상 존재 여부 확인
-        if (!userRepository.existsById(excludeUserId)) {
-            throw new UserException(UserErrorStatus.USER_NOT_FOUND);
-        }
+        validateUserExists(excludeUserId);
 
         // 3. Pageable 생성 (정렬은 쿼리 내 ORDER BY로 처리)
-        Pageable pageable = PageRequest.of(page - 1, size);
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
 
         // 4. 맞팔로우 관계 조회 (DTO Projection)
         Slice<MutualFriendProjection> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(
@@ -392,15 +394,22 @@ public class FriendServiceImpl implements FriendService {
     }
 
     private Map<String, String> getOrLoadProfileImageUrls(List<MutualFriendProjection> projections) {
+        // 입력 자체가 없으면 바로 종료
         if (projections.isEmpty()) {
             return Collections.emptyMap();
         }
 
-        // 1. projection에서 profileImageName만 추출 + 중복 제거
+        // 1. projection에서 profileImageName만 추출
         List<String> profileImageNames = projections.stream()
                 .map(MutualFriendProjection::getProfileImageName)
+                .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+
+        // null 제거 후 아무것도 없으면 종료
+        if (profileImageNames.isEmpty()) {
+            return Collections.emptyMap();
+        }
 
         // 2. Redis 조회를 위한 cache key 생성
         List<String> cacheKeys = profileImageNames.stream()
@@ -410,29 +419,41 @@ public class FriendServiceImpl implements FriendService {
         // 3. Redis multiGet으로 한번에 조회
         List<String> cachedUrls = profileImageRedisTemplate.opsForValue().multiGet(cacheKeys);
 
-        // 4. 최종 결과를 담을 Map (profileImageName -> URL)
+        // 최종 결과를 담을 Map (profileImageName -> URL)
         Map<String, String> profileImageUrlMap = new HashMap<>();
+        // 캐시 miss 결과를 Redis에 한 번에 저장하기 위한 Map
+        Map<String, String> missedCacheMap = new HashMap<>();
 
-        // 5. 조회 결과를 순회하면서 캐시 hit/miss 처리
+        // 4. 조회 결과를 순회하면서 캐시 hit/miss 처리
         for (int i = 0; i < profileImageNames.size(); i++) {
 
             String profileImageName = profileImageNames.get(i);
             String cachedUrl = cachedUrls.get(i);
 
-            // 5-1. cache hit
+            // 4-1. cache hit
             if (cachedUrl != null) {
                 profileImageUrlMap.put(profileImageName, cachedUrl);
             }
-            // 5-2. cache miss
+            // 4-2. cache miss
             else {
                 // Presigned URL 생성
                 String newUrl = s3Util.toPresignedUrl("profile/" + profileImageName, Duration.ofMinutes(30));
 
-                // Redis에 저장 (다음 요청부터 cache hit)
-                profileImageRedisTemplate.opsForValue().set(buildCacheKey(profileImageName), newUrl, PROFILE_URL_CACHE_TTL);
-
                 profileImageUrlMap.put(profileImageName, newUrl);
+                missedCacheMap.put(buildCacheKey(profileImageName), newUrl);
             }
+        }
+
+        // 5. cache miss 데이터 Redis에 일괄 저장 (pipeline)
+        if (!missedCacheMap.isEmpty()) {
+            profileImageRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+
+                StringRedisConnection src = (StringRedisConnection) connection;
+
+                missedCacheMap.forEach((k, v) ->
+                        src.set(k, v, Expiration.from(PROFILE_URL_CACHE_TTL), RedisStringCommands.SetOption.UPSERT));
+                return null;
+            });
         }
 
         // 6. profileImageName -> URL 매핑 결과 반환

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -1,10 +1,12 @@
 package umc.teumteum.server.domain.friend.service;
 
+import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.friend.converter.FriendConverter;
@@ -32,10 +34,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,6 +51,13 @@ public class FriendServiceImpl implements FriendService {
     private final NotificationUseCases notificationUseCases;
 
     private final S3Util s3Util;
+
+    @Resource(name = "profileImageRedisTemplate")
+    private RedisTemplate<String, String> profileImageRedisTemplate;
+
+    private static final String PROFILE_URL_CACHE_KEY_PREFIX = "profile:url:";
+    private static final Duration PROFILE_URL_CACHE_TTL = Duration.ofMinutes(20);
+
 
     private static final Set<ScheduleType> GENERAL_SCHEDULE_TYPES =
             EnumSet.of(ScheduleType.TODO, ScheduleType.WISH, ScheduleType.AI);
@@ -121,7 +127,7 @@ public class FriendServiceImpl implements FriendService {
             throw new UserException(UserErrorStatus.USER_NOT_FOUND);
         }
 
-        // 3. Pageable 생성 (정렬은 쿼리 내 ORDER BY로 처리
+        // 3. Pageable 생성 (정렬은 쿼리 내 ORDER BY로 처리)
         Pageable pageable = PageRequest.of(page - 1, size);
 
         // 4. 맞팔로우 관계 조회 (DTO Projection)
@@ -130,10 +136,12 @@ public class FriendServiceImpl implements FriendService {
 
         // 5. 프로필 이미지 URL 변환 및 Dto 변환
         List<MutualFriendProjection> projections = mutualFriendsSlice.getContent();
+        Map<String, String> profileUrlMap = getOrLoadProfileImageUrls(projections);
+
         List<FriendResponseDto.MutualFriend> mutualFriendList = projections.stream()
                 .map(projection -> FriendConverter.toMutualFriendDto(
                         projection,
-                        s3Util.toPresignedUrl("profile/" + projection.getProfileImageName(), Duration.ofMinutes(30))))
+                        profileUrlMap.get(projection.getProfileImageName())))
                 .toList();
 
         // 6. PagingResponseDto 생성
@@ -381,5 +389,58 @@ public class FriendServiceImpl implements FriendService {
                 blockRepository.existsByBlockerAndBlocked(user2, user1)) {
             throw new FriendException(FriendErrorStatus.BLOCK_ACTION_FORBIDDEN);
         }
+    }
+
+    private Map<String, String> getOrLoadProfileImageUrls(List<MutualFriendProjection> projections) {
+        if (projections.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 1. projection에서 profileImageName만 추출 + 중복 제거
+        List<String> profileImageNames = projections.stream()
+                .map(MutualFriendProjection::getProfileImageName)
+                .distinct()
+                .toList();
+
+        // 2. Redis 조회를 위한 cache key 생성
+        List<String> cacheKeys = profileImageNames.stream()
+                .map(this::buildCacheKey)
+                .toList();
+
+        // 3. Redis multiGet으로 한번에 조회
+        List<String> cachedUrls = profileImageRedisTemplate.opsForValue().multiGet(cacheKeys);
+
+        // 4. 최종 결과를 담을 Map (profileImageName -> URL)
+        Map<String, String> profileImageUrlMap = new HashMap<>();
+
+        // 5. 조회 결과를 순회하면서 캐시 hit/miss 처리
+        for (int i = 0; i < profileImageNames.size(); i++) {
+
+            String profileImageName = profileImageNames.get(i);
+            String cachedUrl = cachedUrls.get(i);
+
+            // 5-1. cache hit
+            if (cachedUrl != null) {
+                profileImageUrlMap.put(profileImageName, cachedUrl);
+            }
+            // 5-2. cache miss
+            else {
+                // Presigned URL 생성
+                String newUrl = s3Util.toPresignedUrl("profile/" + profileImageName, Duration.ofMinutes(30));
+
+                // Redis에 저장 (다음 요청부터 cache hit)
+                profileImageRedisTemplate.opsForValue().set(buildCacheKey(profileImageName), newUrl, PROFILE_URL_CACHE_TTL);
+
+                profileImageUrlMap.put(profileImageName, newUrl);
+            }
+        }
+
+        // 6. profileImageName -> URL 매핑 결과 반환
+        return profileImageUrlMap;
+    }
+
+    // cache key 생성
+    private String buildCacheKey(String profileImageName) {
+        return PROFILE_URL_CACHE_KEY_PREFIX + profileImageName;
     }
 }

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -1,15 +1,5 @@
 package umc.teumteum.server.domain.friend.service;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.teumteum.server.domain.friend.converter.FriendConverter;
 import umc.teumteum.server.domain.friend.dto.FriendResponseDto;
+import umc.teumteum.server.domain.friend.dto.MutualFriendProjection;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.friend.exception.FriendException;
 import umc.teumteum.server.domain.friend.exception.status.FriendErrorStatus;
@@ -31,9 +22,22 @@ import umc.teumteum.server.domain.home.repository.ScheduleRepository;
 import umc.teumteum.server.domain.notification.service.NotificationUseCases;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.UserStatus;
+import umc.teumteum.server.domain.user.exception.UserException;
+import umc.teumteum.server.domain.user.exception.status.UserErrorStatus;
 import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.global.dto.PagingResponseDto;
 import umc.teumteum.server.global.util.S3Util;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -112,27 +116,25 @@ public class FriendServiceImpl implements FriendService {
         // 1. 자기 자신을 제외하는지 확인
         validateNotSelf(loginUser.getId(), excludeUserId);
 
-        // 2. 제외하려는 대상 조회
-        User excludeUser = getUserOrThrow(excludeUserId);
+        // 2. 제외하려는 대상 존재 여부 확인
+        if (!userRepository.existsById(excludeUserId)) {
+            throw new UserException(UserErrorStatus.USER_NOT_FOUND);
+        }
 
-        // 3. Pageable 생성 (닉네임순 정렬)
-        Pageable pageable = PageRequest.of(page - 1, size,
-                Sort.by(Sort.Order.asc("following.nickname")));
+        // 3. Pageable 생성 (정렬은 쿼리 내 ORDER BY로 처리
+        Pageable pageable = PageRequest.of(page - 1, size);
 
-        // 4. 맞팔로우 관계 조회 (특정 사용자 제외)
-        Slice<Friend> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(loginUser, excludeUser,
-                UserStatus.ACTIVE, pageable);
+        // 4. 맞팔로우 관계 조회 (DTO Projection)
+        Slice<MutualFriendProjection> mutualFriendsSlice = friendRepository.findMutualFriendsExcluding(
+                loginUser, excludeUserId, UserStatus.ACTIVE, pageable);
 
-        // 5. 맞팔로우한 상대방들에 대한 S3 프리사인드 URL 생성 및 Dto 변환
-        List<FriendResponseDto.MutualFriend> mutualFriendList = mutualFriendsSlice.getContent()
-                .stream()
-                .map(friend -> {
-                    User targetUser = friend.getFollowing();
-                    String profileImageUrl = s3Util.toPresignedUrl("profile/" + targetUser.getProfileImageName(),
-                            Duration.ofMinutes(30));
-                    return FriendConverter.toMutualFriendDto(targetUser, profileImageUrl);
-                })
-                .collect(Collectors.toList());
+        // 5. 프로필 이미지 URL 변환 및 Dto 변환
+        List<MutualFriendProjection> projections = mutualFriendsSlice.getContent();
+        List<FriendResponseDto.MutualFriend> mutualFriendList = projections.stream()
+                .map(projection -> FriendConverter.toMutualFriendDto(
+                        projection,
+                        s3Util.toPresignedUrl("profile/" + projection.getProfileImageName(), Duration.ofMinutes(30))))
+                .toList();
 
         // 6. PagingResponseDto 생성
         return new PagingResponseDto<>(mutualFriendList, mutualFriendsSlice.hasNext());


### PR DESCRIPTION
### 👀 관련 이슈
#354

---

### ✨ 작업한 내용

맞팔로우 목록 조회 API(`/api/friends/mutuals`)의 성능 병목을 분석하고 다음과 같이 최적화를 적용했습니다.

- EXISTS 서브쿼리 기반 조회 → JOIN 구조로 변경
- Fetch Join 적용을 통한 N+1 문제 제거
- DTO Projection 적용으로 불필요한 엔티티 로딩 제거
- excludeUser 조회를 existsById 기반 검증으로 변경
- Redis multiGet 적용으로 프로필 이미지 URL 캐시 조회 최적화
- friend 테이블 복합 인덱스 추가 (`follower_user_id`, `following_user_id`)

---

### 📊 성능 개선 결과 요약

| 지표 | v1 | v7 | 개선 |
|---|---|---|---|
| p95 | 8.25s | 3.06s | ↓ 약 63% |
| avg | 4.51s | 1.43s | ↓ 약 68% |
| RPS | 54.8 | 139 | ↑ 약 2.5배 |

- **p95 (Latency)**: 전체 요청 중 95%가 이 시간 이하로 처리되는 응답 시간 (사용자 체감 성능 지표)
- **avg (Average Latency)**: 전체 요청의 평균 응답 시간
- **RPS (Requests Per Second)**: 초당 처리 가능한 요청 수 (처리량 지표)

---

### 🌀 PR Point

- Fetch Join을 통해 N+1 문제를 제거하며 가장 큰 성능 개선이 발생했습니다.
- 이후 DTO Projection으로 전환하여 엔티티 로딩을 제거했습니다.
- Redis 캐싱의 접근 방식 변경 (GET → multiGet) 으로 큰 개선이 발생했습니다.

---

### 🍰 참고사항

- 해당 API는 기획 변동으로 인해 현재 서비스에서 사용되지 않는 것으로 파악하고 있습니다.
다만 담당 API 중 부하테스트 시나리오 구성이 가장 용이하다고 판단하여 진행하였습니다.

- 운영 서버에 직접 부하를 가하는 것은 서비스에 영향을 줄 수 있다고 판단하여,
개인 AWS 계정에서 별도 인프라를 간단하게 구축(EC2, RDS)하여 테스트를 진행하였습니다.

---

### 📄 상세 부하 테스트 과정

<details>
<summary> 내용 정리 </summary>

<br>


# 📊 맞팔로우 목록 조회 API 부하 테스트 및 단계별 성능 최적화

본 문서는 맞팔로우 목록 조회 API(`/api/friends/mutuals`)를 대상으로 k6 기반 부하 테스트를 수행하고,  
Prometheus + Grafana를 통해 병목 지점을 분석하여 단계적으로 성능을 개선한 과정을 정리한 문서입니다.

---

# 1. 실험 개요

## 1.1 테스트 환경

- 테스트 도구: k6 (ramping-vus)
- 모니터링: Prometheus, Grafana
- 백엔드: Spring Boot, JPA (Hibernate)
- 인프라: AWS EC2 (t3.small), RDS MySQL (db.t3.micro)
- 모니터링 서버: AWS EC2 (t3.small) — Prometheus, Grafana 분리 운영

---

## 1.2 테스트 시나리오

- 최대 500 VU까지 점진적 증가
- 동일 API 반복 호출
- 테스트 시간: 약 7분

```
0~30s:    VU 1 → 50
30s~1m:   VU 50 → 100
1m~2m:    VU 100 → 200
2m~3m:    VU 200 → 300
3m~4m:    VU 300 → 400
4m~5m:    VU 400 → 500
5m~6m:    VU 500 유지
6m~6m30s: VU 500 → 0
```

---

## 1.3 테스트 데이터 구조

- 요청 사용자: 200명
- 맞팔 대상 사용자: 200명

각 로그인 유저는 200명의 맞팔 관계를 보유합니다.
두 그룹 간 상호 팔로우 관계를 구성하여 완전한 맞팔 관계 시뮬레이션을 구축했습니다.

---

# 2. [v1] Baseline – EXISTS 기반 조회

## 🚩 문제 구조

기존 로직은 맞팔 여부를 판단하기 위해 EXISTS 서브쿼리를 사용하는 구조였습니다.

```sql
SELECT f1 FROM Friend f1
WHERE f1.follower = :user
AND f1.following.status = :status
AND EXISTS (
    SELECT f2 FROM Friend f2
    WHERE f2.follower = f1.following
    AND f2.following = :user
)
AND f1.following != :excludeUser
```

이 구조는 맞팔 여부를 판단하기 위해 f1 결과 행마다 EXISTS 서브쿼리가 반복 실행되며,  
데이터가 증가할수록 탐색 비용이 빠르게 증가하는 특징을 가집니다.

또한 `friend.getFollowing()` 호출 시 User 엔티티가 Lazy Loading으로 처리되어  
맞팔 대상 수만큼 추가 쿼리가 발생하는 N+1 문제도 내재되어 있었습니다.

---

## 📊 성능 결과

| 항목 | 값 |
|---|---|
| p95 | 8.25s |
| avg | 4.51s |
| RPS | 54.8 |
| Error | 0.56% |

---

## 📸 결과

| 1 | 2 |
|---|---|
| ![](https://github.com/user-attachments/assets/d1e23413-9078-4d07-9072-f1b9c73ec724) | ![](https://github.com/user-attachments/assets/6efaf5ac-6121-4428-bb2a-12d6c8f826df) | 

---

## 🔍 분석

초기 구간에서는 비교적 안정적인 응답을 유지했으나,
VU 수가 증가할수록 응답 시간이 급격히 증가하는 현상이 관찰되었습니다.

특히 200 VU 이후부터 응답 지연이 빠르게 증가했으며,
400 VU 이상에서는 요청이 처리되지 못하고 큐에 적체되면서 p95 latency가 크게 증가했습니다.

이는 다음과 같은 복합적인 병목이 작용한 결과입니다.

- EXISTS 서브쿼리 반복 실행으로 인한 DB 탐색 비용 증가
- Lazy Loading으로 인한 N+1 문제 (맞팔 200명 → 추가 쿼리 200번)
- 요청 증가에 따른 DB 커넥션 점유 및 처리 지연

결과적으로 단일 쿼리의 문제가 아니라  
**반복 탐색 구조 + N+1 + 정렬 비용 + 요청 적체가 결합된 구조적 병목**이 발생했습니다.

---

## 결론

> EXISTS 기반 구조와 N+1 문제가 결합되어 고부하 환경에서 심각한 성능 저하를 유발했습니다.

---

# 3. [v2] 복합 인덱스 적용

## 개선

맞팔 관계 조회 조건에 맞춰 다음과 같은 복합 인덱스를 적용했습니다.

```sql
CREATE INDEX idx_friend_follower_following
ON friend (follower_user_id, following_user_id);
```

기존 단일 인덱스(`follower_user_id`)만 존재하는 상황에서  
EXISTS 서브쿼리의 `WHERE follower_user_id = ? AND following_user_id = ?` 조건을  
복합 인덱스로 커버링하여 탐색 비용을 줄였습니다.

---

## 📊 성능 결과

| 지표 | v1 | v2 | 개선율 |
|---|---|---|---|
| p95 | 8.25s | 7.01s | 15% ↓ |
| avg | 4.51s | 3.15s | 30% ↓ |
| RPS | 54.8 | 75.2 | 37% ↑ |
| Error | 0.56% | 0.29% | 48% ↓ |

---

## 📸 결과

| 1 | 2 |
|---|---|
| ![](https://github.com/user-attachments/assets/8c9fccac-84cc-487c-a651-dfee739b3335) | ![](https://github.com/user-attachments/assets/3e6d6490-efa5-4c17-b018-7b9222ac0a5e) |

---

## 🔍 분석

복합 인덱스 적용 이후 평균 응답 시간과 RPS는 의미 있는 수준으로 개선되었습니다.

이는 다음과 같은 이유로 분석됩니다.

- 기존 단일 인덱스 대비 EXISTS 서브쿼리의 `(follower, following)` 조건을 한 번에 처리 가능
- MySQL이 중복 인덱스를 자동 제거하여 복합 인덱스가 단일 인덱스를 대체

하지만 p95는 여전히 7초대를 유지했습니다.
인덱스는 단일 탐색 성능을 개선하지만 반복 실행되는 쿼리 구조 자체와 N+1은 그대로 유지되었기 때문입니다.

---

## 결론

> 복합 인덱스는 탐색 비용을 일부 줄였으나,  
> 반복 쿼리 구조 및 N+1로 인한 근본적인 병목 해결에는 부족했습니다.

---

# 4. [v3] Presigned URL 캐싱 (Redis)

## 개선

맞팔 목록 조회 시 각 유저의 프로필 이미지에 대해 매번 S3 Presigned URL을 생성하는 구조를  
Redis 캐싱을 통해 반복 생성을 줄이도록 개선했습니다.

```java
private String getProfileImageUrl(String profileImageName) {
    String cacheKey = PROFILE_URL_CACHE_KEY_PREFIX + profileImageName;
    String cachedUrl = profileImageRedisTemplate.opsForValue().get(cacheKey);
    if (cachedUrl != null) return cachedUrl;

    String url = s3Util.toPresignedUrl("profile/" + profileImageName, Duration.ofMinutes(30));
    profileImageRedisTemplate.opsForValue().set(cacheKey, url, PROFILE_URL_CACHE_TTL); // TTL 20분
    return url;
}
```

---

## 📊 성능 결과

| 지표 | v2 | v3 |
|---|---|---|
| p95 | 7.01s | 7.21s |
| avg | 3.15s | 3.80s |
| RPS | 75.2 | 63.7 |
| Error | 0.29% | 0.07% |

---

## 📸 결과

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/3a2b6932-ba0b-44bb-83c6-9009ba4cb44d) | ![](https://github.com/user-attachments/assets/10c3a40e-d2f9-4114-8901-00a236504278) |

---

## 🔍 분석

Redis를 활용하여 Presigned URL을 캐싱했지만 기대와 달리 응답 시간은 오히려 증가했습니다.

이는 다음과 같은 이유 때문입니다.

- Presigned URL 생성은 네트워크 호출이 아닌 AWS SDK의 로컬 암호화 서명 연산으로 처리됨
- 즉, S3 호출 자체가 없어 캐싱 대상의 비용이 낮았음
- 반면 Redis 조회는 네트워크 왕복 비용을 추가하여 오히려 레이턴시가 증가

---

## 결론

> Presigned URL 생성은 로컬 연산으로 비용이 낮아 캐싱 효과가 제한적이었습니다.
> 캐싱은 실제 병목 지점에 적용해야 효과가 있으며, 잘못된 위치에 적용할 경우 오히려 성능 저하를 유발합니다.

---

# 5. [v4] EXISTS → JOIN 구조 변경

## 개선

EXISTS 서브쿼리를 INNER JOIN으로 변경하여 쿼리 구조를 단순화했습니다.

```sql
-- 기존 (EXISTS)
SELECT f1 FROM Friend f1
WHERE f1.follower = :user
AND EXISTS (SELECT f2 FROM Friend f2
    WHERE f2.follower = f1.following AND f2.following = :user)

-- 변경 (JOIN)
SELECT f1 FROM Friend f1
JOIN Friend f2 ON f2.follower = f1.following AND f2.following = :user
WHERE f1.follower = :user
```

기존 구조는 f1 결과 행마다 서브쿼리가 실행되었으나,  
JOIN 구조에서는 한 번의 조인으로 맞팔 여부를 처리할 수 있습니다.

---

## 📊 성능 결과

| 지표 | v3 | v4 | 개선율 |
|---|---|---|---|
| p95 | 7.21s | 6.78s | 6% ↓ |
| avg | 3.80s | 3.67s | 3% ↓ |
| RPS | 63.7 | 65.7 | 3% ↑ |
| Error | 0.07% | 0.09% | 유사 |

---

## 📸 결과

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/ff717e27-a11d-4e60-8658-9e48e82742b7) | ![](https://github.com/user-attachments/assets/c19bdb65-cecd-4d3c-ad0d-e224feeb6db7) |

---

## 🔍 분석

EXISTS 기반 반복 탐색 구조를 JOIN으로 변경하여 일부 성능 개선이 이루어졌습니다.

하지만 개선 폭이 제한적인 이유는 다음과 같습니다.

- JOIN으로 구조는 단순화되었지만 Lazy Loading으로 인한 N+1은 여전히 존재
- `friend.getFollowing()` 호출 시 User 엔티티가 여전히 건별로 조회됨
- CPU 사용률이 여전히 90% 근접 상태 유지

---

## 결론

> 쿼리 구조 개선은 필요하지만, ORM 레벨의 N+1 문제를 함께 해결하지 않으면 성능 개선 효과는 제한적입니다.

---

# 6. [v5] Fetch Join (N+1 제거)

## 개선

JPQL에 `JOIN FETCH`를 추가하여 Friend 조회 시 User 엔티티를 한 번에 로딩하도록 변경했습니다.

```java
@Query("SELECT f1 FROM Friend f1 " +
       "JOIN FETCH f1.following u " +
       "JOIN Friend f2 ON f2.follower = f1.following AND f2.following = :user " +
       "WHERE f1.follower = :user " +
       "AND u.status = :status " +
       "AND u != :excludeUser")
Slice<Friend> findMutualFriendsExcluding(...);
```

기존에는 `friend.getFollowing()` 호출 시 User가 Lazy Loading으로 건별 조회되었으나,  
`JOIN FETCH` 적용 이후 Friend + User를 단일 쿼리로 처리합니다.

```
Before: Friend 조회 1번 + User 조회 N번 = N+1번
After:  Friend + User 조인 조회 1번
```

---

## 📊 성능 결과

| 지표 | v4 | v5 | 개선율 |
|---|---|---|---|
| p95 | 6.78s | 5.13s | 24% ↓ |
| avg | 3.67s | 2.48s | 32% ↓ |
| RPS | 65.7 | 91.9 | 40% ↑ |
| Error | 0.09% | 0.00% | 100% ↓ |

---

## 📸 결과

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/7854050c-d6a5-4307-8977-20bf16997bb2) | ![](https://github.com/user-attachments/assets/5bda57df-77ff-4112-bffb-16a89e740eb3) |

---

## 🔍 분석

Fetch Join을 적용하여 N+1 문제를 제거하면서 성능이 크게 개선되었습니다.

개선 효과가 크게 나타난 이유는 다음과 같습니다.

- Lazy Loading으로 인해 발생하던 추가 쿼리 완전 제거
- DB 접근 횟수 대폭 감소 (N+1 → 1)
- CPU 사용률이 이전 대비 감소하며 처리 여유 확보

특히 RPS 40% 증가와 에러율 0% 달성이 동시에 나타났다는 점에서 실질적인 병목이 ORM 레벨의 N+1에 있었음을 확인할 수 있습니다.

---

## 결론

> Fetch Join은 본 API에서 가장 효과적인 단일 최적화였으며,  
> N+1 제거가 구조적 병목 해소의 핵심이었습니다.

---

# 7. [v6] DTO Projection + existsById

## 개선

두 가지를 함께 적용했습니다.

**1. DTO Projection**  
엔티티 전체 조회 대신 필요한 컬럼(userId, nickname, profileImageName)만 조회하도록 변경했습니다.

**2. existsById 기반 존재 여부 검증**  
기존에 `getUserOrThrow(excludeUserId)`로 User 엔티티를 전체 조회하던 방식을 `existsById`로 존재 여부만 확인하도록 변경했습니다.

---

## 📊 성능 결과

| 지표 | v5 | v6 | 개선율 |
|---|---|---|---|
| p95 | 5.13s | 4.98s | 3% ↓ |
| avg | 2.48s | 2.35s | 5% ↓ |
| RPS | 91.9 | 96 | 4% ↑ |
| Error | 0.00% | 0.01% | 유사 |

---

## 📸 결과

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/2985b20b-085e-466e-a494-cfbf24bcfdc7) | ![](https://github.com/user-attachments/assets/aa085151-fdfa-4541-84d6-0167431419c8) |

---

## 🔍 분석

DTO Projection과 existsById 적용으로 소폭의 성능 개선이 이루어졌습니다.

개선 효과는 다음과 같습니다.

- 불필요한 컬럼 조회 제거
- 엔티티 생성 및 영속성 컨텍스트 관리 비용 감소
- excludeUser 조회를 위한 불필요한 엔티티 로딩 제거

하지만 성능 개선 폭이 제한적인 이유는 다음과 같습니다.

- v5에서 N+1이 제거된 이후 DB 쿼리 자체는 이미 빠른 상태
- 병목이 DB가 아닌 애플리케이션 및 네트워크 레벨로 이동한 상태
- JSON 직렬화 및 네트워크 비용이 상대적으로 더 큰 비중을 차지

---

## 결론

> DTO Projection은 구조적으로 올바른 개선이지만,  
> 병목이 이미 DB 외부로 이동한 상황에서는 성능 개선 효과가 제한적입니다.

---

# 8. [v7] Redis multiGet 최적화

## 🔧 개선 내용

기존 v3에서 적용한 Redis 캐싱 구조는 친구 수만큼 Redis GET 요청이 반복 발생하는 문제가 있었습니다.

```
기존 구조
200명 조회 → Redis GET 200번
```

이를 다음과 같이 개선했습니다.

```
개선 구조
profileImageName 수집 → distinct → Redis multiGet 1회
```

```java
List<String> imageNames = friends.stream()
    .map(f -> f.getProfileImageName())
    .distinct()
    .collect(toList());

List<String> keys = imageNames.stream()
    .map(name -> PROFILE_URL_CACHE_KEY_PREFIX + name)
    .collect(toList());

List<String> cachedUrls = profileImageRedisTemplate.opsForValue().multiGet(keys);
```

---

## 📊 성능 결과 (default 이미지)

| 지표 | 값 |
|---|---|
| p95 | 2.78s |
| avg | 1.30s |
| RPS | 151 |
| Error | 0.00% |

---

## 📸 결과 (default 이미지)

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/b6649004-339c-4216-98b0-99036c8b5937) | ![](https://github.com/user-attachments/assets/8e6bf36f-316e-4f97-a771-3b3ed10b8edd) |

---

## ⚠ 문제 인식

default.svg 하나만 사용되는 테스트 데이터 특성상  
모든 요청이 동일 key를 사용하게 되었고, Redis 조회가 사실상 1회로 수렴했습니다.
이로 인해 실제보다 과도하게 좋은 성능 결과가 나타났습니다.

---

## 🔧 데이터 보정

```sql
UPDATE user
SET profile_image_name = CONCAT('profile_', FLOOR(1 + RAND() * 50), '.svg')
WHERE id BETWEEN 246 AND 445;
```

50가지 이미지로 분산하여 보다 현실적인 환경을 구성했습니다.

---

## 📊 성능 결과 (랜덤 이미지)

| 지표 | v6 | v7 | 개선율 |
|---|---|---|---|
| p95 | 4.98s | 3.06s | 39% ↓ |
| avg | 2.35s | 1.43s | 39% ↓ |
| RPS | 96 | 139 | 45% ↑ |
| Error | 0.01% | 0.00% | 100% ↓ |

---

## 📸 결과 (랜덤 이미지)

| 1 | 2 |
|---|---|
![](https://github.com/user-attachments/assets/eefeb1e4-6b52-40ce-b1ed-a6cd9a034a7d) | ![](https://github.com/user-attachments/assets/4d535e80-7913-4173-956e-4a831d441494) |

---

## 🔍 분석

Redis multiGet 적용을 통해 Redis 호출 횟수를 획기적으로 줄였습니다.

고부하 환경에서 호출 횟수 차이:

| 구조 | 500 VU 기준 Redis 호출 수 |
|---|---|
| 기존 (GET 반복) | 500 × 200 = 100,000회 |
| 개선 (multiGet) | 500 × 1 = 500회 |

네트워크 왕복 비용이 크게 감소하면서 응답 시간과 처리량이 동시에 개선되었습니다.  
이는 v3에서 Redis 캐싱이 효과를 내지 못했던 원인이 **캐싱 자체**가 아닌 **캐시 조회 방식의 비효율**에 있었음을 보여줍니다.

---

## 결론

> Redis multiGet은 반복적인 네트워크 왕복을 제거하여 고부하 환경에서 가장 큰 폭의 성능 개선을 가져왔습니다.
> 테스트 데이터 편향을 인지하고 보정한 뒤 재검증함으로써 보다 신뢰성 있는 수치를 확보했습니다.

---

# 9. 최종 성능 개선 목표 및 달성 현황 요약

## 단계별 수치 전체 비교

| 버전 | 주요 변경 | avg | p95 | RPS | Error |
|---|---|---|---|---|---|
| v1 | 기준 (EXISTS + N+1) | 4.51s | 8.25s | 54.8 | 0.56% |
| v2 | 복합 인덱스 추가 | 3.15s | 7.01s | 75.2 | 0.29% |
| v3 | Redis Presigned URL 캐싱 | 3.80s | 7.21s | 63.7 | 0.07% |
| v4 | EXISTS → JOIN 변경 | 3.67s | 6.78s | 65.7 | 0.09% |
| v5 | Fetch Join (N+1 제거) | 2.48s | 5.13s | 91.9 | 0.00% |
| v6 | DTO Projection + existsById | 2.35s | 4.98s | 96.0 | 0.01% |
| v7 | Redis multiGet 최적화 | 1.43s | 3.06s | 139 | 0.00% |

---

## 목표 달성 현황

| 구분 | 목표치 (Thresholds) | v1 (기존) | v7 (최종) | 결과 |
|---|---|---|---|---|
| p(95) Latency | 3.0s 미만 | 8.25s | 3.06s | ⚠ 근접 달성 |
| Error Rate | 1.0% 미만 | 0.56% | 0.00% | ✅ 통과 |
| Throughput (RPS) | 증가 | 54.8 | 139 | ✅ 약 2.5배 증가 |

---

## 🔍 종합 분석

본 작업에서는 단계별 최적화를 통해 병목을 점진적으로 제거했습니다.

병목의 이동 흐름은 다음과 같습니다.

- v1: DB 반복 탐색 (EXISTS) + N+1 → DB 병목
- v5: Fetch Join → ORM 병목 제거 (가장 큰 단일 개선)
- v6: DTO Projection → 불필요한 데이터 로딩 감소
- v7: Redis multiGet → 네트워크 병목 개선

특히 주목할 점은 다음과 같습니다.

- **v3**에서 Redis 캐싱이 효과 없었던 이유: 병목 지점이 아닌 곳에 캐싱을 적용했기 때문
- **v7**에서 동일한 Redis 캐싱이 효과를 낸 이유: multiGet으로 호출 구조 자체를 개선했기 때문
- 이를 통해 캐싱 자체보다 **어디에, 어떤 방식으로** 적용하느냐가 중요함을 확인

---

## 🔥 최종 결론

단계별 최적화를 통해 구조적 병목을 제거하고 성능을 개선했습니다.

특히 Fetch Join과 Redis multiGet 적용이 성능 개선에 가장 큰 영향을 미쳤으며,
최종적으로 시스템 병목이 DB에서 네트워크 및 응답 처리 영역으로 이동했음을 확인했습니다.

이를 통해 단순한 쿼리 최적화뿐만 아니라,  
**시스템 전반의 병목이 단계적으로 어떻게 이동하는지**를 분석하고 개선하는 것이 중요함을 확인했습니다.

---

## 🚀 향후 방향

현재 p95가 목표치에 근접했으나 완전히 안정적으로 달성하지는 못하였다.

이는 단일 인스턴스 환경에서 CPU 및 요청 대기 큐 영향이 남아 있기 때문이며,
다음과 같은 개선을 통해 추가 성능 향상이 가능합니다.

- 기본 이미지에 대한 고정 URL 적용 (응답 크기 감소)
- 맞팔 조회 결과 자체 캐싱
- Scale-out 및 Load Balancer 도입


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 상호 친구 목록 조회 최적화 — 경량화된 조회로 응답 속도 개선 및 별도 정렬(이름 오름차순) 적용
  * 프로필 이미지 URL을 Redis에 캐시하여 반복 조회 시 로딩 시간 대폭 단축
  * 친구 관계 조회용 DB 복합 인덱스 추가로 조회 성능 향상

* **Chores**
  * 제외 대상 사용자 유효성 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->