### PR TITLE
BUG : Redis 테스트 환경 오류 수정 및 FriendLockService 동시성 테스트 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.mockito:mockito-inline:5.2.0'
 
-	testImplementation "org.testcontainers:junit-jupiter:2.0.3"
-	testImplementation "org.testcontainers:testcontainers:2.0.3"
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.3"
+    testImplementation "org.testcontainers:testcontainers:2.0.3"
 
 	// Swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'

--- a/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
+++ b/src/main/java/umc/teumteum/server/global/config/RedisConfig.java
@@ -7,7 +7,6 @@ import org.redisson.config.SingleServerConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -15,7 +14,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@Profile("!test")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/test/java/umc/teumteum/server/ServerApplicationTests.java
+++ b/src/test/java/umc/teumteum/server/ServerApplicationTests.java
@@ -3,10 +3,11 @@ package umc.teumteum.server;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import umc.teumteum.server.support.RedisTestContainerSupport;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class ServerApplicationTests {
+class ServerApplicationTests extends RedisTestContainerSupport {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
+++ b/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
@@ -1,12 +1,5 @@
 package umc.teumteum.server.integration.friend.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
-import umc.teumteum.server.domain.friend.exception.FriendException;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
 import umc.teumteum.server.domain.friend.service.FriendLockService;
 import umc.teumteum.server.domain.notification.service.NotificationUseCases;
@@ -23,9 +15,16 @@ import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.domain.user.entity.enums.SocialType;
 import umc.teumteum.server.domain.user.entity.enums.UserStep;
 import umc.teumteum.server.domain.user.repository.UserRepository;
-import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.S3Util;
 import umc.teumteum.server.support.RedisTestContainerSupport;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -83,7 +82,10 @@ public class FriendLockServiceTest extends RedisTestContainerSupport {
         // given
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
 
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failCount = new AtomicInteger();
@@ -92,17 +94,23 @@ public class FriendLockServiceTest extends RedisTestContainerSupport {
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {
                 try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
                     friendLockService.followWithLock(loginUser, targetUser.getId());
                     successCount.incrementAndGet();
-                } catch (FriendException | GlobalHandler e) {
+                } catch (Exception e) {
                     failCount.incrementAndGet();
                 } finally {
-                    latch.countDown();
+                    doneLatch.countDown();
                 }
             });
         }
 
-        latch.await();
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await();
+
         executorService.shutdown();
 
         long totalSaved = friendRepository.count();

--- a/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
+++ b/src/test/java/umc/teumteum/server/integration/friend/service/FriendLockServiceTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,11 +108,19 @@ public class FriendLockServiceTest extends RedisTestContainerSupport {
             });
         }
 
-        readyLatch.await();
-        startLatch.countDown();
-        doneLatch.await();
+        try {
+            assertThat(readyLatch.await(5, TimeUnit.SECONDS))
+                    .as("모든 테스트 스레드가 준비 상태에 도달해야 합니다.")
+                    .isTrue();
 
-        executorService.shutdown();
+            startLatch.countDown();
+
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS))
+                    .as("모든 테스트 스레드가 제한 시간 내 종료되어야 합니다.")
+                    .isTrue();
+        } finally {
+            executorService.shutdownNow();
+        }
 
         long totalSaved = friendRepository.count();
 

--- a/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/home/service/ActivityServiceTest.java
@@ -1,17 +1,5 @@
 package umc.teumteum.server.unit.home.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +21,17 @@ import umc.teumteum.server.domain.home.repository.CategoryRepository;
 import umc.teumteum.server.domain.home.repository.WishRepository;
 import umc.teumteum.server.domain.home.service.ActivityServiceImpl;
 import umc.teumteum.server.domain.user.entity.User;
-import umc.teumteum.server.support.RedisTestContainerSupport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ActivityServiceImpl - Activity(채움활동) 관련 단위 테스트")

--- a/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
@@ -25,6 +25,8 @@ import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -94,9 +96,16 @@ public class NotificationServiceTest {
     User testFriend4 = mock(User.class); when(testFriend4.getProfileImageName()).thenReturn("tf4.png");
 
       // 관련 엔티티 mock, repodisoty stubbing
+    TeumRequest acceptedRequest = mock(TeumRequest.class);
+    when(acceptedRequest.getDate()).thenReturn(LocalDate.now());
+    when(acceptedRequest.getStartTime()).thenReturn(LocalTime.of(10, 0));
+
     TeumResponse teumResponse_related_accepted = mock(TeumResponse.class);
     when(teumResponse_related_accepted.getReceiverUser()).thenReturn(testFriend1);
+    when(teumResponse_related_accepted.getTeumRequest()).thenReturn(acceptedRequest);
     when(teumResponseRepository.findById(101L)).thenReturn(Optional.of(teumResponse_related_accepted));
+
+    TeumRequest canceledRequest = mock(TeumRequest.class);
 
     TeumResponse tuemResponse_related_canceled = mock(TeumResponse.class);
     when(tuemResponse_related_canceled.getReceiverUser()).thenReturn(testFriend2);
@@ -104,6 +113,8 @@ public class NotificationServiceTest {
 
     TeumRequest teumRequest = mock(TeumRequest.class);
     when(teumRequest.getUser()).thenReturn(testFriend3);
+    when(teumRequest.getDate()).thenReturn(LocalDate.now());
+    when(teumRequest.getStartTime()).thenReturn(LocalTime.of(12, 0));
     when(teumRequestRepository.findById(103L)).thenReturn(Optional.of(teumRequest));
 
     Friend friend = mock(Friend.class);
@@ -155,6 +166,8 @@ public class NotificationServiceTest {
     when(testFriend.getProfileImageName()).thenReturn("tf1.png");
     TeumRequest tq = mock(TeumRequest.class);
     when(tq.getUser()).thenReturn(testFriend);
+    when(tq.getDate()).thenReturn(LocalDate.now());
+    when(tq.getStartTime()).thenReturn(LocalTime.of(10, 0));
 
     when(teumRequestRepository.findById(201L)).thenReturn(Optional.of(tq));
     when(friendRepository.findById(202L)).thenReturn(Optional.empty());
@@ -229,7 +242,10 @@ public class NotificationServiceTest {
 
     User testFriend = mock(User.class);
     when(testFriend.getProfileImageName()).thenReturn("tf1.png");
-    TeumRequest tq = mock(TeumRequest.class); when(tq.getUser()).thenReturn(testFriend);
+    TeumRequest tq = mock(TeumRequest.class);
+    when(tq.getUser()).thenReturn(testFriend);
+    when(tq.getDate()).thenReturn(LocalDate.now());
+    when(tq.getStartTime()).thenReturn(LocalTime.of(10, 0));
     when(teumRequestRepository.findById(401L)).thenReturn(Optional.of(tq));
 
 

--- a/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
@@ -26,6 +26,7 @@ import umc.teumteum.server.global.util.S3Util;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -77,6 +78,7 @@ public class NotificationServiceTest {
     // given
     int page = 1;
     int size = 10;
+    LocalDate today = LocalDate.now();
 
       // 알림 종류들 : RESPONSE, SCHEDULE(둘 다 TeumResponse), REQUEST(TeumRequest), FRIEND(Friend)
     Notification n1 = mockNoti(1L, NotificationType.TEUM_ACCEPTED, 101L); // TEUM_RESPONSE
@@ -97,7 +99,7 @@ public class NotificationServiceTest {
 
       // 관련 엔티티 mock, repodisoty stubbing
     TeumRequest acceptedRequest = mock(TeumRequest.class);
-    when(acceptedRequest.getDate()).thenReturn(LocalDate.now());
+    when(acceptedRequest.getDate()).thenReturn(today);
     when(acceptedRequest.getStartTime()).thenReturn(LocalTime.of(10, 0));
 
     TeumResponse teumResponse_related_accepted = mock(TeumResponse.class);
@@ -105,15 +107,13 @@ public class NotificationServiceTest {
     when(teumResponse_related_accepted.getTeumRequest()).thenReturn(acceptedRequest);
     when(teumResponseRepository.findById(101L)).thenReturn(Optional.of(teumResponse_related_accepted));
 
-    TeumRequest canceledRequest = mock(TeumRequest.class);
-
     TeumResponse tuemResponse_related_canceled = mock(TeumResponse.class);
     when(tuemResponse_related_canceled.getReceiverUser()).thenReturn(testFriend2);
     when(teumResponseRepository.findById(102L)).thenReturn(Optional.of(tuemResponse_related_canceled));
 
     TeumRequest teumRequest = mock(TeumRequest.class);
     when(teumRequest.getUser()).thenReturn(testFriend3);
-    when(teumRequest.getDate()).thenReturn(LocalDate.now());
+    when(teumRequest.getDate()).thenReturn(today);
     when(teumRequest.getStartTime()).thenReturn(LocalTime.of(12, 0));
     when(teumRequestRepository.findById(103L)).thenReturn(Optional.of(teumRequest));
 
@@ -139,10 +139,10 @@ public class NotificationServiceTest {
 
     // then
       // 1. 통과 기준 : 타입별로 변환이 잘 되었는지 확인
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n1), eq(testFriend1), anyString(), any()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n2), eq(testFriend2), anyString(), any()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n3), eq(testFriend3), anyString(), any()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n4), eq(testFriend4), anyString(), any()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n1), eq(testFriend1), anyString(), eq(LocalDateTime.of(today, LocalTime.of(10, 0)))));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n2), eq(testFriend2), anyString(), isNull()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n3), eq(testFriend3), anyString(), eq(LocalDateTime.of(today, LocalTime.of(12, 0)))));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n4), eq(testFriend4), anyString(), isNull()));
 
       // 2. 통과 기준 : S3 presigned URL 호출 확인
     verify(s3Util, atLeast(4)).toPresignedUrl(startsWith("profile/"), eq(Duration.ofMinutes(30)));
@@ -153,6 +153,7 @@ public class NotificationServiceTest {
   @DisplayName("[getNotifications] - TC2 관련 엔티티가 없으면 해당 알림은 필터링 된다.")
   void filter_when_related_not_found() {
     int page = 1, size = 10;
+    LocalDate today = LocalDate.now();
 
     Notification exist = mockNoti(1L, NotificationType.TEUM_REQUEST, 201L);
     Notification none  = mockNoti(2L, NotificationType.FOLLOW,       202L);
@@ -166,7 +167,7 @@ public class NotificationServiceTest {
     when(testFriend.getProfileImageName()).thenReturn("tf1.png");
     TeumRequest tq = mock(TeumRequest.class);
     when(tq.getUser()).thenReturn(testFriend);
-    when(tq.getDate()).thenReturn(LocalDate.now());
+    when(tq.getDate()).thenReturn(today);
     when(tq.getStartTime()).thenReturn(LocalTime.of(10, 0));
 
     when(teumRequestRepository.findById(201L)).thenReturn(Optional.of(tq));
@@ -192,7 +193,7 @@ public class NotificationServiceTest {
       // 1. 통과 기준 : 필터링 되야 되는 none은 절대로 호출 안됨
     converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(none), any(), any(), any()), never());
       // 2. 통과 기준 : 필터링 되면 안되는 exist는 호출됨
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(exist), eq(testFriend), anyString(), any()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(exist), eq(testFriend), anyString(), eq(LocalDateTime.of(today, LocalTime.of(10, 0)))));
 
   }
 
@@ -233,6 +234,7 @@ public class NotificationServiceTest {
   void verify_presigned_url() {
     // given
     int page = 3, size = 5;
+    LocalDate today = LocalDate.now();
 
     Notification n = mockNoti(1L, NotificationType.TEUM_REQUEST, 401L);
 
@@ -244,7 +246,7 @@ public class NotificationServiceTest {
     when(testFriend.getProfileImageName()).thenReturn("tf1.png");
     TeumRequest tq = mock(TeumRequest.class);
     when(tq.getUser()).thenReturn(testFriend);
-    when(tq.getDate()).thenReturn(LocalDate.now());
+    when(tq.getDate()).thenReturn(today);
     when(tq.getStartTime()).thenReturn(LocalTime.of(10, 0));
     when(teumRequestRepository.findById(401L)).thenReturn(Optional.of(tq));
 
@@ -266,6 +268,12 @@ public class NotificationServiceTest {
     assertEquals("profile/tf1.png", keyCap.getValue());
     assertEquals(Duration.ofMinutes(30), durCap.getValue());
 
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(
+            eq(n),
+            eq(testFriend),
+            anyString(),
+            eq(LocalDateTime.of(today, LocalTime.of(10, 0)))
+    ));
   }
 
 

--- a/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/notification/service/NotificationServiceTest.java
@@ -1,35 +1,14 @@
 package umc.teumteum.server.unit.notification.service;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import umc.teumteum.server.domain.friend.entity.Friend;
 import umc.teumteum.server.domain.friend.repository.FriendRepository;
 import umc.teumteum.server.domain.notification.converter.NotificationConverter;
@@ -38,11 +17,21 @@ import umc.teumteum.server.domain.notification.entity.Notification;
 import umc.teumteum.server.domain.notification.entity.enums.NotificationType;
 import umc.teumteum.server.domain.notification.repository.NotificationRepository;
 import umc.teumteum.server.domain.notification.service.NotificationServiceImpl;
-import umc.teumteum.server.domain.teum.entity.*;
-import umc.teumteum.server.domain.teum.repository.*;
+import umc.teumteum.server.domain.teum.entity.TeumRequest;
+import umc.teumteum.server.domain.teum.entity.TeumResponse;
+import umc.teumteum.server.domain.teum.repository.TeumRequestRepository;
+import umc.teumteum.server.domain.teum.repository.TeumResponseRepository;
 import umc.teumteum.server.domain.user.entity.User;
 import umc.teumteum.server.global.util.S3Util;
-import umc.teumteum.server.support.RedisTestContainerSupport;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("NotificationServiceImpl - Notification 관련 서비스 메서드 단위 테스트")
@@ -126,7 +115,7 @@ public class NotificationServiceTest {
 
       // NotificationResponseDto.NotificationDto mocking
     NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
-    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any(), any()))
         .thenReturn(dto);
 
       // NotificatoinResponseDto.SliceResposneDto mocking
@@ -139,10 +128,10 @@ public class NotificationServiceTest {
 
     // then
       // 1. 통과 기준 : 타입별로 변환이 잘 되었는지 확인
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n1), eq(testFriend1), anyString()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n2), eq(testFriend2), anyString()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n3), eq(testFriend3), anyString()));
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n4), eq(testFriend4), anyString()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n1), eq(testFriend1), anyString(), any()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n2), eq(testFriend2), anyString(), any()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n3), eq(testFriend3), anyString(), any()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(n4), eq(testFriend4), anyString(), any()));
 
       // 2. 통과 기준 : S3 presigned URL 호출 확인
     verify(s3Util, atLeast(4)).toPresignedUrl(startsWith("profile/"), eq(Duration.ofMinutes(30)));
@@ -173,7 +162,7 @@ public class NotificationServiceTest {
         .thenReturn("https://presigned/mock/test");
 
     NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
-    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any(), any()))
         .thenReturn(dto);
 
     NotificationResponseDto.SliceResponseDto expected = mock(NotificationResponseDto.SliceResponseDto.class);
@@ -188,9 +177,9 @@ public class NotificationServiceTest {
     // then
     assertSame(expected, actual);
       // 1. 통과 기준 : 필터링 되야 되는 none은 절대로 호출 안됨
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(none), any(), any()), never());
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(none), any(), any(), any()), never());
       // 2. 통과 기준 : 필터링 되면 안되는 exist는 호출됨
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(exist), eq(testFriend), anyString()));
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(eq(exist), eq(testFriend), anyString(), any()));
 
   }
 
@@ -211,7 +200,7 @@ public class NotificationServiceTest {
         .thenReturn("https://presigned/mock/test");
 
     NotificationResponseDto.NotificationDto dto = mock(NotificationResponseDto.NotificationDto.class);
-    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any())).thenReturn(dto);
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any(), any())).thenReturn(dto);
 
     NotificationResponseDto.SliceResponseDto expected = mock(NotificationResponseDto.SliceResponseDto.class);
     converterMock.when(() -> NotificationConverter.toSliceResponseDto(anyList(), eq(true), eq(page), eq(size)))
@@ -245,7 +234,7 @@ public class NotificationServiceTest {
 
 
     when(s3Util.toPresignedUrl(anyString(), any())).thenReturn("url");
-    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any()))
+    converterMock.when(() -> NotificationConverter.toNotificationDto(any(), any(), any(), any()))
         .thenReturn(mock(NotificationResponseDto.NotificationDto.class));
     converterMock.when(() -> NotificationConverter.toSliceResponseDto(anyList(), anyBoolean(), anyInt(), anyInt()))
         .thenReturn(mock(NotificationResponseDto.SliceResponseDto.class));
@@ -284,7 +273,7 @@ public class NotificationServiceTest {
     notificationServiceImpl.getNotifications(testUser, 1, 10);
 
     // then
-    converterMock.verify(() -> NotificationConverter.toNotificationDto(any(), any(), any()), never());
+    converterMock.verify(() -> NotificationConverter.toNotificationDto(any(), any(), any(), any()), never());
     verifyNoInteractions(teumRequestRepository, teumResponseRepository, friendRepository);
 
   }

--- a/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/OnboardingServiceTest.java
@@ -1,15 +1,5 @@
 package umc.teumteum.server.unit.user.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.verify;
-
-import java.time.LocalTime;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +23,15 @@ import umc.teumteum.server.domain.user.repository.RoutineRepository;
 import umc.teumteum.server.domain.user.service.OnboardingServiceImpl;
 import umc.teumteum.server.global.exception.handler.GlobalHandler;
 import umc.teumteum.server.global.util.TimeUtil;
-import umc.teumteum.server.support.RedisTestContainerSupport;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OnboardingService 관련 단위 테스트")

--- a/src/test/java/umc/teumteum/server/unit/user/service/UserServiceTest.java
+++ b/src/test/java/umc/teumteum/server/unit/user/service/UserServiceTest.java
@@ -17,7 +17,6 @@ import umc.teumteum.server.domain.user.repository.UserRepository;
 import umc.teumteum.server.domain.user.service.UserServiceImpl;
 
 import java.util.Optional;
-import umc.teumteum.server.support.RedisTestContainerSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
## 👀 관련 이슈
#361

## ✨ 작업한 내용
### 1. Testcontainers 의존성 오류 수정
기존 Testcontainers 의존성 설정에서 artifact 이름이 잘못 지정되어 있던 거 같습니다(?)

#### 기존 설정

```gradle
org.testcontainers:junit-jupiter:2.0.3
```

#### 수정 후

```gradle
org.testcontainers:testcontainers-junit-jupiter:2.0.3
```

### 2. Redis 테스트 환경 충돌 수정
워크플로우가 변경되며, Redis가 필요한 통합 테스트에서는 `RedisTestContainerSupport`를 통해 테스트 코드 내부에서 Redis 컨테이너를 직접 실행하는 구조가 추가된 것 같습니다. 하지만, 동시에 `RedisConfig`에 추가된 설정으로 인해 test 환경에서 Redis Bean이 생성되지 않아 문제가 발생했습니다.

```java
@Profile("!test")
```

이로 인해 `profileImageRedisTemplate`, `RedissonClient` 등 Redis 관련 Bean을 필요로 하는 테스트에서 `ApplicationContext` 로딩 실패가 발생한 듯하여, test 환경에서도 Redis Bean이 정상적으로 생성될 수 있도록 해당 설정을 삭제하였습니다.

또한 `ServerApplicationTests`는 전체 Spring Context를 로딩하는 `@SpringBootTest` 기반 테스트이므로,
Redis Bean 로딩을 위해 `RedisTestContainerSupport`를 상속하도록 수정했습니다.

### 3. FriendLockService 동시성 테스트 코드 개선
기존 `FriendLockService` 동시성 테스트가 의도와 다르게 여러 스레드의 실제 동시 호출 상황을 보장하지 못한 거 같습니다.

#### 기존 방식
- 기존에는 단일 `CountDownLatch`를 사용하여 작업 완료 여부만 대기하는 구조
- 10개의 작업이 모두 완료되었는지는 보장할 수 있지만, 10개의 스레드가 동시에 `followWithLock()`을 호출했는지는 보장 X

#### 수정 후

- `readyLatch`, `startLatch`, `doneLatch` 3개의 latch로 역할 분리

```text
[메인 테스트 스레드]
→ ExecutorService를 통해 테스트 스레드 10개 생성
                                                ↓
                                [테스트 스레드 1 ~ 10]
                                → readyLatch.countDown()
                                → "준비 완료" 상태로 변경
                                → startLatch.await() 에서 대기

[메인 테스트 스레드]
→ readyLatch.await()
→ 모든 테스트 스레드가 준비될 때까지 대기
→ readyLatch == 0 확인
                                                ↓
                                [테스트 스레드 1 ~ 10]
                                → 아직 startLatch.await() 에서 대기 중
                                → followWithLock() 아직 호출하지 않음

[메인 테스트 스레드]
→ startLatch.countDown()
→ "동시 출발" 신호 전달
                                                ↓
                                [테스트 스레드 1 ~ 10]
                                → await() 해제
                                → 거의 동시에 followWithLock() 호출
                                → Redisson 분산 락 경쟁 시작

[메인 테스트 스레드]
→ doneLatch.await()
→ 모든 테스트 스레드 작업 종료까지 대기
                                                ↓
                                [테스트 스레드 1 ~ 10]
                                → 성공 또는 실패 처리
                                → doneLatch.countDown()
                                → 작업 종료

[메인 테스트 스레드]
→ doneLatch == 0 확인
→ 성공 횟수 / 실패 횟수 / DB 저장 개수 검증
```

## 🌀 PR Point
X

## 🍰 참고사항
- 혹시나 `RedisConfig`의 `@Profile("!test")` 설정이 꼭 필요한 것이라면 알려주시면 감사하겠습니다.
- `NotificationService`의 변경된 로직이 기존 테스트 코드에 반영되지 않아 테스트 실패가 발생하고 있었습니다. 해당 파트를 담당하지 않은 관계로, 우선 테스트 통과를 목적으로 GPT를 활용하여 임시 수정하였습니다. 확인 부탁드립니다!

## 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
| 테스트 | <img width="664" height="395" alt="스크린샷 2026-05-09 오후 9 19 47" src="https://github.com/user-attachments/assets/908bf658-fc8f-41c9-b26f-2d4bc2182b56" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 통합 테스트 인프라 개선 — Redis 관련 설정이 테스트 환경에도 적용되어 통합 테스트 신뢰성 향상
  * 동시성 테스트 로직 보강으로 멀티스레드 상황 검증 강화
  * 알림 관련 테스트 및 단위 테스트들에서 인터페이스 변화에 맞춘 검증 업데이트 및 정리

* **Chores**
  * 테스트 빌드/설정 선언 형식 정리 (기능 변경 없음)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UMC8-TeumTeum/BE/pull/362)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->