### PR TITLE
BUG : 중복 팔로우 DB 유니크 키 제약 및 예외 처리 추가

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
@@ -13,10 +13,19 @@ import umc.teumteum.server.global.common.BaseEntity;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "friend", indexes = {
-        @Index(name = "idx_friend_follower_following",
-                columnList = "follower_user_id, following_user_id")
-})
+@Table(
+        name = "friend",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_friend_follower_following",
+                        columnNames = {"follower_user_id", "following_user_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_friend_follower_following",
+                        columnList = "follower_user_id, following_user_id")
+        }
+)
 public class Friend extends BaseEntity {
 
     @Id

--- a/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/entity/Friend.java
@@ -20,10 +20,6 @@ import umc.teumteum.server.global.common.BaseEntity;
                         name = "uk_friend_follower_following",
                         columnNames = {"follower_user_id", "following_user_id"}
                 )
-        },
-        indexes = {
-                @Index(name = "idx_friend_follower_following",
-                        columnList = "follower_user_id, following_user_id")
         }
 )
 public class Friend extends BaseEntity {

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -2,6 +2,8 @@ package umc.teumteum.server.domain.friend.service;
 
 import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -59,6 +61,7 @@ public class FriendServiceImpl implements FriendService {
     @Resource(name = "profileImageRedisTemplate")
     private RedisTemplate<String, String> profileImageRedisTemplate;
 
+    private static final String FRIEND_UNIQUE_CONSTRAINT_NAME = "uk_friend_follower_following";
     private static final String PROFILE_URL_CACHE_KEY_PREFIX = "profile:url:";
     private static final Duration PROFILE_URL_CACHE_TTL = Duration.ofMinutes(20);
 
@@ -95,7 +98,14 @@ public class FriendServiceImpl implements FriendService {
 
         // 5. Friend 생성 및 저장
         Friend friend = FriendConverter.toFriend(loginUser, targetUser);
-        friendRepository.save(friend);
+        try {
+            friendRepository.saveAndFlush(friend);
+        } catch (DataIntegrityViolationException e) {
+            if (isConstraintViolation(e, FRIEND_UNIQUE_CONSTRAINT_NAME)) {
+                throw new FriendException(FriendErrorStatus.ALREADY_FOLLOWING);
+            }
+            throw e;
+        }
 
         // 5. 알림 전송
         notificationUseCases.notifyFollow(loginUser, targetUser, friend.getId());
@@ -463,5 +473,17 @@ public class FriendServiceImpl implements FriendService {
     // cache key 생성
     private String buildCacheKey(String profileImageName) {
         return PROFILE_URL_CACHE_KEY_PREFIX + profileImageName;
+    }
+
+    // DB 제약조건 위반 예외가 특정 constraint에서 발생했는지 확인
+    private boolean isConstraintViolation(DataIntegrityViolationException e, String constraintName) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException constraintViolationException) {
+                return constraintName.equals(constraintViolationException.getConstraintName());
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
#363 

### ✨ 작업한 내용
- `friend` 테이블의 `follower_user_id`, `following_user_id` 조합에 DB unique constraint를 추가했습니다.
- 중복 팔로우 저장 시 발생하는 DB 제약 위반을 `ALREADY_FOLLOWING` 도메인 예외로 변환하도록 처리했습니다.
- `DataIntegrityViolationException` 전체를 변환하지 않고, constraint 이름이 `uk_friend_follower_following`인 경우에만 중복 팔로우 예외로 처리하도록 했습니다

### 🌀 PR Point
- Redisson 분산 락은 애플리케이션 레벨의 동시성 제어이므로, 팔로우 관계의 중복 불가 조건을 DB unique constraint로도 보장하도록 했습니다.
- `saveAndFlush()`를 사용해 unique constraint 위반이 서비스 로직의 try-catch 내부에서 발생하도록 처리했습니다.
- FK/null 제약 위반 등 다른 무결성 오류가 `ALREADY_FOLLOWING`으로 잘못 변환되지 않도록 constraint 이름을 확인합니다.

### 🍰 참고사항
X

### 📷 스크린샷 또는 GIF
| 기능 | 스크린샷 |
| :--: | :------: |
| UK 추가 | <img width="586" height="273" alt="스크린샷 2026-05-28 오후 4 59 22" src="https://github.com/user-attachments/assets/e5921db3-6ee6-417e-badf-8eafa326aa45" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 팔로우 기능에서 중복 팔로우 시도 시 더 명확한 오류 처리로 개선되었습니다. 데이터 무결성 제약 조건을 강화하여 시스템 안정성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UMC8-TeumTeum/BE/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->