### PR TITLE
FEAT: AOP 기반 Rate Limit 기능 구현

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/controller/AuthController.java
@@ -14,7 +14,9 @@ import umc.teumteum.server.domain.auth.exception.status.AuthSuccessStatus;
 import umc.teumteum.server.domain.auth.service.AuthService;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.annotation.CurrentUser;
+import umc.teumteum.server.global.annotation.RateLimit;
 import umc.teumteum.server.global.apiPayload.ApiResponse;
+import umc.teumteum.server.global.ratelimit.RateLimitPolicy;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 @RestController
@@ -29,6 +31,7 @@ public class AuthController {
             description = "카카오, 네이버, 구글 소셜 플랫폼을 통한 로그인을 처리합니다."
     )
     @PostMapping(value = "/social-login/{socialType}", produces = "application/json")
+    @RateLimit(policies = {RateLimitPolicy.SOCIAL_LOGIN_SOCIAL_ID, RateLimitPolicy.SOCIAL_LOGIN_IP})
     public ApiResponse<AuthResponseDto.LoginResponse> socialLogin(
             @Parameter(
                     description = "소셜 로그인 타입 (kakao 또는 naver 또는 google)",
@@ -49,6 +52,7 @@ public class AuthController {
             description = "리프레시 토큰을 사용하여 새로운 액세스 토큰&리프레시 토큰을 발급받습니다."
     )
     @PostMapping(value = "/reissue", produces = "application/json")
+    @RateLimit(policies = {RateLimitPolicy.REISSUE_USER})
     public ApiResponse<AuthResponseDto.ReissueResponse> reissueToken(
             @Valid @RequestBody AuthRequestDto.ReissueRequest request
     ) {

--- a/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/AuthServiceImpl.java
@@ -30,6 +30,7 @@ import umc.teumteum.server.domain.user.service.UserService;
 import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
 import umc.teumteum.server.global.exception.InvalidTokenTypeException;
 import umc.teumteum.server.global.jwt.JwtProvider;
+import umc.teumteum.server.global.util.LogHashUtil;
 
 @Slf4j
 @Service
@@ -49,6 +50,7 @@ public class AuthServiceImpl implements AuthService {
 
     private final JwtProvider jwtProvider;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final LogHashUtil logHashUtil;
 
     private final RoutineRepository routineRepository;
     private final ScheduleRepository scheduleRepository;
@@ -285,7 +287,9 @@ public class AuthServiceImpl implements AuthService {
 
         // 요청받은 RT와 Redis에 저장된 RT 다름
         if (!refreshToken.equals(savedRefreshToken)) {
-            log.warn("[Refresh 토큰 탈취 의심] : 요청 RT != Redis RT - userId: {}, sessionId: {}", userId, sessionId);
+            log.warn("[Refresh Token Mismatch] user={}, session={}",
+                    logHashUtil.hashIdentifier(userId),
+                    logHashUtil.hashIdentifier(sessionId));
 
             // 동일한 sessionID를 갖는 AT 블랙리스트 저장
             saveAccessTokenBlacklist(userId, sessionId, accessExpirationMs);

--- a/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/GoogleOAuthServiceImpl.java
@@ -13,6 +13,7 @@ import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.auth.exception.AuthException;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.global.util.LogHashUtil;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -26,6 +27,7 @@ public class GoogleOAuthServiceImpl implements OAuthService {
     private static final long NONCE_TTL_HOURS = 1;
 
     private final GoogleIdTokenVerifier googleIdTokenVerifier;
+    private final LogHashUtil logHashUtil;
 
     @Resource(name = "nonceRedisTemplate")
     private RedisTemplate<String, String> nonceRedisTemplate;
@@ -33,40 +35,45 @@ public class GoogleOAuthServiceImpl implements OAuthService {
 
     @Override
     public OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
-        // 1. Nonce 검증 및 저장
-        validateAndSaveNonce(nonce);
+        // 1. nonce 필수값 검증
+        validateNonceNotBlank(nonce);
 
         // 2. ID Token 검증
         GoogleIdToken googleIdToken = verifyIdToken(idToken);
 
-        // 3. Nonce 클레임 검증
-        verifyNonceClaim(googleIdToken.getPayload(), nonce);
+        // 3. nonce 클레임 검증
+        Payload payload = googleIdToken.getPayload();
+        verifyNonceClaim(payload, nonce);
 
         // 4. 사용자 정보 추출
-        Payload payload = googleIdToken.getPayload();
         String socialId = payload.getSubject();
         String email = payload.getEmail();
 
-        // 5. OAuthUserInfo 반환
+        // 5. nonce 재사용 검증 및 저장
+        validateAndSaveNonce(nonce, socialId);
+
+        // 6. OAuthUserInfo 반환
         return AuthConverter.toOAuthUserInfo(SocialType.GOOGLE, socialId, email);
     }
 
-    private void validateAndSaveNonce(String nonce) {
-        // 1. nonce 확인
+    private void validateNonceNotBlank(String nonce) {
         if (nonce == null || nonce.isBlank()) {
             throw new AuthException(AuthErrorStatus.NONCE_REQUIRED);
         }
+    }
 
-        // 2. Redis 키 생성
+    private void validateAndSaveNonce(String nonce, String socialId) {
+        // 1. Redis 키 생성
         String key = getNonceKey(nonce);
 
-        // 3. Redis에 저장 시도
+        // 2. Redis에 저장 시도
         Boolean wasUsed = nonceRedisTemplate.opsForValue()
                 .setIfAbsent(key, "used", Duration.ofHours(NONCE_TTL_HOURS));
 
-        // 4. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
+        // 3. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
         if (Boolean.FALSE.equals(wasUsed)) {
-            log.warn("[ID 토큰 탈취 의심] : 이미 사용한 ID Token & nonce로 로그인 시도");
+            log.warn("[ID Token Replay Suspected] provider=GOOGLE, id={}",
+                    logHashUtil.hashIdentifier(socialId));
             throw new AuthException(AuthErrorStatus.NONCE_ALREADY_USED);
         }
     }

--- a/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/auth/service/KakaoOAuthServiceImpl.java
@@ -18,6 +18,7 @@ import umc.teumteum.server.domain.auth.dto.OAuthUserInfo;
 import umc.teumteum.server.domain.auth.exception.AuthException;
 import umc.teumteum.server.domain.auth.exception.status.AuthErrorStatus;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
+import umc.teumteum.server.global.util.LogHashUtil;
 
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
@@ -34,6 +35,7 @@ public class KakaoOAuthServiceImpl implements OAuthService {
     private String platformKey;
 
     private final JwkProvider kakaoJwkProvider;
+    private final LogHashUtil logHashUtil;
 
     @Resource(name = "nonceRedisTemplate")
     private RedisTemplate<String, String> nonceRedisTemplate;
@@ -41,8 +43,8 @@ public class KakaoOAuthServiceImpl implements OAuthService {
 
     @Override
     public OAuthUserInfo getUserInfoWithIdToken(String idToken, String nonce) {
-        // 1. Nonce 검증 및 저장
-        validateAndSaveNonce(nonce);
+        // 1. nonce 필수값 검증
+        validateNonceNotBlank(nonce);
 
         // 2. ID Token 검증
         DecodedJWT verifiedJwt = verifyIdToken(idToken, nonce);
@@ -51,27 +53,31 @@ public class KakaoOAuthServiceImpl implements OAuthService {
         String socialId = verifiedJwt.getSubject();
         String email = verifiedJwt.getClaim("email").asString();
 
-        // 4. OAuthUserInfo 반환
+        // 4. nonce 재사용 검증 및 저장
+        validateAndSaveNonce(nonce, socialId);
+
+        // 5. OAuthUserInfo 반환
         return AuthConverter.toOAuthUserInfo(SocialType.KAKAO, socialId, email);
     }
 
-
-    private void validateAndSaveNonce(String nonce) {
-        // 1. nonce 확인
+    private void validateNonceNotBlank(String nonce) {
         if (nonce == null || nonce.isBlank()) {
             throw new AuthException(AuthErrorStatus.NONCE_REQUIRED);
         }
+    }
 
-        // 2. Redis 키 생성
+    private void validateAndSaveNonce(String nonce, String socialId) {
+        // 1. Redis 키 생성
         String key = getNonceKey(nonce);
 
-        // 3. Redis에 저장 시도
+        // 2. Redis에 저장 시도
         Boolean wasUsed = nonceRedisTemplate.opsForValue()
                 .setIfAbsent(key, "used", Duration.ofHours(NONCE_TTL_HOURS));
 
-        // 4. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
+        // 3. 이미 사용된 값이면 wasUsed가 False이기 때문에 예외 처리
         if (Boolean.FALSE.equals(wasUsed)) {
-            log.warn("[ID 토큰 탈취 의심] : 이미 사용한 ID Token & nonce로 로그인 시도");
+            log.warn("[ID Token Replay Suspected] provider=KAKAO, id={}",
+                    logHashUtil.hashIdentifier(socialId));
             throw new AuthException(AuthErrorStatus.NONCE_ALREADY_USED);
         }
     }

--- a/src/main/java/umc/teumteum/server/global/annotation/RateLimit.java
+++ b/src/main/java/umc/teumteum/server/global/annotation/RateLimit.java
@@ -1,0 +1,14 @@
+package umc.teumteum.server.global.annotation;
+
+import umc.teumteum.server.global.ratelimit.RateLimitPolicy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+    RateLimitPolicy[] policies();
+}

--- a/src/main/java/umc/teumteum/server/global/aop/RateLimitAspect.java
+++ b/src/main/java/umc/teumteum/server/global/aop/RateLimitAspect.java
@@ -1,0 +1,105 @@
+package umc.teumteum.server.global.aop;
+
+import com.auth0.jwt.JWT;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import umc.teumteum.server.domain.auth.dto.AuthRequestDto;
+import umc.teumteum.server.global.annotation.RateLimit;
+import umc.teumteum.server.global.exception.RateLimitExceededException;
+import umc.teumteum.server.global.ratelimit.RateLimitPolicy;
+import umc.teumteum.server.global.ratelimit.RateLimiter;
+import umc.teumteum.server.global.util.LogHashUtil;
+
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+    private final RateLimiter rateLimiter;
+    private final HttpServletRequest request;
+    private final LogHashUtil logHashUtil;
+
+    @Around("@annotation(rateLimit)")
+    public Object applyRateLimit(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
+        String clientIp = resolveClientIp();
+
+        for (RateLimitPolicy policy : rateLimit.policies()) {
+            // 1. 정책별 식별자 및 Redis 키 생성
+            String identifier = resolveIdentifier(policy, joinPoint, clientIp);
+            String key = policy.buildKey(identifier);
+
+            // 2. Rate Limit 검사
+            if (!rateLimiter.isAllowed(key, policy)) {
+                log.warn("[Rate Limit Exceeded] policy={} id={}",
+                        policy.name(),
+                        logHashUtil.hashIdentifier(identifier));
+                throw new RateLimitExceededException(policy);
+            }
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private String resolveIdentifier(RateLimitPolicy policy, ProceedingJoinPoint joinPoint, String clientIp) {
+        return switch (policy) {
+            case SOCIAL_LOGIN_SOCIAL_ID -> extractSocialIdFromIdToken(joinPoint);
+            case SOCIAL_LOGIN_IP        -> clientIp;
+            case REISSUE_USER           -> extractUserIdFromRT(joinPoint);
+        };
+    }
+
+    // idToken 무검증 decode -> socialId 추출 (Rate Limit 식별자 목적)
+    // 네이버는 JWT가 아닌 accessToken -> subject null -> IP fallback
+    private String extractSocialIdFromIdToken(ProceedingJoinPoint joinPoint) {
+        return Arrays.stream(joinPoint.getArgs())
+                .filter(arg -> arg instanceof AuthRequestDto.SocialLoginRequest)
+                .map(arg -> (AuthRequestDto.SocialLoginRequest) arg)
+                .findFirst()
+                .map(req -> {
+                    try {
+                        String subject = JWT.decode(req.getToken()).getSubject();
+                        if (subject == null) {
+                            return "IP_" + resolveClientIp();
+                        }
+                        return subject;
+                    } catch (Exception e) {
+                        return "INVALID_" + resolveClientIp();
+                    }
+                })
+                .get();
+    }
+
+    // RT 무검증 decode -> userId 추출 (Rate Limit 식별자 목적)
+    private String extractUserIdFromRT(ProceedingJoinPoint joinPoint) {
+        return Arrays.stream(joinPoint.getArgs())
+                .filter(arg -> arg instanceof AuthRequestDto.ReissueRequest)
+                .map(arg -> (AuthRequestDto.ReissueRequest) arg)
+                .findFirst()
+                .map(req -> {
+                    try {
+                        return JWT.decode(req.getRefreshToken()).getSubject();
+                    } catch (Exception e) {
+                        return "INVALID_" + resolveClientIp();
+                    }
+                })
+                .get();
+    }
+
+    // 실제 클라이언트 IP 추출
+    private String resolveClientIp() {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(xForwardedFor)) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/global/apiPayload/code/status/ErrorStatus.java
@@ -14,25 +14,24 @@ public enum ErrorStatus implements BaseErrorCode {
   _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
   _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-  // 동시성 관련
-  LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "COMMON4091", "요청이 처리 중입니다. 잠시 후 다시 시도해주세요."),
-
 
   // 인증 관련
-  MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4101", "잘못 구성된 JWT 형식입니다."),
-  UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4102", "지원하지 않는 JWT 형식입니다."),
-  EMPTY_JWT_CLAIMS(HttpStatus.BAD_REQUEST, "AUTH4103", "JWT 클레임이 비어 있습니다."),
-  USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4111", "존재하지 않는 사용자입니다."),
-  INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4112", "유효하지 않은 JWT 서명입니다."),
-  EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4113", "JWT 토큰이 만료되었습니다."),
-  INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH4114", "유효하지 않은 토큰 타입입니다."),
-  ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "AUTH4115", "블랙리스트된 액세스 토큰입니다."),
-  INACTIVE_USER(HttpStatus.FORBIDDEN, "AUTH4131", "비활성화된 사용자입니다."),
+  MALFORMED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT4001", "잘못 구성된 JWT 형식입니다."),
+  UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT4002", "지원하지 않는 JWT 형식입니다."),
+  EMPTY_JWT_CLAIMS(HttpStatus.BAD_REQUEST, "JWT4003", "JWT 클레임이 비어 있습니다."),
+  USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4011", "존재하지 않는 사용자입니다."),
+  INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "JWT4012", "유효하지 않은 JWT 서명입니다."),
+  EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "JWT4013", "JWT 토큰이 만료되었습니다."),
+  INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "JWT4014", "유효하지 않은 토큰 타입입니다."),
+  ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "JWT4015", "블랙리스트된 액세스 토큰입니다."),
+  INACTIVE_USER(HttpStatus.FORBIDDEN, "JWT4031", "비활성화된 사용자입니다."),
 
 
-  // 회원 관련
-  INVALID_USER(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 유저입니다."),
+  // 동시성 관련
+  LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "LOCK4091", "요청이 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
+  // Rate Limit 관련
+  RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE4291", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
   ;
 

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -83,6 +83,12 @@ public class RedisConfig {
         return createRedisTemplate(createConnectionFactory(5));
     }
 
+    // Rate Limit용 Redis (index 6)
+    @Bean
+    public RedisTemplate<String, String> rateLimitRedisTemplate() {
+        return createRedisTemplate(createConnectionFactory(6));
+    }
+
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();

--- a/src/main/java/umc/teumteum/server/global/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/teumteum/server/global/exception/ExceptionAdvice.java
@@ -163,9 +163,6 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 
 
-
-
-
   //2. 비즈니스 로직에서 발생하는 커스텀 예외 처리
   @ExceptionHandler(value = GeneralException.class)
   public ResponseEntity onThrowException(
@@ -175,6 +172,23 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
   }
 
 
+    // RateLimitExceededException 전용 핸들러
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<Object> handleRateLimitExceeded(RateLimitExceededException e) {
+        ErrorReasonDto reason = e.getErrorReasonHttpStatus();
+        long retryAfterSeconds = e.getPolicy().getWindowMs() / 1000;
+
+        ApiResponse<Object> body = ApiResponse.onFailure(
+                reason.getCode(),
+                reason.getMessage(),
+                null
+        );
+
+        return ResponseEntity
+                .status(reason.getHttpStatus())
+                .header("Retry-After", String.valueOf(retryAfterSeconds))
+                .body(body);
+    }
 
 
 
@@ -225,5 +239,4 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     return super.handleExceptionInternal(
         e, body, headers, errorCommonStatus.getHttpStatus(), request);
   }
-
 }

--- a/src/main/java/umc/teumteum/server/global/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/teumteum/server/global/exception/ExceptionAdvice.java
@@ -176,7 +176,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(RateLimitExceededException.class)
     public ResponseEntity<Object> handleRateLimitExceeded(RateLimitExceededException e) {
         ErrorReasonDto reason = e.getErrorReasonHttpStatus();
-        long retryAfterSeconds = e.getPolicy().getWindowMs() / 1000;
+
+        // 현재 윈도우 종료까지 남은 시간 계산
+        long windowMs = e.getPolicy().getWindowMs();
+        long now = System.currentTimeMillis();
+        long windowStart = (now / windowMs) * windowMs;
+        long retryAfterSeconds = (windowStart + windowMs - now) / 1000;
 
         ApiResponse<Object> body = ApiResponse.onFailure(
                 reason.getCode(),

--- a/src/main/java/umc/teumteum/server/global/exception/RateLimitExceededException.java
+++ b/src/main/java/umc/teumteum/server/global/exception/RateLimitExceededException.java
@@ -1,0 +1,16 @@
+package umc.teumteum.server.global.exception;
+
+import lombok.Getter;
+import umc.teumteum.server.global.apiPayload.code.status.ErrorStatus;
+import umc.teumteum.server.global.ratelimit.RateLimitPolicy;
+
+@Getter
+public class RateLimitExceededException extends GeneralException {
+
+    private final RateLimitPolicy policy;
+
+    public RateLimitExceededException(RateLimitPolicy policy) {
+        super(ErrorStatus.RATE_LIMIT_EXCEEDED);
+        this.policy = policy;
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/ratelimit/RateLimitPolicy.java
+++ b/src/main/java/umc/teumteum/server/global/ratelimit/RateLimitPolicy.java
@@ -2,21 +2,21 @@ package umc.teumteum.server.global.ratelimit;
 
 public enum RateLimitPolicy {
 
-    // social-login: socialId 핵심 키 (IP 로테이션, UA 위변조 공격 대응)
+    // social-login: socialId 핵심 키
     SOCIAL_LOGIN_SOCIAL_ID(
             "RATE_LIMIT:SOCIAL_LOGIN:SOCIAL_ID:%s",
             10 * 60 * 1000L,
             10
     ),
 
-    // social-login: IP 보조 키 (idToken 없이 무차별 시도하는 공격 대응)
+    // social-login: IP 핵심 키
     SOCIAL_LOGIN_IP(
             "RATE_LIMIT:SOCIAL_LOGIN:IP:%s",
             10 * 60 * 1000L,
             50
     ),
 
-    // reissue: userId 핵심 키 (IP 로테이션 공격 대응)
+    // reissue: userId 핵심 키
     REISSUE_USER(
             "RATE_LIMIT:REISSUE:USER:%s",
             10 * 60 * 1000L,

--- a/src/main/java/umc/teumteum/server/global/ratelimit/RateLimitPolicy.java
+++ b/src/main/java/umc/teumteum/server/global/ratelimit/RateLimitPolicy.java
@@ -1,0 +1,42 @@
+package umc.teumteum.server.global.ratelimit;
+
+public enum RateLimitPolicy {
+
+    // social-login: socialId 핵심 키 (IP 로테이션, UA 위변조 공격 대응)
+    SOCIAL_LOGIN_SOCIAL_ID(
+            "RATE_LIMIT:SOCIAL_LOGIN:SOCIAL_ID:%s",
+            10 * 60 * 1000L,
+            10
+    ),
+
+    // social-login: IP 보조 키 (idToken 없이 무차별 시도하는 공격 대응)
+    SOCIAL_LOGIN_IP(
+            "RATE_LIMIT:SOCIAL_LOGIN:IP:%s",
+            10 * 60 * 1000L,
+            50
+    ),
+
+    // reissue: userId 핵심 키 (IP 로테이션 공격 대응)
+    REISSUE_USER(
+            "RATE_LIMIT:REISSUE:USER:%s",
+            10 * 60 * 1000L,
+            15
+    );
+
+    private final String keyTemplate;
+    private final long windowMs;
+    private final int limit;
+
+    RateLimitPolicy(String keyTemplate, long windowMs, int limit) {
+        this.keyTemplate = keyTemplate;
+        this.windowMs = windowMs;
+        this.limit = limit;
+    }
+
+    public String buildKey(String identifier) {
+        return String.format(keyTemplate, identifier);
+    }
+
+    public long getWindowMs() { return windowMs; }
+    public int getLimit() { return limit; }
+}

--- a/src/main/java/umc/teumteum/server/global/ratelimit/RateLimiter.java
+++ b/src/main/java/umc/teumteum/server/global/ratelimit/RateLimiter.java
@@ -1,0 +1,61 @@
+package umc.teumteum.server.global.ratelimit;
+
+import jakarta.annotation.Resource;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class RateLimiter {
+
+    @Resource(name = "rateLimitRedisTemplate")
+    private RedisTemplate<String, String> rateLimitRedisTemplate;
+
+    private static final String SLIDING_WINDOW_COUNTER_SCRIPT = """
+            local current_key = KEYS[1]
+            local previous_key = KEYS[2]
+            local now = tonumber(ARGV[1])
+            local window_ms = tonumber(ARGV[2])
+            local limit = tonumber(ARGV[3])
+            
+            local window_start = math.floor(now / window_ms) * window_ms
+            local elapsed_ratio = (now - window_start) / window_ms
+            
+            local current_count = tonumber(redis.call('GET', current_key) or 0)
+            local previous_count = tonumber(redis.call('GET', previous_key) or 0)
+            
+            -- 이전 윈도우 가중 합산 (경과 비율만큼 비중 감소)
+            local weighted = math.floor(previous_count * (1 - elapsed_ratio)) + current_count
+            
+            if weighted < limit then
+                redis.call('INCR', current_key)
+                redis.call('PEXPIRE', current_key, window_ms * 2)
+                return weighted + 1
+            else
+                return -1
+            end
+            """;
+
+    public boolean isAllowed(String key, RateLimitPolicy policy) {
+        long windowMs = policy.getWindowMs();
+        long now = System.currentTimeMillis();
+
+        // 1. 현재/이전 윈도우 키 생성
+        long currentWindow = now / windowMs;
+        String currentKey = key + ":" + currentWindow;
+        String previousKey = key + ":" + (currentWindow - 1);
+
+        // 2. Lua Script 실행
+        Long result = rateLimitRedisTemplate.execute(
+                new DefaultRedisScript<>(SLIDING_WINDOW_COUNTER_SCRIPT, Long.class),
+                List.of(currentKey, previousKey),
+                String.valueOf(now),
+                String.valueOf(windowMs),
+                String.valueOf(policy.getLimit())
+        );
+
+        return result != null && result != -1L;
+    }
+}

--- a/src/main/java/umc/teumteum/server/global/ratelimit/RateLimiter.java
+++ b/src/main/java/umc/teumteum/server/global/ratelimit/RateLimiter.java
@@ -1,12 +1,14 @@
 package umc.teumteum.server.global.ratelimit;
 
 import jakarta.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 public class RateLimiter {
 
@@ -48,14 +50,19 @@ public class RateLimiter {
         String previousKey = key + ":" + (currentWindow - 1);
 
         // 2. Lua Script 실행
-        Long result = rateLimitRedisTemplate.execute(
-                new DefaultRedisScript<>(SLIDING_WINDOW_COUNTER_SCRIPT, Long.class),
-                List.of(currentKey, previousKey),
-                String.valueOf(now),
-                String.valueOf(windowMs),
-                String.valueOf(policy.getLimit())
-        );
-
-        return result != null && result != -1L;
+        try {
+            Long result = rateLimitRedisTemplate.execute(
+                    new DefaultRedisScript<>(SLIDING_WINDOW_COUNTER_SCRIPT, Long.class),
+                    List.of(currentKey, previousKey),
+                    String.valueOf(now),
+                    String.valueOf(windowMs),
+                    String.valueOf(policy.getLimit())
+            );
+            return result != null && result != -1L;
+        } catch (Exception ex) {
+            // Redis 장애 시 fail-open (가용성 우선)
+            log.error("[Rate Limit Check Failed]", ex);
+            return true;
+        }
     }
 }

--- a/src/main/java/umc/teumteum/server/global/util/LogHashUtil.java
+++ b/src/main/java/umc/teumteum/server/global/util/LogHashUtil.java
@@ -1,0 +1,55 @@
+package umc.teumteum.server.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class LogHashUtil {
+
+    private static final String ALGORITHM = "HmacSHA256";
+
+    @Value("${log.hash.secret}")
+    private String secret;
+
+    // prefix 보존 후 식별자 값만 해시
+    public String hashIdentifier(String identifier) {
+        try {
+            int idx = identifier.indexOf('_');
+
+            if (idx != -1) {
+                String prefix = identifier.substring(0, idx + 1);
+                String value = identifier.substring(idx + 1);
+                return prefix + hash(value);
+            }
+
+            return hash(identifier);
+
+        } catch (Exception e) {
+            return "HASH_FAILED";
+        }
+    }
+
+    private String hash(String value) {
+        try {
+            // 1. HmacSHA256 키 초기화
+            Mac mac = Mac.getInstance(ALGORITHM);
+            SecretKeySpec keySpec = new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8),
+                    ALGORITHM
+            );
+            mac.init(keySpec);
+
+            // 2. 해시 후 Base64 인코딩 반환
+            byte[] raw = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(raw);
+
+        } catch (Exception e) {
+            return "HASH_FAILED";
+        }
+    }
+}


### PR DESCRIPTION
## 👀 관련 이슈
#359
 
## ✨ 작업한 내용
인증 API(소셜 로그인, 토큰 재발급)에 Rate Limit을 추가했습니다.
 
기존 보안 로직(nonce, RT 화이트리스트)은 요청의 유효성을 판단하는 로직이며, 동일한 클라이언트 또는 동일한 사용자가 짧은 시간 안에 반복적으로 요청을 보내는 상황까지 제어하지는 못합니다. Rate Limit은 이를 보완하여 인증 로직 진입 전 요청량 자체를 사전에 제한합니다.
 
| 구분 | 목적 |
|:--:|:--:|
| nonce | 소셜 ID Token 재사용 공격 방지 |
| RT 화이트리스트 | Refresh Token 유효성 검증 |
| **Rate Limit** | **짧은 시간 내 반복 호출 제한** |
 
**적용 대상 및 정책**
| 엔드포인트 | 정책 | 식별자 | 한도 |
|:--:|:--:|:--:|:--:|
| 소셜 로그인 | SOCIAL_LOGIN_SOCIAL_ID | socialId (idToken decode) | 10분/10회 |
| 소셜 로그인 | SOCIAL_LOGIN_IP | IP | 10분/50회 |
| 토큰 재발급 | REISSUE_USER | userId (RT decode) | 10분/15회 |
 
## 🌀 PR Point
### 1. 알고리즘 선택 - Sliding Window Counter
| 알고리즘 | 설명 | 탈락 이유 |
|:--:|:--:|:--:|
| Fixed Window | 고정된 시간 윈도우 내 요청 수 카운팅 | 윈도우 경계에서 버스트 공격 가능 → 보안 목적 API에 부적합 |
| Sliding Window Log | 요청마다 타임스탬프를 ZSet에 저장하여 정확한 슬라이딩 계산 | ZSet 타임스탬프 저장 → 한도가 작은 이 상황에서 복잡도 과함 |
| Token Bucket | 토큰을 일정 속도로 충전하고 요청마다 소비, 버스트 허용 | 버스트 허용 설계 → 보안 목적 API에 부적합 |
| **Sliding Window Counter** | **이전/현재 윈도우 카운터를 경과 비율로 가중합산하여 경계 버스트 완화** | **-** |
 
### 2. Redis + Lua Script
GET(current) → GET(previous) → INCR 세 연산이 원자적으로 실행되어야 Race Condition 없이 정확한 카운팅이 보장됩니다. Lua Script는 Redis에서 원자적으로 실행되어 스크립트 실행 중 다른 명령이 끼어들 수 없습니다. 기존 프로젝트에서 Redis를 일관되게 직접 사용하는 패턴(RT 화이트리스트, AT 블랙리스트, nonce)과도 일관성을 유지합니다.
 
### 3. AOP 기반 구현
`@RateLimit` 어노테이션으로 엔드포인트별 정책을 선언적으로 관리합니다. 정책 변경 시 `RateLimitPolicy` Enum과 `resolveIdentifier` switch문만 수정하면 되며, AOP 코드 자체는 건드리지 않아도 됩니다. Filter 방식 대비 엔드포인트별 세밀한 정책 적용이 용이하며, 새로운 API에 Rate Limit을 추가할 때도 Policy와 분기처리만 추가하면 Controller에서 `@RateLimit` 어노테이션만으로 적용 가능합니다.
 
```java
// 새로운 API에 적용 시
@RateLimit(policies = {RateLimitPolicy.NEW_POLICY})
public ApiResponse<?> newApi(...) { ... }
```
 
### 4. 커스텀 Exception + ExceptionAdvice 별도 처리
Rate Limit 초과 시 429 응답과 함께 `Retry-After` 헤더(RFC 6585 표준)를 같이 내려줍니다. 클라이언트가 언제 재시도하면 되는지 알 수 있도록, 윈도우 전체가 아닌 현재 윈도우 종료까지 남은 시간을 계산해서 반환합니다. `GeneralException`을 확장한 `RateLimitExceededException`으로 `policy` 정보를 함께 전달하고, `ExceptionAdvice`에서 전용 핸들러로 `Retry-After` 헤더를 추가했습니다.
 
```
HTTP/1.1 429 Too Many Requests
Retry-After: 600
```
 
### 5. 식별자 전략
소셜 로그인은 로그인 전이라 userId가 없습니다. IP 단독은 공용 와이파이 환경에서 정상 사용자가 영향을 받을 수 있다고 판단했습니다. 이를 해결하기 위해 idToken을 무검증 decode하여 socialId를 추출합니다. 보안 결정이 아닌 Rate Limit 식별자 목적이므로 무검증 decode를 허용했습니다.
 
```
카카오/구글 → idToken decode → socialId 추출
네이버      → accessToken (JWT 아님) → subject null → IP fallback
```
 
토큰 재발급은 RT를 무검증 decode하여 userId를 추출합니다. IP 로테이션으로 IP를 바꾸더라도 동일 userId로 차단됩니다.
 
### 6. LogHashUtil - 보안 이벤트 로그 식별자 해시
Rate Limit 초과, ID Token Replay, RT Mismatch 등 보안 이벤트 로그에 식별자(socialId, userId, IP)를 그대로 찍으면 개인정보 노출이 우려된다고 판단했습니다. HmacSHA256으로 해시하여 원본을 알 수 없도록 하면서도, 동일한 식별자는 항상 동일한 해시값을 가지므로 반복 공격 패턴 추적이 가능합니다.
 
```
// prefix 보존 후 식별자 값만 해시
INVALID_1.2.3.4 → INVALID_{해시값}
1234567890      → {해시값}
```
 
## 🍰 참고사항
- 네이버는 OIDC가 아닌 OAuth 방식이라 idToken이 없어 socialId 추출이 불가능합니다. 이로 인해 SOCIAL_LOGIN_SOCIAL_ID 정책에서 socialId 대신 IP 기반으로 카운팅되고, SOCIAL_LOGIN_IP 정책도 동일한 IP 기반으로 카운팅하므로 네이버 요청의 경우 서로 다른 Redis 키에 동일한 IP가 각각 카운팅되는 중복이 발생합니다. socialType을 AOP에서 분기하여 해결할 수 있으나, AOP가 특정 엔드포인트의 파라미터 구조를 직접 알게 되어 결합도가 높아지는 문제가 있어 현재 구조를 유지합니다...
- Redis 기반으로 구현하여 다중 인스턴스 환경으로 확장해도 코드 변경 없이 동작합니다.
- 네이버는 공용 와이파이 환경에서 IP 기반 카운터를 여러 사용자가 공유하게 되므로, 이를 고려하여 SOCIAL_LOGIN_IP 한도를 50회로 느슨하게 설정하였습니다.

## 📷 스크린샷 또는 GIF

※ 현재, 테스트쪽이 전체적으로 뭔가 꼬인듯해서 직접 실행한 결과 첨부하겠습니다.

| 기능 | 스크린샷 |
|:--:|:--:|
| 소셜 로그인 Rate Limit | <img width="765" height="175" alt="스크린샷 2026-05-04 오후 6 36 00" src="https://github.com/user-attachments/assets/2c92a528-4cea-40d9-b6d8-470ccdec2813" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 소셜 로그인 및 토큰 재발급 엔드포인트에 속도 제한(Rate Limiting) 기능이 추가되었습니다. 부정 행위를 방지하고 서비스 안정성을 향상시킵니다.

* **Security**
  * 로그에 기록되는 민감한 사용자 정보가 암호화 처리되도록 개선되었습니다.
  * Nonce 검증 로직이 강화되어 재사용 공격에 대한 보안이 향상되었습니다.

* **Bug Fixes**
  * JWT 관련 에러 코드가 표준화되었습니다.
  * 속도 제한 초과 시 HTTP 응답 헤더에 재시도 시간 정보를 포함하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->