### PR TITLE
BUG : 즐겨찾기 API 요청 검증 및 멱등성 보장

### DIFF
--- a/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/controller/FriendController.java
@@ -3,6 +3,7 @@ package umc.teumteum.server.domain.friend.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -94,7 +95,7 @@ public class FriendController {
             @Parameter(hidden = true) @CurrentUser User loginUser,
             @Parameter(name = "userId", description = "즐겨찾기를 설정/해제할 대상 유저의 ID", example = "1")
             @PathVariable("userId") Long targetUserId,
-            @RequestBody FriendRequestDto.FriendFavorite requestDto
+            @RequestBody @Valid FriendRequestDto.FriendFavorite requestDto
     ) {
         FriendResponseDto.FriendFavorite response = friendService.updateFavorite(loginUser, targetUserId, requestDto.getIsFavorite());
         return ApiResponse.of(FriendSuccessStatus._FAVORITE_UPDATE_SUCCESS, response);

--- a/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/exception/status/FriendErrorStatus.java
@@ -14,7 +14,6 @@ public enum FriendErrorStatus implements BaseErrorCode {
     ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FRIEND4001", "이미 팔로우한 유저입니다."),
     INVALID_SELF_REQUEST(HttpStatus.BAD_REQUEST, "FRIEND4002", "자기 자신에 대한 요청은 처리할 수 없습니다."),
     NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "FRIEND4003", "팔로우하지 않은 유저입니다."),
-    FAVORITE_ALREADY_SET(HttpStatus.BAD_REQUEST, "FRIEND4004", "즐겨찾기가 이미 요청한 상태로 설정되어 있습니다"),
     ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "FRIEND4005", "이미 차단된 사용자입니다."),
     NOT_BLOCKED(HttpStatus.BAD_REQUEST, "FRIEND4006", "차단하지 않은 사용자입니다."),
     BLOCK_ACTION_FORBIDDEN(HttpStatus.BAD_REQUEST, "FRIEND4007", "차단 관계로 인해 요청을 수행할 수 없습니다.")

--- a/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/umc/teumteum/server/domain/friend/service/FriendServiceImpl.java
@@ -174,9 +174,6 @@ public class FriendServiceImpl implements FriendService {
                 .orElseThrow(() -> new FriendException(FriendErrorStatus.NOT_FOLLOWING));
 
         // 4. 즐겨찾기 상태 수정
-        if (friend.getIsFavorite().equals(isFavorite)) {
-            throw new FriendException(FriendErrorStatus.FAVORITE_ALREADY_SET);
-        }
         friend.updateIsFavorite(isFavorite);
 
         // 5. 결과 반환


### PR DESCRIPTION
### 👀 관련 이슈
#365 

### ✨ 작업한 내용
- 즐겨찾기 API의 기존 동작을 다시 확인하면서, 현재 API 설계에서 멱등성을 어떻게 보장하는 것이 자연스러운지 함께 검토했습니다.
- 즐겨찾기 상태 변경 API의 RequestBody에 `@Valid`를 추가해 `isFavorite` 값이 누락된 요청을 validation 단계에서 차단하도록 했습니다.
- 이미 동일한 즐겨찾기 상태인 경우 `FAVORITE_ALREADY_SET` 예외를 반환하던 기존 로직을 제거하고, 성공 응답을 반환하도록 변경했습니다.
- 더 이상 사용하지 않는 `FAVORITE_ALREADY_SET` 에러 상태를 제거했습니다.

### 🌀 PR Point
- 기존에는 이미 동일한 즐겨찾기 상태인 경우 `FAVORITE_ALREADY_SET` 예외를 반환하도록 구현했지만, 다시 확인해보니 현재 API 성격과는 맞지 않는 처리라고 판단했습니다. 이 API는 토글이 아니라 RequestBody의 `isFavorite` 값으로 최종 상태를 지정하는 방식이기 때문에, 이미 같은 상태라면 실패가 아니라 요청한 상태가 이미 충족된 상황에 가깝습니다.
- 특히 네트워크 재시도나 중복 요청이 발생하면 실제로는 첫 요청이 성공했는데도 이후 요청이 `FAVORITE_ALREADY_SET`으로 실패처럼 보일 수 있습니다. 그래서 동일 상태 요청도 성공으로 처리하도록 변경해, 같은 요청이 반복돼도 클라이언트가 안정적으로 같은 결과를 받을 수 있도록 했습니다.
- `PATCH` 메서드 자체가 항상 멱등적인 것은 아니지만, 현재 API처럼 최종 상태를 명시해 멱등성을 보장하는 설계도 가능하다고 합니다.

### 🍰 참고사항
- https://docs.tosspayments.com/blog/rest-api-post-put-patch
- https://html6.tistory.com/1974

### 📷 스크린샷 또는 GIF
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 친구 즐겨찾기 기능의 중복 설정 로직을 개선하여, 이미 설정된 상태를 다시 설정하려는 경우 더 이상 오류가 발생하지 않도록 수정했습니다.

* **Chores**
  * 친구 즐겨찾기 API의 입력값 유효성 검증을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UMC8-TeumTeum/BE/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->